### PR TITLE
Promote /brain to Claudia's primary knowledge graph explorer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ build/
 # Local
 .claude/settings.local.json
 tmp/
+visualizer/test-results/
 
 # Tarballs
 *.tgz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Claudia will be documented in this file.
 
+## Unreleased
+
+### Visualizer
+
+- **Primary `/brain` explorer rebuild** -- Replaces the old browser visualizer path with a technical React + `react-three-fiber` knowledge graph explorer designed for local memory browsing, relationship tracing, evidence reveal, database switching, and live scene tuning.
+- **Entity-first overview graph** -- Overview mode now stays readable by default, with optional full memory overlays, memory-type filtering, and commitment/pattern controls instead of flooding the initial scene.
+- **Non-destructive rollout** -- The visualizer work stays scoped to `visualizer/` and related `/brain` documentation. Core installer, template, and memory-daemon paths are not reworked as part of this visualizer replacement. Legacy visualizer assets are deprecated rather than used as the default runtime path.
+
 ## 1.45.1 (2026-02-26)
 
 ### Open Source & Polish

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Claudia detects your work style and generates structure that fits:
 | `/what-am-i-missing` | Surface risks, overdue items, cooling relationships |
 | `/research [topic]` | Deep research with web sources and memory integration |
 | `/inbox-check` | Lightweight inbox triage across connected email accounts |
-| `/brain` | Launch 3D brain visualizer |
+| `/brain` | Launch Claudia's primary 3D knowledge graph explorer |
 | `/meditate` | End-of-session reflection: extracts learnings, judgment, patterns |
 | `/deep-context [topic]` | Full-context deep analysis |
 | `/memory-audit` | See everything Claudia knows, with source chains |
@@ -340,7 +340,7 @@ You ──► Claude Code ──► Reads Claudia's templates ──► Becomes 
 
 **Provenance chains** trace any fact to its source email, transcript, or conversation.
 
-**Graph traversal** connects dots across your network. Ask about one person, see related entities with top memories. The 3D brain visualizer (`/brain`) renders the graph in real-time.
+**Graph traversal** connects dots across your network. Ask about one person, see related entities with top memories. The `/brain` explorer is Claudia's primary visual knowledge graph: relationship-first, evidence-aware, and tuned for browsing the local memory database without touching the rest of the core system.
 
 **Per-project isolation** keeps work memories separate from personal. Each workspace gets its own database.
 

--- a/docs/visualizer-rollout.md
+++ b/docs/visualizer-rollout.md
@@ -1,0 +1,67 @@
+# Visualizer Rollout Plan
+
+## Goal
+
+Adopt the rebuilt `visualizer/` application as Claudia's primary `/brain` explorer without destabilizing the installer, template, or memory-daemon codepaths.
+
+## Scope
+
+This rollout is intentionally narrow:
+
+- `visualizer/` becomes the maintained graph explorer
+- `/brain` documentation points at the new explorer
+- Legacy visualizer runtime assets are deprecated
+
+This rollout does not:
+
+- rewrite Claudia's SQLite schema
+- alter memory-daemon semantics
+- change onboarding, templates, or installer behavior outside the visualizer surface
+
+## Why This Replaces Prior Visualizers
+
+The new visualizer is intended to supersede prior graph implementations because it provides:
+
+- a stable entity-first overview
+- relationship tracing and evidence reveal
+- database switching across local Claudia stores
+- richer inspector and search workflows
+- live-tunable rendering without changing Claudia core
+
+Older visualizer paths were useful experiments, but should no longer be treated as the preferred `/brain` runtime.
+
+## Deprecation Strategy
+
+### Keep
+
+- Claudia installer
+- Claudia template and command system
+- Claudia memory daemon
+- Existing SQLite-backed memory store
+
+### Deprecate
+
+- legacy browser visualizer runtime assets under `visualizer/public-legacy/`
+- older graph runtime paths that are no longer the active `/brain` entrypoint
+
+### Remove later
+
+Only after the new explorer has proven stable in normal desktop usage should legacy assets be removed completely.
+
+## Recommended Merge Posture
+
+Merge this work as a visualizer-focused PR, not as a broad Claudia architecture rewrite.
+
+That keeps review simple:
+
+1. accept the new `/brain` explorer
+2. keep legacy visualizer paths deprecated, not default
+3. leave core Claudia behavior untouched
+
+## Follow-Up Work
+
+After merge, the highest-value follow-ups are:
+
+1. wire the visualizer more directly into any desktop shell or app tabs
+2. add non-WebGL fallback behavior for automated test environments
+3. trim legacy dependencies once the new explorer is fully accepted

--- a/visualizer/README.md
+++ b/visualizer/README.md
@@ -1,6 +1,25 @@
 # Claudia Brain Visualizer
 
-Real-time 3D visualization of Claudia's memory system. Entities, relationships, memories, patterns, and predictions rendered as an interactive force-directed graph with semantic clustering.
+Claudia's primary `/brain` experience: a relationship-first 3D knowledge graph for exploring the local memory database.
+
+This implementation is intended to replace the older experimental visualizer runtime paths while keeping the rest of Claudia's installer, template, and memory-daemon architecture intact.
+
+## What This Ships
+
+- React + `react-three-fiber` scene with custom node, edge, label, camera, and effects layers
+- Entity-first overview graph with optional memory overlay
+- Neighborhood expansion and relationship trace mode
+- Live database switching across local Claudia databases
+- Tunable scene controls for labels, line weight, particles, grid, fog, and post-processing
+- Side panels for search, metrics, evidence, commitments, and live tuning
+
+## Non-Goals
+
+- No schema rewrites for Claudia core memory storage
+- No installer or template behavior changes outside the `/brain` surface
+- No destructive removal of core Claudia functionality
+
+Legacy visualizer assets are deprecated and should not be used as the active `/brain` runtime path once this version lands.
 
 ## Quick Start
 
@@ -11,11 +30,11 @@ node server.js
 # Open http://localhost:3849
 ```
 
-The server auto-detects your Claudia memory database at `~/.claudia/memory/`.
+The server auto-detects the Claudia memory database at `~/.claudia/memory/`.
 
 ### Options
 
-```
+```text
 --port 3849           Server port (default: 3849)
 --project-dir /path   Use project-specific database (hashed like the daemon)
 --db /path/to/db      Direct path to a .db file
@@ -23,81 +42,81 @@ The server auto-detects your Claudia memory database at `~/.claudia/memory/`.
 
 ### From a Claudia session
 
-```
+```text
 /brain
 ```
 
-## What You See
-
-### Nodes
-
-| Type | Shape | Color |
-|------|-------|-------|
-| Person | Sphere | Warm gold |
-| Organization | Cube | Blue |
-| Project | Octahedron | Green |
-| Concept | Icosahedron | Purple |
-| Location | Sphere + rings | Orange |
-| Memory (fact) | Particle | White |
-| Memory (commitment) | Particle (pulsing) | Red |
-| Memory (learning) | Particle | Green |
-| Pattern | Wireframe icosahedron | Purple (breathing) |
-
-Node size scales with `sqrt(importance)`. Opacity fades for items not accessed in 90+ days.
-
-### Edges
-
-- **Entity relationships:** Thickness = strength, directional particles for forward edges
-- **Memory links:** Thin lines connecting memories to related entities
-- **Historical relationships:** Dashed ghost edges (toggle with `?historical=true`)
-
-### Real-Time Updates
-
-The visualizer polls the database every 500ms via SSE. When Claudia learns something new in another session:
-
-- New memories spawn with a flash animation
-- Recalled memories pulse and brighten
-- LLM-improved memories shimmer with golden aura
-- New relationships draw in with growing edges
-- Superseded relationships fade to dashed ghosts
-
-### Controls
-
-- **Click** a node to see details (memories, relationships, documents)
-- **Search** entities and memories in the sidebar
-- **Filter** by node type and memory type
-- **Timeline** scrubber to view the graph at any point in time
-- **Drag** to rotate, scroll to zoom
-
 ## Architecture
 
+```text
+server.js                 Express server + normalized graph APIs
+lib/graph-data.js         Shared dataset loading and graph normalization
+lib/overview.js           Entity-first overview graph
+lib/neighborhood.js       Local entity/memory neighborhood expansion
+lib/trace.js              Relationship path tracing with evidence
+src/app/                  Shell layout
+src/components/           HUD, sidebars, settings, timeline, inspector
+src/engine/               R3F scene, layout worker, labels, camera, edges
+src/store/                Zustand app state
 ```
-server.js          Express on :3849, static files + API
-lib/database.js    Read-only SQLite (WAL mode), workspace hash
-lib/graph.js       SQL -> graph JSON (nodes + edges)
-lib/projection.js  UMAP 384-dim -> 3D (with graceful fallback)
-lib/events.js      SSE stream, 500ms change detection
-public/            Vanilla JS + 3d-force-graph (zero build step)
+
+### Frontend stack
+
+- `react`
+- `zustand`
+- `three`
+- `@react-three/fiber`
+- `@react-three/drei`
+- `@react-three/postprocessing`
+- `d3-force-3d`
+
+## Current Behavior
+
+### Overview mode
+
+- Entities stay primary
+- Patterns remain visible by default
+- Commitments stay visible by default
+- Full memory overlay is optional
+- `fact` memories start hidden by default to avoid overloading weaker systems
+
+### Interaction model
+
+- Click to select and inspect
+- Double-click to expand deeper evidence
+- Shift-click two entities to trace a path
+- Hide left, right, or bottom panels independently
+- Save, export, and import visual settings
+
+## Settings
+
+The right inspector's `Tune` mode exposes live controls for:
+
+- Entity, memory, and pattern scale
+- Label size and label density
+- Line thickness, selected thickness, curvature, and opacity
+- Camera speed and orbit behavior
+- Bloom, chromatic aberration, particles
+- Fog and grid density/opacity
+- Entity, memory, and commitment colors
+- Theme switching
+
+## Themes
+
+Built-in themes include:
+
+- Claudia Core
+- Infrared Ops
+- Polar Signal
+- Matrix Construct
+- Lightcycle Grid
+- Offworld Noir
+
+## Testing
+
+```bash
+npm run build
+npm run test:smoke
 ```
 
-The visualizer opens the database in **read-only mode** and never interferes with the running memory daemon.
-
-## API
-
-| Endpoint | Purpose |
-|----------|---------|
-| `GET /health` | Server status + entity count |
-| `GET /api/graph` | Full graph (nodes + edges + UMAP positions) |
-| `GET /api/graph?historical=true` | Include superseded relationships |
-| `GET /api/stats` | Counts for HUD overlay |
-| `GET /api/entity/:id` | Entity detail with memories, relationships, documents |
-| `GET /api/timeline?start=&end=` | Events for timeline scrubber |
-| `GET /api/events` | SSE stream for real-time updates |
-
-## Schema Compatibility
-
-The visualizer detects available database columns at startup and adapts queries accordingly. It works with any schema version from v1 through v8+:
-
-- Pre-v5: No verification_status on memories (defaults to 'pending')
-- Pre-v7: No documents table (documents section hidden)
-- Pre-v8: No bi-temporal relationships (no historical toggle)
+`npm run test:smoke` is only a shell-level check. In headless Chromium, WebGL context creation may fail, so final visual verification still needs a normal desktop browser session.

--- a/visualizer/index.html
+++ b/visualizer/index.html
@@ -3,78 +3,11 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Claudia Brain</title>
+  <title>Claudia Graph Explorer</title>
   <link rel="stylesheet" href="/styles.css">
 </head>
 <body>
-  <!-- 3d-force-graph mounts here (creates its own canvas) -->
-  <div id="graph-container"></div>
-
-  <!-- Top HUD bar -->
-  <div id="hud-bar">
-    <div id="hud-title">
-      <img src="/claudia-logo.png" alt="Claudia" class="hud-logo-img">
-      <span>Claudia Brain</span>
-      <span id="activity-pulse" class="pulse"></span>
-    </div>
-    <div id="hud-stats">
-      <div class="stat"><span id="stat-entities">0</span> entities</div>
-      <div class="stat"><span id="stat-memories">0</span> memories</div>
-      <div class="stat"><span id="stat-patterns">0</span> patterns</div>
-      <div class="stat"><span id="stat-relationships">0</span> relationships</div>
-    </div>
-    <div id="hud-controls">
-      <span id="fps-counter">-- FPS</span>
-      <span id="engine-info"></span>
-      <div id="settings-container">
-        <button id="settings-btn" title="Settings">&#x2699;</button>
-        <div id="settings-panel" class="hidden">
-          <!-- Tabs and content built dynamically by ui.js -->
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <!-- Left sidebar -->
-  <div id="sidebar">
-    <div id="search-container">
-      <input type="text" id="search-input" placeholder="Search entities & memories..." autocomplete="off">
-      <div id="search-results"></div>
-    </div>
-    <div id="filters">
-      <h3>Node Types</h3>
-      <div id="type-filters"></div>
-      <h3>Memory Types</h3>
-      <div id="memory-filters"></div>
-    </div>
-  </div>
-
-  <!-- Right detail panel (slides in on node click) -->
-  <div id="detail-panel" class="hidden">
-    <button id="detail-close">&times;</button>
-    <div id="detail-content"></div>
-  </div>
-
-  <!-- Bottom timeline -->
-  <div id="timeline-container">
-    <div id="timeline-bar">
-      <input type="range" id="timeline-slider" min="0" max="100" value="100">
-      <div id="timeline-labels">
-        <span id="timeline-start"></span>
-        <span id="timeline-current"></span>
-        <span id="timeline-end">Now</span>
-      </div>
-    </div>
-    <div id="timeline-controls">
-      <button id="timeline-play" title="Play/Pause">&#9654;</button>
-      <button id="timeline-speed" title="Speed">1x</button>
-    </div>
-    <div id="timeline-density"></div>
-  </div>
-
-  <!-- Hidden file input for settings import -->
-  <input type="file" id="settings-import-input" accept=".json" style="display:none">
-
-  <script type="module" src="/src/main.js"></script>
+  <div id="root"></div>
+  <script type="module" src="/src/main.jsx"></script>
 </body>
 </html>

--- a/visualizer/lib/commitments.js
+++ b/visualizer/lib/commitments.js
@@ -1,0 +1,40 @@
+import {
+  activeCommitmentMemories,
+  buildNeighborhoodMemoryNode,
+  loadGraphDataset,
+  normalizeCommitmentSortScore
+} from './graph-data.js';
+import { makeGraphId } from './graph-contract.js';
+
+export async function getActiveCommitments({ entityId = null, limit = 20 } = {}) {
+  const dataset = await loadGraphDataset();
+  const resolvedLimit = Math.max(1, Math.min(100, Number(limit || 20)));
+  const parsedEntityId = entityId ? Number(String(entityId).replace(/^entity-/, '')) : null;
+
+  const candidates = activeCommitmentMemories(dataset.memories, dataset.memoryContextById)
+    .filter((memory) => {
+      if (!parsedEntityId) return true;
+      const context = dataset.memoryContextById.get(memory.id);
+      return context?.entityRefs?.includes(parsedEntityId);
+    })
+    .sort((left, right) => normalizeCommitmentSortScore(right) - normalizeCommitmentSortScore(left))
+    .slice(0, resolvedLimit);
+
+  const items = candidates.map((memory, index) => {
+    const context = dataset.memoryContextById.get(memory.id) || { entityRefs: [], primaryEntityId: null, completed: false };
+    const anchor = context.primaryEntityId
+      ? dataset.entityNodeById.get(makeGraphId('entity', context.primaryEntityId))
+      : null;
+    return buildNeighborhoodMemoryNode(memory, context, anchor, index, 64);
+  });
+
+  return {
+    items,
+    meta: {
+      generatedAt: new Date().toISOString(),
+      entityId: parsedEntityId ? makeGraphId('entity', parsedEntityId) : null,
+      count: items.length
+    }
+  };
+}
+

--- a/visualizer/lib/graph-contract.js
+++ b/visualizer/lib/graph-contract.js
@@ -1,0 +1,347 @@
+import { getDb } from './database.js';
+
+const ENTITY_COLORS = {
+  person: '#76c7ff',
+  organization: '#9ab3ff',
+  project: '#64f1b4',
+  concept: '#d4a6ff',
+  location: '#ffc36f'
+};
+
+const MEMORY_COLORS = {
+  fact: '#86a8c8',
+  commitment: '#ff6f7d',
+  learning: '#54f2b6',
+  observation: '#7fd8ff',
+  preference: '#ffd166',
+  pattern: '#c89bff'
+};
+
+export function getTableColumns(db, table) {
+  try {
+    return new Set(db.prepare(`PRAGMA table_info(${table})`).all().map((column) => column.name));
+  } catch {
+    return new Set();
+  }
+}
+
+export function getSchemaInfo(db = getDb()) {
+  return {
+    db,
+    entityColumns: getTableColumns(db, 'entities'),
+    memoryColumns: getTableColumns(db, 'memories'),
+    relationshipColumns: getTableColumns(db, 'relationships'),
+    patternColumns: getTableColumns(db, 'patterns')
+  };
+}
+
+export function parseDate(value) {
+  if (!value) return null;
+  const parsed = new Date(String(value).replace(' ', 'T'));
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+export function toIso(value) {
+  const parsed = parseDate(value);
+  return parsed ? parsed.toISOString() : null;
+}
+
+export function daysSince(value) {
+  const parsed = parseDate(value);
+  if (!parsed) return null;
+  return (Date.now() - parsed.getTime()) / 86400000;
+}
+
+export function daysUntil(value) {
+  const parsed = parseDate(value);
+  if (!parsed) return null;
+  return (parsed.getTime() - Date.now()) / 86400000;
+}
+
+export function clamp01(value) {
+  return Math.max(0, Math.min(1, value));
+}
+
+export function round(value, precision = 3) {
+  const factor = 10 ** precision;
+  return Math.round(value * factor) / factor;
+}
+
+export function safeJsonParse(value) {
+  if (!value) return null;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+export function freshnessScore(value) {
+  const age = daysSince(value);
+  if (age === null) return 0.25;
+  if (age <= 1) return 1;
+  if (age <= 7) return 0.88;
+  if (age <= 14) return 0.74;
+  if (age <= 30) return 0.58;
+  if (age <= 90) return 0.34;
+  return 0.14;
+}
+
+export function urgencyScore({ deadlineAt, importance = 0, overdue = false, type = null }) {
+  if (overdue) return 1;
+  if (!deadlineAt) {
+    if (type === 'commitment') return clamp01(importance * 0.65);
+    return 0;
+  }
+
+  const until = daysUntil(deadlineAt);
+  if (until === null) return clamp01(importance * 0.5);
+  if (until <= 0) return 1;
+  if (until <= 1) return 0.95;
+  if (until <= 3) return 0.82;
+  if (until <= 7) return 0.67;
+  if (until <= 14) return 0.48;
+  return clamp01(importance * 0.4);
+}
+
+export function entityStatus(entity) {
+  const age = daysSince(entity.last_contact_at || entity.updated_at || entity.created_at);
+  if (entity.contact_trend === 'cooling') return 'cooling';
+  if (age !== null && age > 45) return 'stale';
+  return 'active';
+}
+
+export function memoryStatus(memory, overdue) {
+  if (memory.invalidated_at) return 'inactive';
+  if (overdue) return 'overdue';
+  if (memory.type === 'commitment' && memory.deadline_at) return 'scheduled';
+  if (memory.verification_status === 'verified') return 'verified';
+  return 'active';
+}
+
+export function patternStatus(pattern) {
+  return pattern.is_active === 0 ? 'inactive' : 'active';
+}
+
+export function makeGraphId(kind, dbId) {
+  return `${kind}-${dbId}`;
+}
+
+export function entityTone(subtype) {
+  return ENTITY_COLORS[subtype] || '#8ba2c3';
+}
+
+export function memoryTone(subtype) {
+  return MEMORY_COLORS[subtype] || '#8ba2c3';
+}
+
+export function normalizeEntityNode(entity, extras = {}) {
+  const importance = Number(entity.importance ?? 0.5);
+  const activityAt = entity.last_contact_at || extras.lastMemoryAt || entity.updated_at || entity.created_at;
+  const freshness = freshnessScore(activityAt);
+  const graphId = makeGraphId('entity', entity.id);
+  const signal = clamp01(
+    extras.signalScore ??
+    importance * 0.6 +
+    Math.min((extras.memoryCount || 0) / 30, 0.18) +
+    Math.min((extras.relationshipCount || 0) / 20, 0.22)
+  );
+
+  return {
+    id: graphId,
+    kind: 'entity',
+    subtype: entity.type,
+    label: entity.name,
+    importance: round(importance),
+    signalScore: round(signal),
+    freshnessScore: round(freshness),
+    urgencyScore: 0,
+    clusterKey: extras.clusterKey || `entity:${entity.type}`,
+    status: entityStatus(entity),
+    entityRefs: [entity.id],
+    timestamps: {
+      createdAt: toIso(entity.created_at),
+      updatedAt: toIso(entity.updated_at),
+      activityAt: toIso(activityAt),
+      lastContactAt: toIso(entity.last_contact_at)
+    },
+    description: entity.description || '',
+    relationshipCount: extras.relationshipCount || 0,
+    memoryCount: extras.memoryCount || 0,
+    anchorRef: extras.anchorRef || graphId,
+    layout: {
+      band: extras.band || 'core',
+      seedX: round(extras.seedX ?? extras.x ?? 0, 2),
+      seedY: round(extras.seedY ?? extras.y ?? 0, 2),
+      seedZ: round(extras.seedZ ?? extras.z ?? 0, 2)
+    },
+    color: entityTone(entity.type),
+    size: round(extras.size ?? (7 + signal * 11 + freshness * 2), 2),
+    x: extras.x ?? 0,
+    y: extras.y ?? 0,
+    z: extras.z ?? 0,
+    zIndex: extras.zIndex ?? 1
+  };
+}
+
+export function normalizeMemoryNode(memory, extras = {}) {
+  const importance = Number(memory.importance ?? 0.4);
+  const overdue = Boolean(
+    extras.overdue ??
+    (memory.type === 'commitment' && memory.deadline_at && !memory.invalidated_at && parseDate(memory.deadline_at)?.getTime() < Date.now())
+  );
+  const urgency = urgencyScore({
+    deadlineAt: memory.deadline_at,
+    importance,
+    overdue,
+    type: memory.type
+  });
+  const freshness = freshnessScore(memory.last_accessed_at || memory.updated_at || memory.created_at);
+
+  return {
+    id: makeGraphId('memory', memory.id),
+    kind: memory.type === 'commitment' ? 'commitment' : 'memory',
+    subtype: memory.type,
+    label: extras.label || truncate(memory.content || '', 96),
+    importance: round(importance),
+    signalScore: round(clamp01(extras.signalScore ?? importance * 0.7 + freshness * 0.2 + urgency * 0.1)),
+    freshnessScore: round(freshness),
+    urgencyScore: round(urgency),
+    clusterKey: extras.clusterKey || `${memory.type === 'commitment' ? 'commitment' : 'memory'}:${memory.type}`,
+    status: extras.status || memoryStatus(memory, overdue),
+    entityRefs: extras.entityRefs || [],
+    timestamps: {
+      createdAt: toIso(memory.created_at),
+      updatedAt: toIso(memory.updated_at),
+      activityAt: toIso(memory.last_accessed_at || memory.updated_at || memory.created_at),
+      deadlineAt: toIso(memory.deadline_at)
+    },
+    description: memory.content || '',
+    verificationStatus: memory.verification_status || 'pending',
+    accessCount: memory.access_count || 0,
+    anchorRef: extras.anchorRef || (extras.primaryEntityId ? makeGraphId('entity', extras.primaryEntityId) : null),
+    layout: {
+      band: extras.band || (memory.type === 'commitment' ? 'commitment' : 'memory'),
+      seedX: round(extras.seedX ?? extras.x ?? 0, 2),
+      seedY: round(extras.seedY ?? extras.y ?? 0, 2),
+      seedZ: round(extras.seedZ ?? extras.z ?? 0, 2)
+    },
+    color: memoryTone(memory.type),
+    size: round(extras.size ?? (memory.type === 'commitment' ? 5.5 + urgency * 6 : 3.2 + importance * 4.2), 2),
+    x: extras.x ?? 0,
+    y: extras.y ?? 0,
+    z: extras.z ?? 0,
+    zIndex: extras.zIndex ?? 2
+  };
+}
+
+export function normalizePatternNode(pattern, extras = {}) {
+  const importance = Number(pattern.confidence ?? 0.5);
+  const freshness = freshnessScore(pattern.last_observed_at || pattern.first_observed_at);
+  const signal = clamp01(extras.signalScore ?? importance * 0.68 + freshness * 0.14 + Math.min((pattern.occurrences || 0) / 12, 0.18));
+
+  return {
+    id: makeGraphId('pattern', pattern.id),
+    kind: 'pattern',
+    subtype: pattern.pattern_type,
+    label: pattern.name,
+    importance: round(importance),
+    signalScore: round(signal),
+    freshnessScore: round(freshness),
+    urgencyScore: 0,
+    clusterKey: extras.clusterKey || `pattern:${pattern.pattern_type}`,
+    status: patternStatus(pattern),
+    entityRefs: extras.entityRefs || [],
+    timestamps: {
+      createdAt: toIso(pattern.first_observed_at),
+      updatedAt: toIso(pattern.last_observed_at),
+      activityAt: toIso(pattern.last_observed_at || pattern.first_observed_at)
+    },
+    description: pattern.description || '',
+    occurrences: pattern.occurrences || 0,
+    anchorRef: extras.anchorRef || (extras.entityRefs?.[0] ? makeGraphId('entity', extras.entityRefs[0]) : null),
+    layout: {
+      band: extras.band || 'pattern',
+      seedX: round(extras.seedX ?? extras.x ?? 0, 2),
+      seedY: round(extras.seedY ?? extras.y ?? 0, 2),
+      seedZ: round(extras.seedZ ?? extras.z ?? 0, 2)
+    },
+    color: '#b593ff',
+    size: round(extras.size ?? (6 + importance * 6), 2),
+    x: extras.x ?? 0,
+    y: extras.y ?? 0,
+    z: extras.z ?? 0,
+    zIndex: extras.zIndex ?? 1.5
+  };
+}
+
+export function normalizeRelationshipEdge(relationship, extras = {}) {
+  return {
+    id: extras.id || makeGraphId('relationship', relationship.id),
+    source: extras.source || makeGraphId('entity', relationship.source_entity_id),
+    target: extras.target || makeGraphId('entity', relationship.target_entity_id),
+    kind: extras.kind || 'relationship',
+    channel: extras.channel || (extras.status === 'trace' ? 'trace' : 'relationship'),
+    strength: round(Number(relationship.strength ?? extras.strength ?? 0.5)),
+    direction: relationship.direction || extras.direction || 'bidirectional',
+    evidenceCount: extras.evidenceCount || 0,
+    status: extras.status || (relationship.invalid_at ? 'historical' : 'active'),
+    label: relationship.relationship_type || extras.label || '',
+    timestamps: {
+      createdAt: toIso(relationship.created_at),
+      updatedAt: toIso(relationship.updated_at),
+      validAt: toIso(relationship.valid_at),
+      invalidAt: toIso(relationship.invalid_at)
+    }
+  };
+}
+
+export function normalizeEvidenceEdge({
+  id,
+  source,
+  target,
+  strength = 0.4,
+  label = '',
+  evidenceCount = 1,
+  status = 'active',
+  channel = null
+}) {
+  return {
+    id,
+    source,
+    target,
+    kind: 'evidence',
+    channel: channel || (status === 'trace' ? 'trace' : label === 'commitment' ? 'commitment' : 'evidence'),
+    strength: round(strength),
+    direction: 'undirected',
+    evidenceCount,
+    status,
+    label,
+    timestamps: {}
+  };
+}
+
+export function placeholders(ids) {
+  return ids.map(() => '?').join(', ');
+}
+
+export function truncate(value, maxLength) {
+  if (!value) return '';
+  return value.length > maxLength ? `${value.slice(0, maxLength).trimEnd()}...` : value;
+}
+
+export function applyPosition(node, position) {
+  if (!position) return node;
+  return {
+    ...node,
+    x: round(position.x, 2),
+    y: round(position.y, 2),
+    z: round(position.z ?? node.z ?? 0, 2),
+    layout: {
+      ...(node.layout || {}),
+      seedX: round(position.x, 2),
+      seedY: round(position.y, 2),
+      seedZ: round(position.z ?? node.z ?? 0, 2)
+    }
+  };
+}

--- a/visualizer/lib/graph-data.js
+++ b/visualizer/lib/graph-data.js
@@ -1,0 +1,589 @@
+import { getDb } from './database.js';
+import { getProjectedPositions } from './projection.js';
+import {
+  applyPosition,
+  clamp01,
+  getSchemaInfo,
+  makeGraphId,
+  normalizeMemoryNode,
+  normalizePatternNode,
+  normalizeRelationshipEdge,
+  normalizeEntityNode,
+  parseDate,
+  round,
+  safeJsonParse
+} from './graph-contract.js';
+
+function buildEntitySelect(entityColumns) {
+  return [
+    'id',
+    'name',
+    'type',
+    'canonical_name',
+    'description',
+    'importance',
+    'created_at',
+    'updated_at',
+    'metadata',
+    entityColumns.has('last_contact_at') ? 'last_contact_at' : 'NULL AS last_contact_at',
+    entityColumns.has('contact_frequency_days') ? 'contact_frequency_days' : 'NULL AS contact_frequency_days',
+    entityColumns.has('contact_trend') ? 'contact_trend' : 'NULL AS contact_trend',
+    entityColumns.has('attention_tier') ? 'attention_tier' : "'standard' AS attention_tier",
+    entityColumns.has('deleted_at') ? 'deleted_at' : 'NULL AS deleted_at'
+  ].join(', ');
+}
+
+function buildMemorySelect(memoryColumns) {
+  return [
+    'id',
+    'content',
+    'type',
+    'importance',
+    'confidence',
+    'source',
+    memoryColumns.has('source_context') ? 'source_context' : 'NULL AS source_context',
+    'created_at',
+    'updated_at',
+    'last_accessed_at',
+    memoryColumns.has('access_count') ? 'access_count' : '0 AS access_count',
+    memoryColumns.has('verification_status') ? 'verification_status' : "'pending' AS verification_status",
+    memoryColumns.has('deadline_at') ? 'deadline_at' : 'NULL AS deadline_at',
+    memoryColumns.has('invalidated_at') ? 'invalidated_at' : 'NULL AS invalidated_at',
+    memoryColumns.has('corrected_at') ? 'corrected_at' : 'NULL AS corrected_at',
+    'metadata'
+  ].join(', ');
+}
+
+function buildRelationshipQuery(relationshipColumns, includeHistorical) {
+  const hasTemporalRelationships = relationshipColumns.has('invalid_at');
+  if (!hasTemporalRelationships) {
+    return 'SELECT * FROM relationships ORDER BY strength DESC, updated_at DESC';
+  }
+  if (includeHistorical) {
+    return 'SELECT * FROM relationships ORDER BY strength DESC, updated_at DESC';
+  }
+  return 'SELECT * FROM relationships WHERE invalid_at IS NULL ORDER BY strength DESC, updated_at DESC';
+}
+
+function stableHash(value) {
+  let hash = 2166136261;
+  const text = String(value ?? '');
+  for (let i = 0; i < text.length; i++) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return Math.abs(hash >>> 0);
+}
+
+function fallbackEntityPosition(entity, index, total) {
+  const goldenAngle = Math.PI * (3 - Math.sqrt(5));
+  const angle = index * goldenAngle + (stableHash(entity.type) % 19) * 0.04;
+  const radius = 44 + Math.sqrt(index + 1) * 52 + Math.min(Number(entity.importance || 0), 1) * 28 + total * 0.08;
+  const typeBias = {
+    person: { x: -18, y: 8 },
+    organization: { x: 14, y: -12 },
+    project: { x: 6, y: 18 },
+    concept: { x: -10, y: -16 },
+    location: { x: 20, y: 14 }
+  }[entity.type] || { x: 0, y: 0 };
+  return {
+    x: Math.cos(angle) * radius + typeBias.x,
+    y: Math.sin(angle) * radius + typeBias.y,
+    z: ((stableHash(`entity:${entity.id}`) % 240) - 120) * 0.7 + Math.min(total, 180) * 0.04
+  };
+}
+
+function averagePosition(points, fallback = { x: 0, y: 0, z: 0 }) {
+  if (!points.length) return fallback;
+  const total = points.reduce((acc, point) => {
+    acc.x += point.x;
+    acc.y += point.y;
+    acc.z += point.z ?? 0;
+    return acc;
+  }, { x: 0, y: 0, z: 0 });
+  return {
+    x: total.x / points.length,
+    y: total.y / points.length,
+    z: total.z / points.length
+  };
+}
+
+function offsetPosition(base, seed, radius = 32) {
+  const angle = ((stableHash(seed) % 360) * Math.PI) / 180;
+  const distance = radius + (stableHash(`${seed}:distance`) % 28);
+  const depth = ((stableHash(`${seed}:z`) % 140) - 70) * 0.8;
+  return {
+    x: base.x + Math.cos(angle) * distance,
+    y: base.y + Math.sin(angle) * distance,
+    z: (base.z ?? 0) + depth
+  };
+}
+
+function dedupe(values) {
+  return [...new Set(values.filter((value) => value !== null && value !== undefined))];
+}
+
+function inferCommitmentState(memory) {
+  if (memory.invalidated_at) return 'inactive';
+  if (/^\s*completed[:\s]/i.test(memory.content || '')) return 'completed';
+  if (/^\s*sent[:\s]/i.test(memory.content || '')) return 'completed';
+  if (/^\s*done[:\s]/i.test(memory.content || '')) return 'completed';
+  return 'active';
+}
+
+function patternReferenceIds(pattern, relationshipById) {
+  const refs = new Set();
+  const metadata = safeJsonParse(pattern.metadata);
+  const evidence = safeJsonParse(pattern.evidence);
+  const relationshipMatch = String(pattern.name || '').match(/relationship_(\d+)/i);
+
+  if (relationshipMatch) {
+    const relationship = relationshipById.get(Number(relationshipMatch[1]));
+    if (relationship) {
+      refs.add(relationship.source_entity_id);
+      refs.add(relationship.target_entity_id);
+    }
+  }
+
+  const visit = (value) => {
+    if (!value) return;
+    if (Array.isArray(value)) {
+      value.forEach(visit);
+      return;
+    }
+    if (typeof value === 'object') {
+      Object.entries(value).forEach(([key, nested]) => {
+        if ((key === 'entityId' || key === 'entity_id') && Number.isFinite(Number(nested))) {
+          refs.add(Number(nested));
+        } else {
+          visit(nested);
+        }
+      });
+      return;
+    }
+    const text = String(value);
+    const matches = text.match(/\bentity[_ -]?id[:= ]?(\d+)\b/ig) || [];
+    for (const match of matches) {
+      const digits = match.match(/(\d+)/);
+      if (digits) refs.add(Number(digits[1]));
+    }
+  };
+
+  visit(metadata);
+  visit(evidence);
+  return [...refs];
+}
+
+function buildEntityStats(entities, relationships, memoryEntityRows) {
+  const stats = new Map();
+  for (const entity of entities) {
+    stats.set(entity.id, {
+      relationshipCount: 0,
+      memoryCount: 0,
+      totalRelationshipStrength: 0,
+      lastMemoryAt: null
+    });
+  }
+
+  for (const relationship of relationships) {
+    const strength = Number(relationship.strength ?? 0.5);
+    const source = stats.get(relationship.source_entity_id);
+    const target = stats.get(relationship.target_entity_id);
+    if (source) {
+      source.relationshipCount += 1;
+      source.totalRelationshipStrength += strength;
+    }
+    if (target) {
+      target.relationshipCount += 1;
+      target.totalRelationshipStrength += strength;
+    }
+  }
+
+  for (const row of memoryEntityRows) {
+    const stat = stats.get(row.entity_id);
+    if (!stat) continue;
+    stat.memoryCount += 1;
+    if (!stat.lastMemoryAt || String(row.memory_created_at) > String(stat.lastMemoryAt)) {
+      stat.lastMemoryAt = row.memory_created_at;
+    }
+  }
+
+  return stats;
+}
+
+function resolvePrimaryEntityId(memory, linkRows, entityById) {
+  if (!linkRows.length) return null;
+  const ranked = [...linkRows].sort((left, right) => {
+    const leftEntity = entityById.get(left.entity_id);
+    const rightEntity = entityById.get(right.entity_id);
+    const relationshipBias = (value) => (value === 'about' ? 1 : value === 'mentions' ? 0.5 : 0);
+    const leftScore = Number(leftEntity?.importance || 0) + relationshipBias(left.relationship);
+    const rightScore = Number(rightEntity?.importance || 0) + relationshipBias(right.relationship);
+    return rightScore - leftScore;
+  });
+  return ranked[0]?.entity_id ?? null;
+}
+
+function relateMemories(memoryEntityRows) {
+  const rowsByMemory = new Map();
+  const rowsByEntity = new Map();
+  for (const row of memoryEntityRows) {
+    if (!rowsByMemory.has(row.memory_id)) rowsByMemory.set(row.memory_id, []);
+    if (!rowsByEntity.has(row.entity_id)) rowsByEntity.set(row.entity_id, []);
+    rowsByMemory.get(row.memory_id).push(row);
+    rowsByEntity.get(row.entity_id).push(row);
+  }
+  return { rowsByMemory, rowsByEntity };
+}
+
+function linkEntityAdjacency(relationships) {
+  const adjacency = new Map();
+  for (const relationship of relationships) {
+    const add = (source, target) => {
+      if (!adjacency.has(source)) adjacency.set(source, []);
+      adjacency.get(source).push({
+        entityId: target,
+        relationship
+      });
+    };
+    add(relationship.source_entity_id, relationship.target_entity_id);
+    add(relationship.target_entity_id, relationship.source_entity_id);
+  }
+  return adjacency;
+}
+
+function assignOverviewPatternPosition(entityRefIds, entityNodeById, pattern, index) {
+  const anchorPoints = entityRefIds
+    .map((entityId) => entityNodeById.get(makeGraphId('entity', entityId)))
+    .filter(Boolean);
+
+  if (anchorPoints.length) {
+    return offsetPosition(averagePosition(anchorPoints), `${pattern.id}:${index}`, 42);
+  }
+
+  const angle = ((index * 43 + stableHash(pattern.name)) % 360) * (Math.PI / 180);
+  const radius = 420 + (index % 7) * 28;
+  return {
+    x: Math.cos(angle) * radius,
+    y: Math.sin(angle) * radius,
+    z: -160 + (index % 9) * 28
+  };
+}
+
+export function parseGraphId(graphId) {
+  const match = String(graphId || '').match(/^([a-z]+)-(\d+)$/i);
+  if (!match) return null;
+  return {
+    kind: match[1].toLowerCase(),
+    dbId: Number(match[2])
+  };
+}
+
+export async function loadGraphDataset({ includeHistorical = false } = {}) {
+  const db = getDb();
+  const schema = getSchemaInfo(db);
+
+  const entities = db.prepare(
+    `SELECT ${buildEntitySelect(schema.entityColumns)} FROM entities ORDER BY importance DESC, name ASC`
+  ).all().filter((entity) => !entity.deleted_at);
+
+  const memories = db.prepare(
+    `SELECT ${buildMemorySelect(schema.memoryColumns)} FROM memories ORDER BY importance DESC, created_at DESC`
+  ).all();
+
+  const relationships = db.prepare(
+    buildRelationshipQuery(schema.relationshipColumns, includeHistorical)
+  ).all();
+
+  const patterns = db.prepare(`
+    SELECT id, name, description, pattern_type, occurrences, first_observed_at, last_observed_at,
+           confidence, is_active, evidence, metadata
+    FROM patterns
+    WHERE is_active = 1
+    ORDER BY confidence DESC, occurrences DESC, id ASC
+  `).all();
+
+  const memoryEntityRows = db.prepare(`
+    SELECT me.memory_id, me.entity_id, me.relationship, m.created_at AS memory_created_at
+    FROM memory_entities me
+    JOIN memories m ON m.id = me.memory_id
+  `).all();
+
+  const positions = await getProjectedPositions().catch(() => null);
+  const entityById = new Map(entities.map((entity) => [entity.id, entity]));
+  const memoryById = new Map(memories.map((memory) => [memory.id, memory]));
+  const relationshipById = new Map(relationships.map((relationship) => [relationship.id, relationship]));
+  const patternById = new Map(patterns.map((pattern) => [pattern.id, pattern]));
+  const entityStats = buildEntityStats(entities, relationships, memoryEntityRows);
+  const { rowsByMemory, rowsByEntity } = relateMemories(memoryEntityRows);
+  const adjacency = linkEntityAdjacency(relationships);
+  const memoryIdSetsByEntity = new Map();
+
+  for (const [entityId, rows] of rowsByEntity.entries()) {
+    memoryIdSetsByEntity.set(entityId, new Set(rows.map((row) => row.memory_id)));
+  }
+
+  const entityNodes = [];
+  const entityNodeById = new Map();
+
+  entities.forEach((entity, index) => {
+    const stats = entityStats.get(entity.id) || {};
+    const projected = positions?.[makeGraphId('entity', entity.id)] || fallbackEntityPosition(entity, index, entities.length);
+    const node = applyPosition(normalizeEntityNode(entity, {
+      relationshipCount: stats.relationshipCount || 0,
+      memoryCount: stats.memoryCount || 0,
+      lastMemoryAt: stats.lastMemoryAt || null,
+      anchorRef: makeGraphId('entity', entity.id),
+      band: 'core',
+      signalScore: clamp01(
+        Number(entity.importance ?? 0.5) * 0.54 +
+        Math.min((stats.relationshipCount || 0) / 12, 0.24) +
+        Math.min((stats.memoryCount || 0) / 40, 0.18)
+      )
+    }), projected);
+    entityNodes.push(node);
+    entityNodeById.set(node.id, node);
+  });
+
+  const memoryContextById = new Map();
+  for (const memory of memories) {
+    const links = rowsByMemory.get(memory.id) || [];
+    const entityRefs = dedupe(links.map((row) => row.entity_id));
+    const primaryEntityId = resolvePrimaryEntityId(memory, links, entityById);
+    const commitmentState = memory.type === 'commitment' ? inferCommitmentState(memory) : null;
+    memoryContextById.set(memory.id, {
+      entityRefs,
+      primaryEntityId,
+      completed: commitmentState === 'completed'
+    });
+  }
+
+  const patternContextById = new Map();
+  patterns.forEach((pattern, index) => {
+    const entityRefs = patternReferenceIds(pattern, relationshipById);
+    const projected = assignOverviewPatternPosition(entityRefs, entityNodeById, pattern, index);
+    patternContextById.set(pattern.id, {
+      entityRefs,
+      position: projected
+    });
+  });
+
+  return {
+    db,
+    schema,
+    positions,
+    entities,
+    memories,
+    relationships,
+    patterns,
+    entityById,
+    memoryById,
+    relationshipById,
+    patternById,
+    entityStats,
+    rowsByMemory,
+    rowsByEntity,
+    adjacency,
+    memoryIdSetsByEntity,
+    entityNodes,
+    entityNodeById,
+    memoryContextById,
+    patternContextById
+  };
+}
+
+export function buildOverviewCommitmentNode(memory, context, entityNodeById, index) {
+  const primaryEntityNode = context.primaryEntityId
+    ? entityNodeById.get(makeGraphId('entity', context.primaryEntityId))
+    : null;
+  const anchor = primaryEntityNode
+    ? offsetPosition({ x: primaryEntityNode.x, y: primaryEntityNode.y, z: primaryEntityNode.z }, `commitment:${memory.id}`, 58 + index * 2)
+    : { x: 0, y: 0, z: 120 };
+  anchor.z += 48;
+
+  return applyPosition(normalizeMemoryNode(memory, {
+    entityRefs: context.entityRefs,
+    primaryEntityId: context.primaryEntityId,
+    anchorRef: context.primaryEntityId ? makeGraphId('entity', context.primaryEntityId) : null,
+    band: 'commitment',
+    clusterKey: context.primaryEntityId ? `commitment:entity:${context.primaryEntityId}` : 'commitment:unassigned',
+    status: context.completed ? 'completed' : undefined,
+    size: 7.5 + clamp01(Number(memory.importance || 0.5)) * 5.5 + (context.completed ? -1.25 : 0.75),
+    zIndex: 2.4
+  }), anchor);
+}
+
+export function buildOverviewMemoryNode(memory, context, entityNodeById, index) {
+  const primaryEntityNode = context.primaryEntityId
+    ? entityNodeById.get(makeGraphId('entity', context.primaryEntityId))
+    : null;
+  const base = primaryEntityNode
+    ? { x: primaryEntityNode.x, y: primaryEntityNode.y, z: primaryEntityNode.z }
+    : { x: 0, y: 0, z: 0 };
+  const radius = memory.type === 'commitment'
+    ? 60 + (index % 6) * 5
+    : 92 + (index % 8) * 6;
+  const position = offsetPosition(base, `overview-memory:${memory.id}:${index}`, radius);
+  position.z += memory.type === 'commitment' ? 44 : 16;
+
+  return applyPosition(normalizeMemoryNode(memory, {
+    entityRefs: context.entityRefs,
+    primaryEntityId: context.primaryEntityId,
+    anchorRef: context.primaryEntityId ? makeGraphId('entity', context.primaryEntityId) : null,
+    band: memory.type === 'commitment' ? 'commitment' : 'memory',
+    clusterKey: context.primaryEntityId
+      ? `${memory.type === 'commitment' ? 'commitment' : 'memory'}:entity:${context.primaryEntityId}`
+      : `${memory.type === 'commitment' ? 'commitment' : 'memory'}:unassigned`,
+    status: context.completed ? 'completed' : undefined,
+    size: memory.type === 'commitment'
+      ? 6.8 + clamp01(Number(memory.importance || 0.5)) * 5.2
+      : 3.2 + clamp01(Number(memory.importance || 0.4)) * 3.2,
+    zIndex: memory.type === 'commitment' ? 2.35 : 2.05
+  }), position);
+}
+
+export function buildNeighborhoodMemoryNode(memory, context, anchorNode, index, radius = 72) {
+  const base = anchorNode
+    ? { x: anchorNode.x, y: anchorNode.y, z: anchorNode.z }
+    : { x: 0, y: 0, z: 0 };
+  const position = offsetPosition(base, `${memory.id}:${index}`, radius);
+  position.z += memory.type === 'commitment' ? 52 : 20;
+
+  return applyPosition(normalizeMemoryNode(memory, {
+    entityRefs: context.entityRefs,
+    primaryEntityId: context.primaryEntityId,
+    anchorRef: context.primaryEntityId ? makeGraphId('entity', context.primaryEntityId) : null,
+    band: memory.type === 'commitment' ? 'commitment' : 'memory',
+    clusterKey: context.primaryEntityId ? `memory:entity:${context.primaryEntityId}` : 'memory:unassigned',
+    status: context.completed ? 'completed' : undefined,
+    size: memory.type === 'commitment'
+      ? 6.5 + clamp01(Number(memory.importance || 0.5)) * 5
+      : 3.6 + clamp01(Number(memory.importance || 0.4)) * 3.8,
+    zIndex: memory.type === 'commitment' ? 2.4 : 2.1
+  }), position);
+}
+
+export function buildPatternNode(pattern, context, overrides = {}) {
+  return applyPosition(normalizePatternNode(pattern, {
+    entityRefs: context.entityRefs,
+    anchorRef: context.entityRefs.length ? makeGraphId('entity', context.entityRefs[0]) : null,
+    band: 'pattern',
+    clusterKey: context.entityRefs.length ? `pattern:group:${context.entityRefs[0]}` : `pattern:${pattern.pattern_type}`,
+    zIndex: 1.8,
+    ...overrides
+  }), context.position);
+}
+
+export function buildRelationshipNodeLookup(relationships) {
+  const byPair = new Map();
+  for (const relationship of relationships) {
+    const key = [relationship.source_entity_id, relationship.target_entity_id].sort((left, right) => left - right).join(':');
+    if (!byPair.has(key)) byPair.set(key, []);
+    byPair.get(key).push(relationship);
+  }
+  return byPair;
+}
+
+export function commonEntityRelationshipEdges(relationships) {
+  return relationships.map((relationship) => normalizeRelationshipEdge(relationship));
+}
+
+export function strongestRelationship(relationshipList) {
+  if (!relationshipList?.length) return null;
+  return [...relationshipList].sort((left, right) => Number(right.strength || 0) - Number(left.strength || 0))[0];
+}
+
+export function activeCommitmentMemories(memories, memoryContextById) {
+  return memories.filter((memory) => {
+    if (memory.type !== 'commitment') return false;
+    const context = memoryContextById.get(memory.id);
+    if (!context || context.completed) return false;
+    return !memory.invalidated_at;
+  });
+}
+
+export function normalizeCommitmentSortScore(memory) {
+  const deadline = parseDate(memory.deadline_at)?.getTime() ?? Number.POSITIVE_INFINITY;
+  return (
+    (memory.deadline_at ? 1 : 0) * 10000000000000 -
+    deadline +
+    Number(memory.importance || 0) * 1000
+  );
+}
+
+export function relationshipPathCost(relationship) {
+  const strength = clamp01(Number(relationship.strength ?? 0.5));
+  return round(1.25 - strength * 0.9, 4);
+}
+
+function sharedMemoryCount(dataset, leftEntityId, rightEntityId) {
+  const left = dataset.memoryIdSetsByEntity.get(leftEntityId) || new Set();
+  const right = dataset.memoryIdSetsByEntity.get(rightEntityId) || new Set();
+  let count = 0;
+  for (const memoryId of left) {
+    if (right.has(memoryId)) count += 1;
+  }
+  return count;
+}
+
+export function findHubEntityId(dataset) {
+  const explicit = dataset.entityNodes.find((node) => /kamil banc/i.test(node.label));
+  if (explicit) return Number(explicit.id.replace('entity-', ''));
+  const strongest = [...dataset.entityNodes].sort((left, right) => (right.relationshipCount || 0) - (left.relationshipCount || 0))[0];
+  return strongest ? Number(strongest.id.replace('entity-', '')) : null;
+}
+
+export function buildInferredRelationships(dataset, { minSharedMemories = 2, maxEdges = 48 } = {}) {
+  const hubEntityId = findHubEntityId(dataset);
+  const inferred = [];
+  const seenPairs = new Set();
+
+  for (const node of dataset.entityNodes) {
+    const entityId = Number(node.id.replace('entity-', ''));
+    if ((node.relationshipCount || 0) > 0) continue;
+
+    const candidates = new Map();
+    for (const row of dataset.rowsByEntity.get(entityId) || []) {
+      for (const linked of dataset.rowsByMemory.get(row.memory_id) || []) {
+        if (linked.entity_id === entityId) continue;
+        const current = candidates.get(linked.entity_id) || 0;
+        candidates.set(linked.entity_id, current + 1);
+      }
+    }
+
+    const ranked = [...candidates.entries()]
+      .filter(([, count]) => count >= minSharedMemories)
+      .sort((left, right) => {
+        if (hubEntityId && right[0] === hubEntityId) return 1;
+        if (hubEntityId && left[0] === hubEntityId) return -1;
+        return right[1] - left[1];
+      });
+
+    const best = ranked[0];
+    if (!best) continue;
+
+    const [targetEntityId, sharedCount] = best;
+    const pairKey = [entityId, targetEntityId].sort((a, b) => a - b).join(':');
+    if (seenPairs.has(pairKey)) continue;
+    seenPairs.add(pairKey);
+
+    inferred.push({
+      id: `inferred-${entityId}-${targetEntityId}`,
+      source_entity_id: entityId,
+      target_entity_id: targetEntityId,
+      relationship_type: 'shared_memory_context',
+      direction: 'bidirectional',
+      strength: round(clamp01(0.34 + Math.min(sharedCount / 8, 0.44)), 3),
+      evidenceCount: sharedCount,
+      inferred: true,
+      created_at: null,
+      updated_at: null,
+      valid_at: null,
+      invalid_at: null
+    });
+
+    if (inferred.length >= maxEdges) break;
+  }
+
+  return inferred;
+}

--- a/visualizer/lib/graph.js
+++ b/visualizer/lib/graph.js
@@ -1,19 +1,16 @@
 /**
- * Graph builder — transforms SQLite data into nodes + edges JSON
- * for the 3d-force-graph frontend.
+ * Graph builder -- transforms SQLite data into nodes + edges JSON for the
+ * 3d-force-graph frontend.
  */
 
 import { getDb } from './database.js';
 
-/** Detect which columns exist on a table. */
 function getTableColumns(db, table) {
   try {
-    return new Set(db.prepare(`PRAGMA table_info(${table})`).all().map(c => c.name));
-  } catch { return new Set(); }
-}
-
-function hasColumn(db, table, column) {
-  return getTableColumns(db, table).has(column);
+    return new Set(db.prepare(`PRAGMA table_info(${table})`).all().map((column) => column.name));
+  } catch {
+    return new Set();
+  }
 }
 
 const NODE_COLORS = {
@@ -33,172 +30,311 @@ const MEMORY_COLORS = {
   pattern: '#a78bfa'
 };
 
-/**
- * Build the full graph from the database.
- * Returns { nodes: [...], links: [...], meta: {...} }
- */
 export function buildGraph({ includeHistorical = false } = {}) {
   const db = getDb();
   const nodes = [];
   const links = [];
+  const nodeById = new Map();
 
-  // ── Entities → nodes ──────────────────────────────────────
-  const entities = db.prepare(`
-    SELECT id, name, type, description, importance, created_at, updated_at, metadata
-    FROM entities
-    ORDER BY importance DESC
-  `).all();
+  const entityColumns = getTableColumns(db, 'entities');
+  const memoryColumns = getTableColumns(db, 'memories');
+  const relationshipColumns = getTableColumns(db, 'relationships');
 
-  for (const e of entities) {
-    const meta = safeJsonParse(e.metadata);
-    const daysSinceUpdate = daysSince(e.updated_at);
+  const entitySelect = [
+    'id',
+    'name',
+    'type',
+    'description',
+    'importance',
+    'created_at',
+    'updated_at',
+    'metadata',
+    entityColumns.has('last_contact_at') ? 'last_contact_at' : 'NULL AS last_contact_at',
+    entityColumns.has('contact_frequency_days') ? 'contact_frequency_days' : 'NULL AS contact_frequency_days',
+    entityColumns.has('contact_trend') ? 'contact_trend' : 'NULL AS contact_trend',
+    entityColumns.has('attention_tier') ? 'attention_tier' : "'standard' AS attention_tier",
+    entityColumns.has('deleted_at') ? 'deleted_at' : 'NULL AS deleted_at'
+  ].join(', ');
 
-    nodes.push({
-      id: `entity-${e.id}`,
-      dbId: e.id,
-      nodeType: 'entity',
-      entityType: e.type,
-      name: e.name,
-      description: e.description,
-      importance: e.importance,
-      color: NODE_COLORS[e.type] || '#888',
-      size: Math.max(3, Math.sqrt(e.importance) * 8),
-      opacity: getOpacity(e.importance, daysSinceUpdate),
-      createdAt: e.created_at,
-      updatedAt: e.updated_at,
-      llmImproved: meta?.llm_improved || false
+  const entities = db.prepare(
+    `SELECT ${entitySelect} FROM entities ORDER BY importance DESC, name ASC`
+  ).all().filter((entity) => !entity.deleted_at);
+
+  const entityStats = new Map();
+
+  for (const entity of entities) {
+    entityStats.set(entity.id, {
+      relationshipCount: 0,
+      relationshipStrength: 0,
+      memoryCount: 0,
+      lastMemoryAt: null
     });
+
+    const metadata = safeJsonParse(entity.metadata);
+    const daysSinceUpdate = daysSince(entity.updated_at);
+    const node = {
+      id: `entity-${entity.id}`,
+      dbId: entity.id,
+      nodeType: 'entity',
+      entityType: entity.type,
+      name: entity.name,
+      description: entity.description,
+      importance: numberOr(entity.importance, 0.5),
+      color: NODE_COLORS[entity.type] || '#888888',
+      size: Math.max(3.5, Math.sqrt(numberOr(entity.importance, 0.5)) * 7.5),
+      opacity: getOpacity(numberOr(entity.importance, 0.5), daysSinceUpdate),
+      createdAt: entity.created_at,
+      updatedAt: entity.updated_at,
+      activityAt: entity.last_contact_at || entity.updated_at || entity.created_at,
+      lastContactAt: entity.last_contact_at,
+      contactFrequencyDays: entity.contact_frequency_days,
+      contactTrend: entity.contact_trend || 'steady',
+      attentionTier: entity.attention_tier || 'standard',
+      llmImproved: Boolean(metadata?.llm_improved),
+      signalScore: numberOr(entity.importance, 0.5)
+    };
+
+    nodes.push(node);
+    nodeById.set(node.id, node);
   }
 
-  // ── Memories → nodes ──────────────────────────────────────
-  const memCols = getTableColumns(db, 'memories');
-  const hasVerification = memCols.has('verification_status');
-  const hasSourceContext = memCols.has('source_context');
-  const hasAccessCount = memCols.has('access_count');
-
   const memorySelect = [
-    'id', 'content', 'type', 'importance', 'confidence', 'source',
-    hasSourceContext ? 'source_context' : "NULL as source_context",
-    'created_at', 'updated_at', 'last_accessed_at',
-    hasAccessCount ? 'access_count' : '0 as access_count',
-    hasVerification ? 'verification_status' : "'pending' as verification_status",
+    'id',
+    'content',
+    'type',
+    'importance',
+    'confidence',
+    'source',
+    memoryColumns.has('source_context') ? 'source_context' : 'NULL AS source_context',
+    'created_at',
+    'updated_at',
+    'last_accessed_at',
+    memoryColumns.has('access_count') ? 'access_count' : '0 AS access_count',
+    memoryColumns.has('verification_status') ? 'verification_status' : "'pending' AS verification_status",
+    memoryColumns.has('deadline_at') ? 'deadline_at' : 'NULL AS deadline_at',
+    memoryColumns.has('invalidated_at') ? 'invalidated_at' : 'NULL AS invalidated_at',
+    memoryColumns.has('corrected_at') ? 'corrected_at' : 'NULL AS corrected_at',
     'metadata'
   ].join(', ');
 
-  const memories = db.prepare(`
-    SELECT ${memorySelect}
-    FROM memories
-    ORDER BY importance DESC
-    LIMIT 2000
-  `).all();
+  const memories = db.prepare(
+    `SELECT ${memorySelect} FROM memories ORDER BY importance DESC, created_at DESC LIMIT 2500`
+  ).all();
 
-  for (const m of memories) {
-    const meta = safeJsonParse(m.metadata);
-    const daysSinceAccess = daysSince(m.last_accessed_at || m.updated_at);
+  const memoryStats = new Map();
 
-    nodes.push({
-      id: `memory-${m.id}`,
-      dbId: m.id,
+  for (const memory of memories) {
+    const metadata = safeJsonParse(memory.metadata);
+    const activityAt = memory.last_accessed_at || memory.updated_at || memory.created_at;
+    const daysSinceActivity = daysSince(activityAt);
+    const overdue = Boolean(
+      memory.type === 'commitment' &&
+      memory.deadline_at &&
+      !memory.invalidated_at &&
+      parseDate(memory.deadline_at)?.getTime() < Date.now()
+    );
+
+    const node = {
+      id: `memory-${memory.id}`,
+      dbId: memory.id,
       nodeType: 'memory',
-      memoryType: m.type,
-      name: truncate(m.content, 60),
-      content: m.content,
-      importance: m.importance,
-      confidence: m.confidence,
-      color: MEMORY_COLORS[m.type] || '#888',
-      size: Math.max(1.5, m.importance * (m.type === 'commitment' ? 4 : 3)),
-      opacity: getOpacity(m.importance, daysSinceAccess),
-      source: m.source,
-      sourceContext: m.source_context,
-      accessCount: m.access_count,
-      verificationStatus: m.verification_status,
-      createdAt: m.created_at,
-      lastAccessed: m.last_accessed_at,
-      llmImproved: meta?.llm_improved || false
+      memoryType: memory.type,
+      name: truncate(memory.content, 84),
+      content: memory.content,
+      importance: numberOr(memory.importance, 0.4),
+      confidence: numberOr(memory.confidence, 0.7),
+      color: MEMORY_COLORS[memory.type] || '#888888',
+      size: Math.max(1.3, numberOr(memory.importance, 0.35) * (overdue ? 5 : memory.type === 'commitment' ? 4.2 : 3.2)),
+      opacity: getOpacity(numberOr(memory.importance, 0.35), daysSinceActivity),
+      source: memory.source,
+      sourceContext: memory.source_context,
+      accessCount: memory.access_count,
+      verificationStatus: memory.verification_status,
+      createdAt: memory.created_at,
+      updatedAt: memory.updated_at,
+      activityAt,
+      lastAccessed: memory.last_accessed_at,
+      deadlineAt: memory.deadline_at,
+      invalidatedAt: memory.invalidated_at,
+      correctedAt: memory.corrected_at,
+      llmImproved: Boolean(metadata?.llm_improved),
+      overdue,
+      entityIds: [],
+      primaryEntityId: null,
+      relatedEntityCount: 0,
+      signalScore: numberOr(memory.importance, 0.35)
+    };
+
+    nodes.push(node);
+    nodeById.set(node.id, node);
+    memoryStats.set(memory.id, {
+      entityIds: [],
+      primaryEntityId: null,
+      primaryImportance: -1
     });
   }
 
-  // ── Patterns → nodes ──────────────────────────────────────
-  const patterns = db.prepare(`
+  const patterns = db.prepare(
+    `
     SELECT id, name, description, pattern_type, occurrences, confidence,
            first_observed_at, last_observed_at, evidence
     FROM patterns
     WHERE is_active = 1
-  `).all();
+    ORDER BY confidence DESC, occurrences DESC
+  `
+  ).all();
 
-  for (const p of patterns) {
-    nodes.push({
-      id: `pattern-${p.id}`,
-      dbId: p.id,
+  for (const pattern of patterns) {
+    const node = {
+      id: `pattern-${pattern.id}`,
+      dbId: pattern.id,
       nodeType: 'pattern',
-      patternType: p.pattern_type,
-      name: p.name,
-      description: p.description,
-      importance: p.confidence,
-      confidence: p.confidence,
+      patternType: pattern.pattern_type,
+      name: pattern.name,
+      description: pattern.description,
+      importance: numberOr(pattern.confidence, 0.5),
+      confidence: numberOr(pattern.confidence, 0.5),
       color: '#a78bfa',
-      size: Math.max(4, p.confidence * 10),
-      opacity: Math.max(0.4, p.confidence),
-      occurrences: p.occurrences,
-      createdAt: p.first_observed_at,
-      evidence: safeJsonParse(p.evidence)
-    });
+      size: Math.max(4.5, numberOr(pattern.confidence, 0.5) * 12),
+      opacity: Math.max(0.42, numberOr(pattern.confidence, 0.5)),
+      createdAt: pattern.first_observed_at,
+      updatedAt: pattern.last_observed_at,
+      activityAt: pattern.last_observed_at || pattern.first_observed_at,
+      occurrences: pattern.occurrences,
+      evidence: safeJsonParse(pattern.evidence),
+      signalScore: numberOr(pattern.confidence, 0.5)
+    };
+
+    nodes.push(node);
+    nodeById.set(node.id, node);
   }
 
-  // ── Entity ↔ Entity relationships → links ────────────────
-  const hasTemporal = hasColumn(db, 'relationships', 'invalid_at');
-  let relQuery;
-  if (hasTemporal) {
-    relQuery = includeHistorical
-      ? 'SELECT * FROM relationships ORDER BY strength DESC'
-      : 'SELECT * FROM relationships WHERE invalid_at IS NULL ORDER BY strength DESC';
-  } else {
-    relQuery = 'SELECT * FROM relationships ORDER BY strength DESC';
-  }
+  const hasTemporalRelationships = relationshipColumns.has('invalid_at');
+  const relationshipQuery = hasTemporalRelationships
+    ? includeHistorical
+      ? 'SELECT * FROM relationships ORDER BY strength DESC, updated_at DESC'
+      : 'SELECT * FROM relationships WHERE invalid_at IS NULL ORDER BY strength DESC, updated_at DESC'
+    : 'SELECT * FROM relationships ORDER BY strength DESC, updated_at DESC';
 
-  const relationships = db.prepare(relQuery).all();
+  const relationships = db.prepare(relationshipQuery).all();
 
-  for (const r of relationships) {
-    const invalidAt = hasTemporal ? r.invalid_at : null;
+  for (const relationship of relationships) {
+    const sourceNode = nodeById.get(`entity-${relationship.source_entity_id}`);
+    const targetNode = nodeById.get(`entity-${relationship.target_entity_id}`);
+    if (!sourceNode || !targetNode) continue;
+
+    const invalidAt = hasTemporalRelationships ? relationship.invalid_at : null;
+
     links.push({
-      id: `rel-${r.id}`,
-      source: `entity-${r.source_entity_id}`,
-      target: `entity-${r.target_entity_id}`,
+      id: `rel-${relationship.id}`,
+      source: sourceNode.id,
+      target: targetNode.id,
       linkType: 'relationship',
-      label: r.relationship_type,
-      strength: r.strength,
-      direction: r.direction,
+      label: relationship.relationship_type,
+      strength: numberOr(relationship.strength, 0.5),
+      direction: relationship.direction,
       color: invalidAt ? 'rgba(255,255,255,0.08)' : undefined,
-      dashed: invalidAt !== null || r.strength < 0.3,
-      width: Math.max(0.5, r.strength * 3),
-      validAt: hasTemporal ? r.valid_at : null,
+      dashed: Boolean(invalidAt) || numberOr(relationship.strength, 0.5) < 0.28,
+      width: Math.max(0.55, numberOr(relationship.strength, 0.5) * 3.2),
+      validAt: hasTemporalRelationships ? relationship.valid_at : null,
       invalidAt,
-      historical: invalidAt !== null
+      historical: Boolean(invalidAt)
     });
+
+    const sourceStats = entityStats.get(relationship.source_entity_id);
+    const targetStats = entityStats.get(relationship.target_entity_id);
+    if (sourceStats) {
+      sourceStats.relationshipCount += 1;
+      sourceStats.relationshipStrength += numberOr(relationship.strength, 0.5);
+    }
+    if (targetStats) {
+      targetStats.relationshipCount += 1;
+      targetStats.relationshipStrength += numberOr(relationship.strength, 0.5);
+    }
   }
 
-  // ── Memory ↔ Entity links ────────────────────────────────
-  const memoryLinks = db.prepare(`
-    SELECT me.memory_id, me.entity_id, me.relationship
+  const memoryLinks = db.prepare(
+    `
+    SELECT me.memory_id, me.entity_id, me.relationship, e.importance AS entity_importance
     FROM memory_entities me
     JOIN memories m ON m.id = me.memory_id
-    ORDER BY m.importance DESC
-    LIMIT 5000
-  `).all();
+    JOIN entities e ON e.id = me.entity_id
+    ORDER BY m.importance DESC, e.importance DESC
+    LIMIT 7000
+  `
+  ).all();
 
-  for (const ml of memoryLinks) {
+  for (const memoryLink of memoryLinks) {
+    const memoryNode = nodeById.get(`memory-${memoryLink.memory_id}`);
+    const entityNode = nodeById.get(`entity-${memoryLink.entity_id}`);
+    if (!memoryNode || !entityNode) continue;
+
     links.push({
-      source: `memory-${ml.memory_id}`,
-      target: `entity-${ml.entity_id}`,
+      id: `mem-${memoryLink.memory_id}-${memoryLink.entity_id}`,
+      source: memoryNode.id,
+      target: entityNode.id,
       linkType: 'memory_entity',
-      label: ml.relationship,
-      width: 0.3,
-      opacity: 0.4,
+      label: memoryLink.relationship,
+      width: 0.35,
+      opacity: 0.42,
       dashed: false
     });
+
+    const stats = entityStats.get(memoryLink.entity_id);
+    if (stats) {
+      stats.memoryCount += 1;
+      stats.lastMemoryAt = mostRecent(stats.lastMemoryAt, memoryNode.activityAt || memoryNode.createdAt);
+    }
+
+    const memoryMetric = memoryStats.get(memoryLink.memory_id);
+    if (memoryMetric) {
+      memoryMetric.entityIds.push(entityNode.id);
+      if (numberOr(memoryLink.entity_importance, 0) > memoryMetric.primaryImportance) {
+        memoryMetric.primaryImportance = numberOr(memoryLink.entity_importance, 0);
+        memoryMetric.primaryEntityId = entityNode.id;
+      }
+    }
   }
 
-  // ── Meta ──────────────────────────────────────────────────
+  const maxRelationshipCount = Math.max(...[...entityStats.values()].map((item) => item.relationshipCount), 1);
+  const maxRelationshipStrength = Math.max(...[...entityStats.values()].map((item) => item.relationshipStrength), 1);
+  const maxMemoryCount = Math.max(...[...entityStats.values()].map((item) => item.memoryCount), 1);
+
+  for (const entity of entities) {
+    const node = nodeById.get(`entity-${entity.id}`);
+    const stats = entityStats.get(entity.id);
+    if (!node || !stats) continue;
+
+    const memoryFactor = stats.memoryCount / maxMemoryCount;
+    const relationshipFactor = stats.relationshipCount / maxRelationshipCount;
+    const strengthFactor = stats.relationshipStrength / maxRelationshipStrength;
+    const signalScore = clamp01(
+      numberOr(entity.importance, 0.5) * 0.55 +
+      memoryFactor * 0.18 +
+      relationshipFactor * 0.12 +
+      strengthFactor * 0.15
+    );
+
+    node.memoryCount = stats.memoryCount;
+    node.relationshipCount = stats.relationshipCount;
+    node.relationshipStrength = roundTo(stats.relationshipStrength, 2);
+    node.signalScore = roundTo(signalScore, 3);
+    node.size = Math.max(3.5, Math.sqrt(numberOr(entity.importance, 0.5)) * 7.5 + stats.relationshipCount * 0.18 + stats.memoryCount * 0.08);
+    node.activityAt = stats.lastMemoryAt || node.lastContactAt || node.updatedAt || node.createdAt;
+    node.recentlyActive = (daysSince(node.activityAt) ?? 999) <= 10;
+  }
+
+  for (const memory of memories) {
+    const node = nodeById.get(`memory-${memory.id}`);
+    const stats = memoryStats.get(memory.id);
+    if (!node || !stats) continue;
+
+    node.entityIds = stats.entityIds;
+    node.primaryEntityId = stats.primaryEntityId;
+    node.relatedEntityCount = stats.entityIds.length;
+    node.signalScore = roundTo(clamp01(numberOr(memory.importance, 0.35) * 0.7 + Math.min(stats.entityIds.length / 5, 0.3)), 3);
+  }
+
   const meta = {
     totalEntities: entities.length,
     totalMemories: memories.length,
@@ -210,27 +346,56 @@ export function buildGraph({ includeHistorical = false } = {}) {
   return { nodes, links, meta };
 }
 
-// ── Helpers ─────────────────────────────────────────────────
-
-function safeJsonParse(str) {
-  if (!str) return null;
-  try { return JSON.parse(str); } catch { return null; }
+function safeJsonParse(value) {
+  if (!value) return null;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
 }
 
-function daysSince(dateStr) {
-  if (!dateStr) return 999;
-  const d = new Date(dateStr.replace(' ', 'T'));
-  return (Date.now() - d.getTime()) / (1000 * 60 * 60 * 24);
+function parseDate(value) {
+  if (!value) return null;
+  const parsed = new Date(String(value).replace(' ', 'T'));
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function daysSince(value) {
+  const parsed = parseDate(value);
+  if (!parsed) return null;
+  return (Date.now() - parsed.getTime()) / (1000 * 60 * 60 * 24);
 }
 
 function getOpacity(importance, daysSinceActivity) {
-  if (importance > 0.7) return 1.0;
-  if (daysSinceActivity > 90) return 0.15;
-  if (daysSinceActivity > 30) return 0.4;
-  return Math.max(0.3, importance);
+  if (importance > 0.8) return 1.0;
+  if (daysSinceActivity === null) return Math.max(0.4, importance);
+  if (daysSinceActivity > 120) return 0.12;
+  if (daysSinceActivity > 45) return 0.28;
+  if (daysSinceActivity > 21) return 0.46;
+  return Math.max(0.34, importance);
 }
 
-function truncate(str, len) {
-  if (!str) return '';
-  return str.length > len ? str.slice(0, len) + '...' : str;
+function truncate(value, maxLength) {
+  if (!value) return '';
+  return value.length > maxLength ? `${value.slice(0, maxLength).trimEnd()}...` : value;
+}
+
+function mostRecent(a, b) {
+  if (!a) return b || null;
+  if (!b) return a || null;
+  return parseDate(a)?.getTime() >= parseDate(b)?.getTime() ? a : b;
+}
+
+function numberOr(value, fallback) {
+  return Number.isFinite(Number(value)) ? Number(value) : fallback;
+}
+
+function clamp01(value) {
+  return Math.max(0, Math.min(1, value));
+}
+
+function roundTo(value, precision) {
+  const factor = 10 ** precision;
+  return Math.round(value * factor) / factor;
 }

--- a/visualizer/lib/insights.js
+++ b/visualizer/lib/insights.js
@@ -1,0 +1,293 @@
+/**
+ * Insights builder -- derives useful exploration signals from Claudia's DB.
+ *
+ * The visualizer uses this to surface real hotspots in the local memory store:
+ * who is central, what is urgent, which relationships are cooling, and what
+ * patterns are currently active.
+ */
+
+import { getDb } from './database.js';
+
+function getTableColumns(db, table) {
+  try {
+    return new Set(db.prepare(`PRAGMA table_info(${table})`).all().map((column) => column.name));
+  } catch {
+    return new Set();
+  }
+}
+
+function dateToIso(value) {
+  if (!value) return null;
+  const normalized = String(value).replace(' ', 'T');
+  const parsed = new Date(normalized);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}
+
+function daysSince(value) {
+  if (!value) return null;
+  const parsed = new Date(String(value).replace(' ', 'T'));
+  if (Number.isNaN(parsed.getTime())) return null;
+  return Math.floor((Date.now() - parsed.getTime()) / (1000 * 60 * 60 * 24));
+}
+
+function getPriorityBucket(item) {
+  if (item.overdue) return 'Overdue';
+  if (item.deadlineAt) return 'Scheduled';
+  return 'Tracked';
+}
+
+export function buildInsights() {
+  const db = getDb();
+  const entityColumns = getTableColumns(db, 'entities');
+  const memoryColumns = getTableColumns(db, 'memories');
+  const relationshipColumns = getTableColumns(db, 'relationships');
+
+  const hasTemporalRelationships = relationshipColumns.has('invalid_at');
+  const hasEntityContactFields =
+    entityColumns.has('last_contact_at') &&
+    entityColumns.has('contact_frequency_days') &&
+    entityColumns.has('contact_trend') &&
+    entityColumns.has('attention_tier');
+  const hasMemoryDeadline = memoryColumns.has('deadline_at');
+  const hasMemoryInvalidated = memoryColumns.has('invalidated_at');
+  const hasVerification = memoryColumns.has('verification_status');
+
+  const relationshipWhere = hasTemporalRelationships ? 'WHERE invalid_at IS NULL' : '';
+  const invalidatedFilter = hasMemoryInvalidated ? 'AND m.invalidated_at IS NULL' : '';
+
+  const count = (query, fallback = 0) => {
+    try {
+      return db.prepare(query).get()?.c ?? fallback;
+    } catch {
+      return fallback;
+    }
+  };
+
+  const summary = {
+    entities: count('SELECT COUNT(*) AS c FROM entities'),
+    memories: count('SELECT COUNT(*) AS c FROM memories'),
+    relationships: count(
+      hasTemporalRelationships
+        ? 'SELECT COUNT(*) AS c FROM relationships WHERE invalid_at IS NULL'
+        : 'SELECT COUNT(*) AS c FROM relationships'
+    ),
+    patterns: count('SELECT COUNT(*) AS c FROM patterns WHERE is_active = 1'),
+    predictions: count('SELECT COUNT(*) AS c FROM predictions WHERE is_shown = 0'),
+    commitments: count(
+      `SELECT COUNT(*) AS c FROM memories m WHERE m.type = 'commitment' ${invalidatedFilter}`
+    ),
+    overdueCommitments: hasMemoryDeadline
+      ? count(
+          `SELECT COUNT(*) AS c
+           FROM memories m
+           WHERE m.type = 'commitment'
+             ${invalidatedFilter}
+             AND m.deadline_at IS NOT NULL
+             AND datetime(m.deadline_at) < datetime('now')`
+        )
+      : 0,
+    recentActivity: count(
+      `SELECT COUNT(*) AS c
+       FROM memories
+       WHERE datetime(created_at) > datetime('now', '-24 hours')`
+    )
+  };
+
+  const topEntities = db.prepare(
+    `
+    WITH rels AS (
+      SELECT source_entity_id AS entity_id, COUNT(*) AS relationship_count, SUM(strength) AS relationship_strength
+      FROM relationships
+      ${relationshipWhere}
+      GROUP BY source_entity_id
+      UNION ALL
+      SELECT target_entity_id AS entity_id, COUNT(*) AS relationship_count, SUM(strength) AS relationship_strength
+      FROM relationships
+      ${relationshipWhere}
+      GROUP BY target_entity_id
+    ),
+    rel_agg AS (
+      SELECT entity_id,
+             SUM(relationship_count) AS relationship_count,
+             SUM(relationship_strength) AS relationship_strength
+      FROM rels
+      GROUP BY entity_id
+    ),
+    mem_agg AS (
+      SELECT me.entity_id,
+             COUNT(*) AS memory_count,
+             MAX(m.created_at) AS last_memory_at
+      FROM memory_entities me
+      JOIN memories m ON m.id = me.memory_id
+      GROUP BY me.entity_id
+    )
+    SELECT e.id, e.name, e.type, e.importance,
+           ${entityColumns.has('last_contact_at') ? 'e.last_contact_at' : 'NULL AS last_contact_at'},
+           ${entityColumns.has('contact_frequency_days') ? 'e.contact_frequency_days' : 'NULL AS contact_frequency_days'},
+           ${entityColumns.has('contact_trend') ? 'e.contact_trend' : 'NULL AS contact_trend'},
+           ${entityColumns.has('attention_tier') ? 'e.attention_tier' : "'standard' AS attention_tier"},
+           COALESCE(rel_agg.relationship_count, 0) AS relationship_count,
+           COALESCE(rel_agg.relationship_strength, 0) AS relationship_strength,
+           COALESCE(mem_agg.memory_count, 0) AS memory_count,
+           mem_agg.last_memory_at
+    FROM entities e
+    LEFT JOIN rel_agg ON rel_agg.entity_id = e.id
+    LEFT JOIN mem_agg ON mem_agg.entity_id = e.id
+    ORDER BY (
+      COALESCE(e.importance, 0) * 4.5 +
+      COALESCE(mem_agg.memory_count, 0) * 0.08 +
+      COALESCE(rel_agg.relationship_strength, 0) * 1.1 +
+      COALESCE(rel_agg.relationship_count, 0) * 0.18
+    ) DESC,
+    e.name ASC
+    LIMIT 8
+  `
+  ).all().map((row) => ({
+    id: row.id,
+    graphId: `entity-${row.id}`,
+    name: row.name,
+    type: row.type,
+    importance: row.importance,
+    memoryCount: row.memory_count,
+    relationshipCount: row.relationship_count,
+    relationshipStrength: row.relationship_strength,
+    lastMemoryAt: dateToIso(row.last_memory_at),
+    lastContactAt: dateToIso(row.last_contact_at),
+    contactTrend: row.contact_trend || 'steady',
+    attentionTier: row.attention_tier || 'standard',
+    focusLabel: `${row.memory_count} memories, ${row.relationship_count} links`
+  }));
+
+  const urgentCommitments = db.prepare(
+    `
+    SELECT m.id,
+           m.content,
+           m.importance,
+           ${hasMemoryDeadline ? 'm.deadline_at' : 'NULL AS deadline_at'},
+           ${hasVerification ? 'm.verification_status' : "'pending' AS verification_status"},
+           m.created_at,
+           GROUP_CONCAT(DISTINCT e.name) AS entities
+    FROM memories m
+    LEFT JOIN memory_entities me ON me.memory_id = m.id
+    LEFT JOIN entities e ON e.id = me.entity_id
+    WHERE m.type = 'commitment'
+      ${invalidatedFilter}
+    GROUP BY m.id
+    ORDER BY
+      CASE
+        WHEN ${hasMemoryDeadline ? "m.deadline_at IS NOT NULL AND datetime(m.deadline_at) < datetime('now')" : '0'} THEN 0
+        WHEN ${hasMemoryDeadline ? 'm.deadline_at IS NOT NULL' : '0'} THEN 1
+        ELSE 2
+      END,
+      COALESCE(m.deadline_at, m.created_at) DESC,
+      m.importance DESC
+    LIMIT 8
+  `
+  ).all().map((row) => {
+    const overdue = Boolean(
+      row.deadline_at && new Date(String(row.deadline_at).replace(' ', 'T')).getTime() < Date.now()
+    );
+    return {
+      id: row.id,
+      graphId: `memory-${row.id}`,
+      content: row.content,
+      importance: row.importance,
+      deadlineAt: dateToIso(row.deadline_at),
+      createdAt: dateToIso(row.created_at),
+      verificationStatus: row.verification_status,
+      overdue,
+      priorityBucket: getPriorityBucket({ overdue, deadlineAt: row.deadline_at }),
+      entityNames: row.entities ? String(row.entities).split(',') : []
+    };
+  });
+
+  const activePatterns = db.prepare(
+    `
+    SELECT id, name, description, pattern_type, occurrences, confidence, last_observed_at
+    FROM patterns
+    WHERE is_active = 1
+    ORDER BY confidence DESC, occurrences DESC, last_observed_at DESC
+    LIMIT 6
+  `
+  ).all().map((row) => ({
+    id: row.id,
+    graphId: `pattern-${row.id}`,
+    name: row.name,
+    description: row.description,
+    patternType: row.pattern_type,
+    occurrences: row.occurrences,
+    confidence: row.confidence,
+    lastObservedAt: dateToIso(row.last_observed_at)
+  }));
+
+  const recentMemories = db.prepare(
+    `
+    SELECT m.id, m.content, m.type, m.importance, m.created_at,
+           GROUP_CONCAT(DISTINCT e.name) AS entities
+    FROM memories m
+    LEFT JOIN memory_entities me ON me.memory_id = m.id
+    LEFT JOIN entities e ON e.id = me.entity_id
+    WHERE 1 = 1
+      ${invalidatedFilter}
+    GROUP BY m.id
+    ORDER BY datetime(m.created_at) DESC, m.importance DESC
+    LIMIT 8
+  `
+  ).all().map((row) => ({
+    id: row.id,
+    graphId: `memory-${row.id}`,
+    content: row.content,
+    type: row.type,
+    importance: row.importance,
+    createdAt: dateToIso(row.created_at),
+    entityNames: row.entities ? String(row.entities).split(',') : []
+  }));
+
+  const coolingRelationships = hasEntityContactFields
+    ? db.prepare(
+        `
+        SELECT id, name, type, importance, last_contact_at, contact_frequency_days, contact_trend, attention_tier
+        FROM entities
+        WHERE last_contact_at IS NOT NULL
+        ORDER BY
+          CASE WHEN contact_trend = 'cooling' THEN 0 ELSE 1 END,
+          (julianday('now') - julianday(last_contact_at)) DESC,
+          importance DESC
+        LIMIT 8
+      `
+      ).all()
+        .map((row) => {
+          const days = daysSince(row.last_contact_at);
+          const target = row.contact_frequency_days ? Math.round(row.contact_frequency_days) : null;
+          const isCooling =
+            row.contact_trend === 'cooling' ||
+            (days !== null && target !== null && days > target * 1.2);
+
+          return {
+            id: row.id,
+            graphId: `entity-${row.id}`,
+            name: row.name,
+            type: row.type,
+            importance: row.importance,
+            lastContactAt: dateToIso(row.last_contact_at),
+            daysSinceContact: days,
+            targetFrequencyDays: target,
+            contactTrend: row.contact_trend || 'steady',
+            attentionTier: row.attention_tier || 'standard',
+            cooling: isCooling
+          };
+        })
+        .filter((row) => row.cooling)
+        .slice(0, 6)
+    : [];
+
+  return {
+    summary,
+    topEntities,
+    urgentCommitments,
+    activePatterns,
+    recentMemories,
+    coolingRelationships,
+    generatedAt: new Date().toISOString()
+  };
+}

--- a/visualizer/lib/neighborhood.js
+++ b/visualizer/lib/neighborhood.js
@@ -1,0 +1,171 @@
+import {
+  buildNeighborhoodMemoryNode,
+  buildPatternNode,
+  loadGraphDataset,
+  parseGraphId
+} from './graph-data.js';
+import {
+  makeGraphId,
+  normalizeEvidenceEdge,
+  normalizeRelationshipEdge
+} from './graph-contract.js';
+
+function collectEntityNeighborhood(dataset, startEntityIds, depth) {
+  const seen = new Set(startEntityIds);
+  const queue = startEntityIds.map((entityId) => ({ entityId, depth: 0 }));
+
+  while (queue.length) {
+    const current = queue.shift();
+    if (current.depth >= depth) continue;
+    const neighbors = dataset.adjacency.get(current.entityId) || [];
+    for (const neighbor of neighbors) {
+      if (seen.has(neighbor.entityId)) continue;
+      seen.add(neighbor.entityId);
+      queue.push({ entityId: neighbor.entityId, depth: current.depth + 1 });
+    }
+  }
+
+  return [...seen];
+}
+
+function resolveFocus(dataset, graphId) {
+  const parsed = parseGraphId(graphId);
+  if (!parsed) {
+    throw new Error(`Invalid graph id: ${graphId}`);
+  }
+
+  if (parsed.kind === 'entity') {
+    const entity = dataset.entityById.get(parsed.dbId);
+    if (!entity) throw new Error('Entity not found');
+    return { focusKind: 'entity', entityIds: [parsed.dbId], centerId: makeGraphId('entity', parsed.dbId) };
+  }
+
+  if (parsed.kind === 'memory') {
+    const memory = dataset.memoryById.get(parsed.dbId);
+    if (!memory) throw new Error('Memory not found');
+    const context = dataset.memoryContextById.get(parsed.dbId);
+    const entityIds = context?.entityRefs || [];
+    if (!entityIds.length) throw new Error('Memory has no linked entities');
+    return { focusKind: memory.type === 'commitment' ? 'commitment' : 'memory', entityIds, centerId: makeGraphId('memory', parsed.dbId), focusMemoryId: parsed.dbId };
+  }
+
+  if (parsed.kind === 'pattern') {
+    const pattern = dataset.patternById.get(parsed.dbId);
+    if (!pattern) throw new Error('Pattern not found');
+    const context = dataset.patternContextById.get(parsed.dbId);
+    const entityIds = context?.entityRefs || [];
+    if (!entityIds.length) throw new Error('Pattern has no linked entities');
+    return { focusKind: 'pattern', entityIds, centerId: makeGraphId('pattern', parsed.dbId), focusPatternId: parsed.dbId };
+  }
+
+  throw new Error(`Unsupported graph kind: ${parsed.kind}`);
+}
+
+export async function buildNeighborhoodGraph(graphId, depth = 1) {
+  const resolvedDepth = Math.max(1, Math.min(2, Number(depth || 1)));
+  const dataset = await loadGraphDataset();
+  const focus = resolveFocus(dataset, graphId);
+  const entityIds = collectEntityNeighborhood(dataset, focus.entityIds, resolvedDepth);
+  const entityIdSet = new Set(entityIds);
+
+  const nodes = dataset.entityNodes.filter((node) => entityIdSet.has(node.entityRefs[0]));
+  const nodeById = new Map(nodes.map((node) => [node.id, node]));
+
+  const normalizedEdges = dataset.relationships
+    .filter((relationship) => entityIdSet.has(relationship.source_entity_id) && entityIdSet.has(relationship.target_entity_id))
+    .map((relationship) => normalizeRelationshipEdge(relationship));
+
+  const memoryRows = new Set();
+  for (const entityId of entityIds) {
+    for (const row of dataset.rowsByEntity.get(entityId) || []) {
+      memoryRows.add(row.memory_id);
+    }
+  }
+
+  const rankedMemories = [...memoryRows]
+    .map((memoryId) => dataset.memoryById.get(memoryId))
+    .filter(Boolean)
+    .sort((left, right) => {
+      const leftBoost = left.type === 'commitment' ? 0.35 : 0;
+      const rightBoost = right.type === 'commitment' ? 0.35 : 0;
+      return (Number(right.importance || 0) + rightBoost) - (Number(left.importance || 0) + leftBoost);
+    })
+    .slice(0, 60);
+
+  const memoryNodes = rankedMemories.map((memory, index) => {
+    const context = dataset.memoryContextById.get(memory.id) || { entityRefs: [], primaryEntityId: null, completed: false };
+    const anchorNode = context.primaryEntityId
+      ? nodeById.get(makeGraphId('entity', context.primaryEntityId))
+      : nodes[0];
+    return buildNeighborhoodMemoryNode(memory, context, anchorNode, index, memory.type === 'commitment' ? 76 : 110);
+  });
+
+  for (const memoryNode of memoryNodes) {
+    nodes.push(memoryNode);
+    nodeById.set(memoryNode.id, memoryNode);
+  }
+
+  const evidenceEdges = [];
+  for (const memory of rankedMemories) {
+    const context = dataset.memoryContextById.get(memory.id);
+    if (!context?.entityRefs?.length) continue;
+    for (const entityId of context.entityRefs.filter((entityId) => entityIdSet.has(entityId)).slice(0, 4)) {
+      evidenceEdges.push(normalizeEvidenceEdge({
+        id: `neighborhood-memory-${memory.id}-${entityId}`,
+        source: makeGraphId('memory', memory.id),
+        target: makeGraphId('entity', entityId),
+        strength: memory.type === 'commitment' ? 0.72 : 0.34,
+        label: memory.type,
+        evidenceCount: 1,
+        status: 'active'
+      }));
+    }
+  }
+
+  const patternNodes = dataset.patterns
+    .filter((pattern) => {
+      const context = dataset.patternContextById.get(pattern.id);
+      return context?.entityRefs?.some((entityId) => entityIdSet.has(entityId));
+    })
+    .slice(0, 18)
+    .map((pattern) => buildPatternNode(pattern, dataset.patternContextById.get(pattern.id)));
+
+  for (const patternNode of patternNodes) {
+    nodes.push(patternNode);
+    nodeById.set(patternNode.id, patternNode);
+  }
+
+  const patternEdges = [];
+  for (const pattern of dataset.patterns) {
+    const context = dataset.patternContextById.get(pattern.id);
+    if (!context?.entityRefs?.some((entityId) => entityIdSet.has(entityId))) continue;
+    for (const entityId of context.entityRefs.filter((entityId) => entityIdSet.has(entityId)).slice(0, 3)) {
+      patternEdges.push(normalizeEvidenceEdge({
+        id: `neighborhood-pattern-${pattern.id}-${entityId}`,
+        source: makeGraphId('pattern', pattern.id),
+        target: makeGraphId('entity', entityId),
+        strength: 0.42,
+        label: pattern.pattern_type,
+        evidenceCount: Math.max(1, Number(pattern.occurrences || 1)),
+        status: 'active'
+      }));
+    }
+  }
+
+  return {
+    meta: {
+      mode: 'neighborhood',
+      generatedAt: new Date().toISOString(),
+      centerId: focus.centerId,
+      focusKind: focus.focusKind,
+      depth: resolvedDepth,
+      counts: {
+        entities: entityIds.length,
+        memories: memoryNodes.length,
+        patterns: patternNodes.length
+      }
+    },
+    nodes,
+    edges: [...normalizedEdges, ...evidenceEdges, ...patternEdges]
+  };
+}

--- a/visualizer/lib/overview.js
+++ b/visualizer/lib/overview.js
@@ -1,0 +1,108 @@
+import {
+  activeCommitmentMemories,
+  buildOverviewMemoryNode,
+  buildOverviewCommitmentNode,
+  buildInferredRelationships,
+  buildPatternNode,
+  commonEntityRelationshipEdges,
+  loadGraphDataset,
+  normalizeCommitmentSortScore
+} from './graph-data.js';
+import { normalizeEvidenceEdge, makeGraphId } from './graph-contract.js';
+
+export async function buildOverviewGraph({ includeMemories = false } = {}) {
+  const dataset = await loadGraphDataset();
+  const entityNodes = dataset.entityNodes;
+  const entityEdges = commonEntityRelationshipEdges(dataset.relationships);
+  const inferredEdges = buildInferredRelationships(dataset).map((relationship) =>
+    normalizeEvidenceEdge({
+      id: relationship.id,
+      source: makeGraphId('entity', relationship.source_entity_id),
+      target: makeGraphId('entity', relationship.target_entity_id),
+      strength: relationship.strength,
+      label: 'inferred',
+      evidenceCount: relationship.evidenceCount,
+      status: 'active',
+      channel: 'relationship'
+    })
+  );
+
+  const patternNodes = dataset.patterns.map((pattern) =>
+    buildPatternNode(pattern, dataset.patternContextById.get(pattern.id) || { entityRefs: [], position: { x: 0, y: 0 } })
+  );
+
+  const patternEdges = [];
+  for (const pattern of dataset.patterns) {
+    const context = dataset.patternContextById.get(pattern.id);
+    if (!context?.entityRefs?.length) continue;
+    for (const entityId of context.entityRefs.slice(0, 3)) {
+      patternEdges.push(normalizeEvidenceEdge({
+        id: `pattern-link-${pattern.id}-${entityId}`,
+        source: makeGraphId('pattern', pattern.id),
+        target: makeGraphId('entity', entityId),
+        strength: 0.46 + Number(pattern.confidence || 0) * 0.28,
+        label: pattern.pattern_type,
+        evidenceCount: Math.max(1, Number(pattern.occurrences || 1)),
+        status: 'active'
+      }));
+    }
+  }
+
+  const urgentCommitments = activeCommitmentMemories(dataset.memories, dataset.memoryContextById)
+    .filter((memory) => memory.deadline_at || Number(memory.importance || 0) >= 0.58)
+    .sort((left, right) => normalizeCommitmentSortScore(right) - normalizeCommitmentSortScore(left))
+    .slice(0, 18);
+  const overviewMemories = includeMemories
+    ? dataset.memories
+      .filter((memory) => {
+        if (memory.type === 'commitment') {
+          const context = dataset.memoryContextById.get(memory.id);
+          return !memory.invalidated_at && !context?.completed;
+        }
+        return !memory.invalidated_at;
+      })
+      .sort((left, right) => Number(right.importance || 0) - Number(left.importance || 0))
+    : urgentCommitments;
+
+  const overviewMemoryNodes = overviewMemories.map((memory, index) => {
+    const context = dataset.memoryContextById.get(memory.id) || { entityRefs: [], primaryEntityId: null, completed: false };
+    if (includeMemories) {
+      return buildOverviewMemoryNode(memory, context, dataset.entityNodeById, index);
+    }
+    return buildOverviewCommitmentNode(memory, context, dataset.entityNodeById, index);
+  });
+
+  const overviewMemoryEdges = [];
+  for (const memory of overviewMemories) {
+    const context = dataset.memoryContextById.get(memory.id);
+    if (!context?.entityRefs?.length) continue;
+    const anchorEntityId = context.primaryEntityId || context.entityRefs[0];
+    overviewMemoryEdges.push(normalizeEvidenceEdge({
+      id: `overview-memory-${memory.id}-${anchorEntityId}`,
+      source: makeGraphId('memory', memory.id),
+      target: makeGraphId('entity', anchorEntityId),
+      strength: memory.type === 'commitment' ? 0.58 : 0.34,
+      label: memory.type,
+      evidenceCount: context.entityRefs.length,
+      status: 'active'
+    }));
+  }
+
+  return {
+    meta: {
+      mode: 'overview',
+      generatedAt: new Date().toISOString(),
+      counts: {
+        entities: entityNodes.length,
+        patterns: patternNodes.length,
+        memories: overviewMemoryNodes.filter((node) => node.kind === 'memory').length,
+        commitments: overviewMemoryNodes.filter((node) => node.kind === 'commitment').length,
+        relationships: entityEdges.length + inferredEdges.length,
+        inferredRelationships: inferredEdges.length,
+        memoryOverlayEnabled: includeMemories
+      }
+    },
+    nodes: [...entityNodes, ...patternNodes, ...overviewMemoryNodes],
+    edges: [...entityEdges, ...inferredEdges, ...patternEdges, ...overviewMemoryEdges]
+  };
+}

--- a/visualizer/lib/search.js
+++ b/visualizer/lib/search.js
@@ -1,0 +1,110 @@
+import { loadGraphDataset } from './graph-data.js';
+import { makeGraphId, truncate } from './graph-contract.js';
+
+function scoreText(text, query) {
+  const normalizedText = String(text || '').toLowerCase();
+  const normalizedQuery = String(query || '').toLowerCase();
+  if (!normalizedText || !normalizedQuery) return 0;
+  if (normalizedText === normalizedQuery) return 1;
+  if (normalizedText.startsWith(normalizedQuery)) return 0.88;
+  if (normalizedText.includes(normalizedQuery)) return 0.68;
+  return 0;
+}
+
+function resultRow(base, extra = {}) {
+  return {
+    ...base,
+    ...extra
+  };
+}
+
+function priorityFor(row) {
+  if (row.kind === 'entity') {
+    if (row.subtype === 'person') return 4;
+    if (row.subtype === 'organization') return 3;
+    if (row.subtype === 'project') return 2;
+    return 1;
+  }
+  if (row.kind === 'pattern') return 0;
+  if (row.kind === 'commitment') return -1;
+  if (row.kind === 'memory') return -2;
+  return -3;
+}
+
+export async function searchGraph(query, limit = 20) {
+  const normalizedQuery = String(query || '').trim().toLowerCase();
+  const resolvedLimit = Math.max(1, Math.min(50, Number(limit || 20)));
+  if (!normalizedQuery) {
+    return {
+      query: '',
+      results: []
+    };
+  }
+
+  const dataset = await loadGraphDataset();
+  const rows = [];
+
+  for (const entity of dataset.entities) {
+    const nameScore = scoreText(entity.name, normalizedQuery);
+    const descriptionScore = scoreText(entity.description, normalizedQuery) * 0.55;
+    const score = Math.max(nameScore, descriptionScore) + Number(entity.importance || 0) * 0.18;
+    if (score <= 0) continue;
+    rows.push(resultRow({
+      id: makeGraphId('entity', entity.id),
+      kind: 'entity',
+      subtype: entity.type,
+      label: entity.name,
+      description: truncate(entity.description || '', 140),
+      score
+    }));
+  }
+
+  for (const memory of dataset.memories) {
+    const contentScore = scoreText(memory.content, normalizedQuery);
+    const sourceScore = scoreText(memory.source_context, normalizedQuery) * 0.35;
+    const score = Math.max(contentScore, sourceScore) + Number(memory.importance || 0) * 0.15;
+    if (score <= 0) continue;
+    const context = dataset.memoryContextById.get(memory.id);
+    rows.push(resultRow({
+      id: makeGraphId('memory', memory.id),
+      kind: memory.type === 'commitment' ? 'commitment' : 'memory',
+      subtype: memory.type,
+      label: truncate(memory.content || '', 120),
+      description: truncate(memory.source_context || memory.source || '', 140),
+      score
+    }, {
+      entityRefs: context?.entityRefs || []
+    }));
+  }
+
+  for (const pattern of dataset.patterns) {
+    const nameScore = scoreText(pattern.name, normalizedQuery);
+    const descriptionScore = scoreText(pattern.description, normalizedQuery) * 0.6;
+    const score = Math.max(nameScore, descriptionScore) + Number(pattern.confidence || 0) * 0.14;
+    if (score <= 0) continue;
+    rows.push(resultRow({
+      id: makeGraphId('pattern', pattern.id),
+      kind: 'pattern',
+      subtype: pattern.pattern_type,
+      label: pattern.name,
+      description: truncate(pattern.description || '', 140),
+      score
+    }, {
+      entityRefs: dataset.patternContextById.get(pattern.id)?.entityRefs || []
+    }));
+  }
+
+  rows.sort((left, right) => {
+    const priorityDelta = priorityFor(right) - priorityFor(left);
+    if (priorityDelta !== 0) return priorityDelta;
+    return right.score - left.score;
+  });
+
+  return {
+    query,
+    results: rows.slice(0, resolvedLimit).map((row) => ({
+      ...row,
+      score: Number(row.score.toFixed(3))
+    }))
+  };
+}

--- a/visualizer/lib/trace.js
+++ b/visualizer/lib/trace.js
@@ -1,0 +1,203 @@
+import {
+  buildNeighborhoodMemoryNode,
+  buildInferredRelationships,
+  loadGraphDataset,
+  parseGraphId,
+  relationshipPathCost
+} from './graph-data.js';
+import {
+  makeGraphId,
+  normalizeEvidenceEdge,
+  normalizeRelationshipEdge
+} from './graph-contract.js';
+
+function toEntityGraphId(value) {
+  const parsed = parseGraphId(value);
+  if (!parsed || parsed.kind !== 'entity') {
+    throw new Error('Trace endpoints must be entity graph ids');
+  }
+  return parsed.dbId;
+}
+
+function findShortestPath(dataset, startEntityId, endEntityId, maxDepth) {
+  const frontier = [{
+    entityId: startEntityId,
+    cost: 0,
+    depth: 0,
+    nodePath: [startEntityId],
+    edgePath: []
+  }];
+  const best = new Map([[startEntityId, 0]]);
+
+  while (frontier.length) {
+    frontier.sort((left, right) => left.cost - right.cost);
+    const current = frontier.shift();
+
+    if (current.entityId === endEntityId) {
+      return current;
+    }
+
+    if (current.depth >= maxDepth) continue;
+
+    const neighbors = dataset.adjacency.get(current.entityId) || [];
+    for (const neighbor of neighbors) {
+      const nextDepth = current.depth + 1;
+      if (nextDepth > maxDepth) continue;
+
+      const nextCost = current.cost + relationshipPathCost(neighbor.relationship);
+      if ((best.get(neighbor.entityId) ?? Number.POSITIVE_INFINITY) <= nextCost) {
+        continue;
+      }
+
+      best.set(neighbor.entityId, nextCost);
+      frontier.push({
+        entityId: neighbor.entityId,
+        cost: nextCost,
+        depth: nextDepth,
+        nodePath: [...current.nodePath, neighbor.entityId],
+        edgePath: [...current.edgePath, neighbor.relationship]
+      });
+    }
+  }
+
+  return null;
+}
+
+function inferredAdjacency(dataset) {
+  const adjacency = new Map();
+  const inferred = buildInferredRelationships(dataset);
+  for (const relationship of inferred) {
+    const add = (source, target) => {
+      if (!adjacency.has(source)) adjacency.set(source, []);
+      adjacency.get(source).push({
+        entityId: target,
+        relationship
+      });
+    };
+    add(relationship.source_entity_id, relationship.target_entity_id);
+    add(relationship.target_entity_id, relationship.source_entity_id);
+  }
+  return adjacency;
+}
+
+function sharedMemoriesForEdge(dataset, leftEntityId, rightEntityId) {
+  const left = dataset.memoryIdSetsByEntity.get(leftEntityId) || new Set();
+  const right = dataset.memoryIdSetsByEntity.get(rightEntityId) || new Set();
+  const sharedIds = [...left].filter((memoryId) => right.has(memoryId));
+  return sharedIds
+    .map((memoryId) => dataset.memoryById.get(memoryId))
+    .filter(Boolean)
+    .sort((leftMemory, rightMemory) => Number(rightMemory.importance || 0) - Number(leftMemory.importance || 0))
+    .slice(0, 2);
+}
+
+export async function buildTraceGraph({ from, to, maxDepth = 4 }) {
+  const dataset = await loadGraphDataset();
+  const fromEntityId = toEntityGraphId(from);
+  const toEntityId = toEntityGraphId(to);
+  const resolvedMaxDepth = Math.max(2, Math.min(8, Number(maxDepth || 4)));
+  let result = findShortestPath(dataset, fromEntityId, toEntityId, resolvedMaxDepth);
+  let usedInferred = false;
+
+  if (!result) {
+    const inferred = inferredAdjacency(dataset);
+    const mergedAdjacency = new Map(dataset.adjacency);
+    for (const [entityId, neighbors] of inferred.entries()) {
+      mergedAdjacency.set(entityId, [...(mergedAdjacency.get(entityId) || []), ...neighbors]);
+    }
+    result = findShortestPath({ ...dataset, adjacency: mergedAdjacency }, fromEntityId, toEntityId, resolvedMaxDepth);
+    usedInferred = Boolean(result);
+  }
+
+  if (!result) {
+    return {
+      meta: {
+        mode: 'trace',
+        generatedAt: new Date().toISOString(),
+        from,
+        to,
+        maxDepth: resolvedMaxDepth,
+        found: false,
+        usedInferred: false
+      },
+      nodes: [],
+      edges: [],
+      path: [],
+      evidence: []
+    };
+  }
+
+  const entityIdSet = new Set(result.nodePath);
+  const nodes = dataset.entityNodes.filter((node) => entityIdSet.has(node.entityRefs[0]));
+  const nodeById = new Map(nodes.map((node) => [node.id, node]));
+  const edges = result.edgePath.map((relationship) => normalizeRelationshipEdge(relationship, {
+    status: 'trace',
+    strength: Math.max(Number(relationship.strength || 0.5), 0.55)
+  }));
+
+  const evidence = [];
+  const evidenceNodes = [];
+  const addedMemoryIds = new Set();
+
+  for (let index = 0; index < result.nodePath.length - 1; index++) {
+    const leftEntityId = result.nodePath[index];
+    const rightEntityId = result.nodePath[index + 1];
+    const sharedMemories = sharedMemoriesForEdge(dataset, leftEntityId, rightEntityId);
+
+    for (const memory of sharedMemories) {
+      if (addedMemoryIds.has(memory.id)) continue;
+      addedMemoryIds.add(memory.id);
+
+      const context = dataset.memoryContextById.get(memory.id) || { entityRefs: [], primaryEntityId: leftEntityId, completed: false };
+      const leftNode = nodeById.get(makeGraphId('entity', leftEntityId));
+      const memoryNode = buildNeighborhoodMemoryNode(memory, context, leftNode, index, memory.type === 'commitment' ? 58 : 74);
+      evidenceNodes.push(memoryNode);
+      evidence.push({
+        id: memoryNode.id,
+        label: memoryNode.label,
+        kind: memoryNode.kind,
+        subtype: memoryNode.subtype,
+        entityRefs: memoryNode.entityRefs
+      });
+
+      edges.push(normalizeEvidenceEdge({
+        id: `trace-evidence-${memory.id}-${leftEntityId}`,
+        source: makeGraphId('memory', memory.id),
+        target: makeGraphId('entity', leftEntityId),
+        strength: memory.type === 'commitment' ? 0.7 : 0.38,
+        label: memory.type,
+        evidenceCount: 1,
+        status: 'trace'
+      }));
+      edges.push(normalizeEvidenceEdge({
+        id: `trace-evidence-${memory.id}-${rightEntityId}`,
+        source: makeGraphId('memory', memory.id),
+        target: makeGraphId('entity', rightEntityId),
+        strength: memory.type === 'commitment' ? 0.7 : 0.38,
+        label: memory.type,
+        evidenceCount: 1,
+        status: 'trace'
+      }));
+    }
+  }
+
+  nodes.push(...evidenceNodes);
+
+  return {
+    meta: {
+      mode: 'trace',
+      generatedAt: new Date().toISOString(),
+      from,
+      to,
+      maxDepth: resolvedMaxDepth,
+      found: true,
+      usedInferred,
+      hopCount: result.edgePath.length,
+      aggregateWeight: result.edgePath.reduce((total, relationship) => total + Number(relationship.strength || 0), 0)
+    },
+    nodes,
+    edges,
+    path: result.nodePath.map((entityId) => makeGraphId('entity', entityId)),
+    evidence
+  };
+}

--- a/visualizer/package-lock.json
+++ b/visualizer/package-lock.json
@@ -8,15 +8,286 @@
       "name": "claudia-brain-visualizer",
       "version": "3.0.0",
       "dependencies": {
+        "@react-three/drei": "^10.7.7",
+        "@react-three/fiber": "^9.5.0",
+        "@react-three/postprocessing": "^3.0.4",
+        "@vitejs/plugin-react": "^5.1.4",
         "3d-force-graph": "^1.73.0",
         "better-sqlite3": "^11.0.0",
         "cors": "^2.8.5",
+        "d3-force-3d": "^3.0.6",
         "express": "^4.21.0",
+        "graphology": "^0.26.0",
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4",
+        "sigma": "^3.0.2",
         "three": "^0.172.0",
-        "umap-js": "^1.4.0"
+        "umap-js": "^1.4.0",
+        "zustand": "^5.0.11"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "vite": "^6.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/core/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
+      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -28,6 +299,80 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
@@ -35,7 +380,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -52,7 +396,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -69,7 +412,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -86,7 +428,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -103,7 +444,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -120,7 +460,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -137,7 +476,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -154,7 +492,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -171,7 +508,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -188,7 +524,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -205,7 +540,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -222,7 +556,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -239,7 +572,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -256,7 +588,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -273,7 +604,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -290,7 +620,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -307,7 +636,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -324,7 +652,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -341,7 +668,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -358,7 +684,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -375,7 +700,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -392,7 +716,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -409,7 +732,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -426,7 +748,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -443,7 +764,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -460,7 +780,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -470,6 +789,230 @@
         "node": ">=18"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mediapipe/tasks-vision": {
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.17.tgz",
+      "integrity": "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@monogrid/gainmap-js": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@monogrid/gainmap-js/-/gainmap-js-3.4.0.tgz",
+      "integrity": "sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==",
+      "license": "MIT",
+      "dependencies": {
+        "promise-worker-transferable": "^1.0.4"
+      },
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@react-three/drei": {
+      "version": "10.7.7",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-10.7.7.tgz",
+      "integrity": "sha512-ff+J5iloR0k4tC++QtD/j9u3w5fzfgFAWDtAGQah9pF2B1YgOq/5JxqY0/aVoQG5r3xSZz0cv5tk2YuBob4xEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mediapipe/tasks-vision": "0.10.17",
+        "@monogrid/gainmap-js": "^3.0.6",
+        "@use-gesture/react": "^10.3.1",
+        "camera-controls": "^3.1.0",
+        "cross-env": "^7.0.3",
+        "detect-gpu": "^5.0.56",
+        "glsl-noise": "^0.0.0",
+        "hls.js": "^1.5.17",
+        "maath": "^0.10.8",
+        "meshline": "^3.3.1",
+        "stats-gl": "^2.2.8",
+        "stats.js": "^0.17.0",
+        "suspend-react": "^0.1.3",
+        "three-mesh-bvh": "^0.8.3",
+        "three-stdlib": "^2.35.6",
+        "troika-three-text": "^0.52.4",
+        "tunnel-rat": "^0.1.2",
+        "use-sync-external-store": "^1.4.0",
+        "utility-types": "^3.11.0",
+        "zustand": "^5.0.1"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": "^9.0.0",
+        "react": "^19",
+        "react-dom": "^19",
+        "three": ">=0.159"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.5.0.tgz",
+      "integrity": "sha512-FiUzfYW4wB1+PpmsE47UM+mCads7j2+giRBltfwH7SNhah95rqJs3ltEs9V3pP8rYdS0QlNne+9Aj8dS/SiaIA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/webxr": "*",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "its-fine": "^2.0.0",
+        "react-use-measure": "^2.1.7",
+        "scheduler": "^0.27.0",
+        "suspend-react": "^0.1.3",
+        "use-sync-external-store": "^1.4.0",
+        "zustand": "^5.0.3"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-file-system": ">=11.0",
+        "expo-gl": ">=11.0",
+        "react": ">=19 <19.3",
+        "react-dom": ">=19 <19.3",
+        "react-native": ">=0.78",
+        "three": ">=0.156"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/@react-three/postprocessing": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@react-three/postprocessing/-/postprocessing-3.0.4.tgz",
+      "integrity": "sha512-e4+F5xtudDYvhxx3y0NtWXpZbwvQ0x1zdOXWTbXMK6fFLVDd4qucN90YaaStanZGS4Bd5siQm0lGL/5ogf8iDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "maath": "^0.6.0",
+        "n8ao": "^1.9.4",
+        "postprocessing": "^6.36.6"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": "^9.0.0",
+        "react": "^19.0",
+        "three": ">= 0.156.0"
+      }
+    },
+    "node_modules/@react-three/postprocessing/node_modules/maath": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/maath/-/maath-0.6.0.tgz",
+      "integrity": "sha512-dSb2xQuP7vDnaYqfoKzlApeRcR2xtN8/f7WV/TMAkBC8552TwTLtOO0JTcSygkYMjNDPoo6V01jTw/aPi4JrMw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/three": ">=0.144.0",
+        "three": ">=0.144.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "license": "MIT"
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.57.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
@@ -477,7 +1020,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -491,7 +1033,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -505,7 +1046,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -519,7 +1059,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -533,7 +1072,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -547,7 +1085,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -561,7 +1098,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -575,7 +1111,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -589,7 +1124,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -603,7 +1137,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -617,7 +1150,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -631,7 +1163,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -645,7 +1176,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -659,7 +1189,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -673,7 +1202,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -687,7 +1215,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -701,7 +1228,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -715,7 +1241,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -729,7 +1254,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -743,7 +1267,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -757,7 +1280,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -771,7 +1293,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -785,7 +1306,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -799,7 +1319,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -813,7 +1332,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -826,12 +1344,161 @@
       "integrity": "sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==",
       "license": "MIT"
     },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/draco3d": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
+      "integrity": "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.183.1",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.183.1.tgz",
+      "integrity": "sha512-f2Pu5Hrepfgavttdye3PsH5RWyY/AvdZQwIVhrc4uNtvF7nOWJacQKcoVJn0S4f0yYbmAE6AR+ve7xDcuYtMGw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.0.1"
+      }
+    },
+    "node_modules/@types/three/node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.1.4.tgz",
+      "integrity": "sha512-VIcFLdRi/VYRU8OL/puL7QXMYafHmqOnwTZY50U1JPlCNj30PxCMx65c494b1K9be9hX83KVt0+gTEwTWLqToA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.69",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.69.tgz",
+      "integrity": "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/3d-force-graph": {
       "version": "1.79.1",
@@ -897,6 +1564,18 @@
       ],
       "license": "MIT"
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
+      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/better-sqlite3": {
       "version": "11.10.0",
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
@@ -906,6 +1585,15 @@
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/bindings": {
@@ -950,6 +1638,40 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
     "node_modules/buffer": {
@@ -1014,6 +1736,39 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/camera-controls": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-3.1.2.tgz",
+      "integrity": "sha512-xkxfpG2ECZ6Ww5/9+kf4mfg1VEYAoe9aDSY+IwF0UEs7qEzwy0aVRfs2grImIECs/PoBtWFrh7RXsQkwG922JA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.0.0",
+        "npm": ">=10.5.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.126.1"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001774",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001774.tgz",
+      "integrity": "sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
     "node_modules/chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
@@ -1040,6 +1795,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -1072,6 +1833,44 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -1296,6 +2095,15 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/detect-gpu": {
+      "version": "5.0.70",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.70.tgz",
+      "integrity": "sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==",
+      "license": "MIT",
+      "dependencies": {
+        "webgl-constants": "^1.1.1"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1304,6 +2112,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/draco3d": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
+      "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -1324,6 +2138,12 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.302",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
+      "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
+      "license": "ISC"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -1377,7 +2197,6 @@
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -1415,6 +2234,15 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -1428,6 +2256,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
       }
     },
     "node_modules/expand-template": {
@@ -1489,7 +2326,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -1502,6 +2338,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
@@ -1569,7 +2411,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1587,6 +2428,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/get-intrinsic": {
@@ -1632,6 +2482,12 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
     },
+    "node_modules/glsl-noise": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
+      "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
+      "license": "MIT"
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -1642,6 +2498,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graphology": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/graphology/-/graphology-0.26.0.tgz",
+      "integrity": "sha512-8SSImzgUUYC89Z042s+0r/vMibY7GX/Emz4LDO5e7jYXhuoWfHISPFJYjpRLUSJGq6UQ6xlenvX1p/hJdfXuXg==",
+      "license": "MIT",
+      "dependencies": {
+        "events": "^3.3.0"
+      },
+      "peerDependencies": {
+        "graphology-types": ">=0.24.0"
+      }
+    },
+    "node_modules/graphology-types": {
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/graphology-types/-/graphology-types-0.24.8.tgz",
+      "integrity": "sha512-hDRKYXa8TsoZHjgEaysSRyPdT6uB78Ci8WnjgbStlQysz7xR52PInxNsmnB7IBOM1BhikxkNyCVEFgmPKnpx3Q==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/graphology-utils": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/graphology-utils/-/graphology-utils-2.5.2.tgz",
+      "integrity": "sha512-ckHg8MXrXJkOARk56ZaSCM1g1Wihe2d6iTmz1enGOz4W/l831MBCKSayeFQfowgF8wd+PQ4rlch/56Vs/VZLDQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphology-types": ">=0.23.0"
       }
     },
     "node_modules/has-symbols": {
@@ -1667,6 +2551,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/hls.js": {
+      "version": "1.6.15",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.15.tgz",
+      "integrity": "sha512-E3a5VwgXimGHwpRGV+WxRTKeSp2DW5DI5MWv34ulL3t5UNmyJWCQ1KmLEHbYzcfThfXG8amBL+fCYPneGHC4VA==",
+      "license": "Apache-2.0"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -1720,6 +2610,12 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -1756,6 +2652,60 @@
       "integrity": "sha512-qTiELO+kpTKqPgxPYbshMERlzaFu29JDnpB8s3bjg+JkxBpw29/qqSaOdKv2pCdaG92rLGeG/zG2GauX58hfoA==",
       "license": "MIT"
     },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/its-fine": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-2.0.0.tgz",
+      "integrity": "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.9"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/kapsule": {
       "version": "1.16.3",
       "resolved": "https://registry.npmjs.org/kapsule/-/kapsule-1.16.3.tgz",
@@ -1768,11 +2718,39 @@
         "node": ">=12"
       }
     },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/lodash-es": {
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
       "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
       "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/maath": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/maath/-/maath-0.10.8.tgz",
+      "integrity": "sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/three": ">=0.134.0",
+        "three": ">=0.134.0"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -1800,6 +2778,21 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/meshline": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
+      "integrity": "sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.137"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.0.1.tgz",
+      "integrity": "sha512-Vix+QlA1YYT3FwmBBZ+49cE5y/b+pRrcXKqGpS5ouh33d3lSp2PoTpCw19E0cKDFWalembrHnIaZetf27a+W2g==",
+      "license": "MIT"
     },
     "node_modules/methods": {
       "version": "1.1.2",
@@ -1949,11 +2942,20 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/n8ao": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/n8ao/-/n8ao-1.10.1.tgz",
+      "integrity": "sha512-hhI1pC+BfOZBV1KMwynBrVlIm8wqLxj/abAWhF2nZ0qQKyzTSQa1QtLVS2veRiuoBQXojxobcnp0oe+PUoxf/w==",
+      "license": "ISC",
+      "peerDependencies": {
+        "postprocessing": ">=6.30.0",
+        "three": ">=0.137"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2033,6 +3035,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/node-releases": {
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -2084,6 +3092,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
@@ -2094,20 +3111,66 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/polished": {
@@ -2126,7 +3189,6 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2150,6 +3212,22 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postprocessing": {
+      "version": "6.38.3",
+      "resolved": "https://registry.npmjs.org/postprocessing/-/postprocessing-6.38.3.tgz",
+      "integrity": "sha512-5qCFp8j62nWL6sSVv/RKuHscQUIV+VMMgWeHLYZQEBpAk7G+r3jA3bSKON7gZjiuxdZ/F4PXj2Jc1oPh/7Eg+g==",
+      "license": "Zlib",
+      "peer": true,
+      "peerDependencies": {
+        "three": ">= 0.157.0 < 0.184.0"
+      }
+    },
+    "node_modules/potpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
+      "license": "ISC"
     },
     "node_modules/preact": {
       "version": "10.28.3",
@@ -2185,6 +3263,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/promise-worker-transferable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
+      "integrity": "sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-promise": "^2.1.0",
+        "lie": "^3.0.2"
       }
     },
     "node_modules/proxy-addr": {
@@ -2264,6 +3352,53 @@
         "rc": "cli.js"
       }
     },
+    "node_modules/react": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -2278,11 +3413,19 @@
         "node": ">= 6"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.57.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
       "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -2349,6 +3492,12 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -2411,6 +3560,27 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -2484,6 +3654,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sigma": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sigma/-/sigma-3.0.2.tgz",
+      "integrity": "sha512-/BUbeOwPGruiBOm0YQQ6ZMcLIZ6tf/W+Jcm7dxZyAX0tK3WP9/sq7/NAWBxPIxVahdGjCJoGwej0Gdrv0DxlQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "events": "^3.3.0",
+        "graphology-utils": "^2.5.2"
+      }
+    },
     "node_modules/simple-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
@@ -2533,11 +3713,36 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stats-gl": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/stats-gl/-/stats-gl-2.4.2.tgz",
+      "integrity": "sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/three": "*",
+        "three": "^0.170.0"
+      },
+      "peerDependencies": {
+        "@types/three": "*",
+        "three": "*"
+      }
+    },
+    "node_modules/stats-gl/node_modules/three": {
+      "version": "0.170.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.170.0.tgz",
+      "integrity": "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ==",
+      "license": "MIT"
+    },
+    "node_modules/stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.2",
@@ -2564,6 +3769,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0"
       }
     },
     "node_modules/tar-fs": {
@@ -2598,7 +3812,8 @@
       "version": "0.172.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.172.0.tgz",
       "integrity": "sha512-6HMgMlzU97MsV7D/tY8Va38b83kz8YJX+BefKjspMNAv0Vx6dxMogHOrnRl/sbMIs3BPUKijPqDqJ/+UwJbIow==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/three-forcegraph": {
       "version": "1.43.1",
@@ -2624,6 +3839,15 @@
         "three": ">=0.118.3"
       }
     },
+    "node_modules/three-mesh-bvh": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.8.3.tgz",
+      "integrity": "sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
+    },
     "node_modules/three-render-objects": {
       "version": "1.40.4",
       "resolved": "https://registry.npmjs.org/three-render-objects/-/three-render-objects-1.40.4.tgz",
@@ -2643,6 +3867,29 @@
         "three": ">=0.168"
       }
     },
+    "node_modules/three-stdlib": {
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.36.1.tgz",
+      "integrity": "sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/draco3d": "^1.4.0",
+        "@types/offscreencanvas": "^2019.6.4",
+        "@types/webxr": "^0.5.2",
+        "draco3d": "^1.4.1",
+        "fflate": "^0.6.9",
+        "potpack": "^1.0.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.128.0"
+      }
+    },
+    "node_modules/three-stdlib/node_modules/fflate": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
+      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
+      "license": "MIT"
+    },
     "node_modules/tinycolor2": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
@@ -2653,7 +3900,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -2675,6 +3921,36 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/troika-three-text": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.52.4.tgz",
+      "integrity": "sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg==",
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.2",
+        "troika-three-utils": "^0.52.4",
+        "troika-worker-utils": "^0.52.0",
+        "webgl-sdf-generator": "1.1.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-three-utils": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.52.4.tgz",
+      "integrity": "sha512-NORAStSVa/BDiG52Mfudk4j1FG4jC4ILutB3foPnfGbOeIs9+G5vZLa0pnmnaftZUGm4UwSoqEpWdqvC7zms3A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-worker-utils": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.52.0.tgz",
+      "integrity": "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==",
+      "license": "MIT"
+    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -2685,6 +3961,43 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/tunnel-rat": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tunnel-rat/-/tunnel-rat-0.1.2.tgz",
+      "integrity": "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zustand": "^4.3.2"
+      }
+    },
+    "node_modules/tunnel-rat/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/type-is": {
@@ -2718,11 +4031,59 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/utility-types": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -2746,8 +4107,8 @@
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -2817,11 +4178,72 @@
         }
       }
     },
+    "node_modules/webgl-constants": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
+      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
+    },
+    "node_modules/webgl-sdf-generator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
+      "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "license": "ISC"
+    },
+    "node_modules/zustand": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.11.tgz",
+      "integrity": "sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/visualizer/package.json
+++ b/visualizer/package.json
@@ -2,24 +2,36 @@
   "name": "claudia-brain-visualizer",
   "version": "3.0.0",
   "private": true,
-  "description": "Real-time 3D visualization of Claudia's memory system (3d-force-graph)",
+  "description": "Technical relationship-first knowledge graph explorer for Claudia local memory",
   "type": "module",
   "scripts": {
     "start": "node server.js",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "server": "node --watch server.js"
+    "server": "node --watch server.js",
+    "test:smoke": "playwright test playwright-smoke.spec.js --reporter=line"
   },
   "dependencies": {
+    "@react-three/drei": "^10.7.7",
+    "@react-three/fiber": "^9.5.0",
+    "@react-three/postprocessing": "^3.0.4",
+    "@vitejs/plugin-react": "^5.1.4",
     "3d-force-graph": "^1.73.0",
     "better-sqlite3": "^11.0.0",
     "cors": "^2.8.5",
+    "d3-force-3d": "^3.0.6",
     "express": "^4.21.0",
+    "graphology": "^0.26.0",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "sigma": "^3.0.2",
     "three": "^0.172.0",
-    "umap-js": "^1.4.0"
+    "umap-js": "^1.4.0",
+    "zustand": "^5.0.11"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "vite": "^6.0.0"
   }
 }

--- a/visualizer/playwright-smoke.spec.js
+++ b/visualizer/playwright-smoke.spec.js
@@ -1,0 +1,14 @@
+import { expect, test } from '@playwright/test';
+
+test('shell mounts', async ({ page }) => {
+  const url = process.env.TEST_URL || 'http://localhost:3849';
+  await page.goto(url, { waitUntil: 'networkidle' });
+
+  const snapshot = await page.evaluate(() => ({
+    rootChildren: document.getElementById('root')?.childElementCount ?? 0,
+    title: document.title
+  }));
+
+  expect(snapshot.rootChildren).toBeGreaterThan(0);
+  expect(snapshot.title).toContain('Claudia');
+});

--- a/visualizer/public/styles.css
+++ b/visualizer/public/styles.css
@@ -1,883 +1,884 @@
-/* Claudia Brain Visualizer -- Organic dark theme */
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap');
 
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&display=swap');
+:root {
+  color-scheme: dark;
+  --bg: #05090d;
+  --bg-elevated: #0b1117;
+  --panel: rgba(10, 16, 22, 0.9);
+  --panel-strong: rgba(7, 11, 16, 0.96);
+  --panel-muted: rgba(18, 28, 38, 0.82);
+  --border: rgba(104, 146, 178, 0.24);
+  --border-strong: rgba(137, 210, 255, 0.42);
+  --line: rgba(94, 127, 153, 0.17);
+  --text: #d7e7f2;
+  --text-dim: #9ab3c7;
+  --text-muted: #678095;
+  --accent: #79dbff;
+  --accent-secondary: #f7c16b;
+  --accent-soft: rgba(121, 219, 255, 0.12);
+  --success: #6ef0bf;
+  --danger: #ff8e77;
+  --glow-a: rgba(74, 165, 255, 0.14);
+  --glow-b: rgba(247, 193, 107, 0.07);
+  --radius: 8px;
+  --shadow: 0 22px 56px rgba(0, 0, 0, 0.42);
+}
 
 * {
-  margin: 0;
-  padding: 0;
   box-sizing: border-box;
 }
 
-:root {
-  --bg: #050510;
-  --surface: rgba(8, 8, 20, 0.88);
-  --surface-hover: rgba(12, 12, 30, 0.92);
-  --border: rgba(100, 110, 240, 0.08);
-  --border-bright: rgba(100, 110, 240, 0.15);
-  --text: #c8c8e0;
-  --text-bright: #e8e8f8;
-  --text-dim: #606080;
-  --accent: #818cf8;
-  --accent-glow: rgba(129, 140, 248, 0.2);
-  --warm: #f59e0b;
-  --danger: #f87171;
-  --success: #34d399;
-  --purple: #a78bfa;
-
-  /* Node type colors (softer, more organic palette) */
-  --color-person: #eab308;
-  --color-organization: #60a5fa;
-  --color-project: #34d399;
-  --color-concept: #c084fc;
-  --color-location: #fb923c;
-  --color-memory-fact: #94a3b8;
-  --color-memory-commitment: #f87171;
-  --color-memory-learning: #4ade80;
-  --color-memory-observation: #93c5fd;
-  --color-memory-preference: #fbbf24;
-  --color-pattern: #a78bfa;
-}
-
-body {
-  background: var(--bg);
-  color: var(--text);
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  overflow: hidden;
-  width: 100vw;
-  height: 100vh;
-}
-
-#graph-container {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
+html,
+body,
+#root {
   height: 100%;
-  z-index: 1;
-}
-
-#engine-info {
-  font-size: 10px;
-  letter-spacing: 0.5px;
-  font-weight: 500;
-}
-
-/* -- HUD bar ----------------------------------------------------------- */
-
-#hud-bar {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 44px;
-  background: var(--surface);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
-  border-bottom: 1px solid var(--border);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0 20px;
-  z-index: 100;
-}
-
-#hud-title {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  font-size: 14px;
-  font-weight: 500;
-  letter-spacing: 0.8px;
-  color: var(--text-dim);
-}
-
-.hud-logo-img {
-  height: 28px;
-  width: auto;
-  image-rendering: pixelated;
-  filter: drop-shadow(0 0 4px var(--accent-glow));
-}
-
-#hud-stats {
-  display: flex;
-  gap: 24px;
-}
-
-.stat {
-  font-size: 12px;
-  color: var(--text-dim);
-  letter-spacing: 0.3px;
-}
-
-.stat span {
-  color: var(--accent);
-  font-weight: 600;
-  font-variant-numeric: tabular-nums;
-}
-
-.pulse {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--success);
-  box-shadow: 0 0 6px var(--success);
-  animation: pulse 3s ease-in-out infinite;
-}
-
-@keyframes pulse {
-  0%, 100% { opacity: 0.3; transform: scale(1); }
-  50% { opacity: 1; transform: scale(1.4); }
-}
-
-/* -- HUD controls (FPS + settings) -------------------------------------- */
-
-#hud-controls {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-#fps-counter {
-  font-size: 11px;
-  color: var(--text-dim);
-  font-variant-numeric: tabular-nums;
-  min-width: 52px;
-  text-align: right;
-}
-
-#settings-container {
-  position: relative;
-}
-
-#settings-btn {
-  background: none;
-  border: 1px solid var(--border);
-  color: var(--text-dim);
-  font-size: 16px;
-  cursor: pointer;
-  padding: 2px 6px;
-  border-radius: 6px;
-  transition: all 0.2s;
-  line-height: 1;
-}
-
-#settings-btn:hover {
-  background: rgba(129, 140, 248, 0.08);
-  border-color: var(--border-bright);
-  color: var(--text);
-}
-
-/* -- Settings panel (gear menu) ----------------------------------------- */
-
-#settings-panel {
-  position: absolute;
-  top: 100%;
-  right: 0;
-  margin-top: 8px;
-  background: var(--surface-hover);
-  backdrop-filter: blur(24px);
-  -webkit-backdrop-filter: blur(24px);
-  border: 1px solid var(--border-bright);
-  border-radius: 10px;
-  width: 380px;
-  max-height: 70vh;
-  overflow-y: auto;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
-}
-
-#settings-panel.hidden {
-  display: none;
-}
-
-/* Tabs */
-
-.sp-tabs {
-  display: flex;
-  border-bottom: 1px solid var(--border);
-  padding: 0 4px;
-  gap: 0;
-  overflow-x: auto;
-}
-
-.sp-tab {
-  padding: 8px 12px;
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.8px;
-  color: var(--text-dim);
-  cursor: pointer;
-  border: none;
-  background: none;
-  white-space: nowrap;
-  border-bottom: 2px solid transparent;
-  transition: all 0.2s;
-  font-family: inherit;
-}
-
-.sp-tab:hover {
-  color: var(--text);
-}
-
-.sp-tab.active {
-  color: var(--accent);
-  border-bottom-color: var(--accent);
-}
-
-/* Tab content */
-
-.sp-content {
-  display: none;
-  padding: 14px;
-}
-
-.sp-content.active {
-  display: block;
-}
-
-/* Theme grid */
-
-.sp-theme-grid {
-  display: grid;
-  grid-template-columns: repeat(5, 1fr);
-  gap: 12px;
-  padding: 4px 0;
-}
-
-.sp-theme-item {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 6px;
-  cursor: pointer;
-  padding: 6px;
-  border-radius: 8px;
-  border: 2px solid transparent;
-  transition: all 0.2s;
-}
-
-.sp-theme-item:hover {
-  background: rgba(255, 255, 255, 0.03);
-}
-
-.sp-theme-item.active {
-  border-color: var(--accent);
-  background: rgba(129, 140, 248, 0.06);
-}
-
-.sp-theme-swatch {
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
-  box-shadow: 0 0 10px currentColor;
-  transition: transform 0.2s, box-shadow 0.2s;
-}
-
-.sp-theme-item:hover .sp-theme-swatch {
-  transform: scale(1.1);
-  box-shadow: 0 0 16px currentColor;
-}
-
-.sp-theme-name {
-  font-size: 9px;
-  color: var(--text-dim);
-  text-align: center;
-  line-height: 1.2;
-}
-
-/* Slider rows */
-
-.sp-slider-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 4px 0;
-  font-size: 11px;
-  color: var(--text-dim);
-}
-
-.sp-slider-row label {
-  flex: 0 0 80px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.sp-slider-row input[type="range"] {
-  flex: 1;
-  -webkit-appearance: none;
-  appearance: none;
-  height: 2px;
-  background: rgba(129, 140, 248, 0.15);
-  border-radius: 1px;
-  outline: none;
-}
-
-.sp-slider-row input[type="range"]::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  width: 10px;
-  height: 10px;
-  background: var(--accent);
-  border-radius: 50%;
-  cursor: pointer;
-  box-shadow: 0 0 6px var(--accent-glow);
-}
-
-.sp-slider-value {
-  font-size: 10px;
-  min-width: 36px;
-  text-align: right;
-  font-variant-numeric: tabular-nums;
-  color: var(--accent);
-}
-
-/* Toggle rows */
-
-.sp-toggle-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 5px 0;
-  font-size: 11px;
-  color: var(--text-dim);
-}
-
-.sp-toggle-row input[type="checkbox"] {
-  accent-color: var(--accent);
-  width: 14px;
-  height: 14px;
-  cursor: pointer;
-}
-
-/* Radio group */
-
-.sp-radio-group {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.sp-radio-item {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 5px 8px;
-  border-radius: 6px;
-  cursor: pointer;
-  font-size: 12px;
-  color: var(--text);
-  transition: background 0.15s;
-}
-
-.sp-radio-item:hover {
-  background: rgba(255, 255, 255, 0.03);
-}
-
-.sp-radio-item input[type="radio"] {
-  accent-color: var(--accent);
   margin: 0;
 }
 
-.sp-radio-desc {
-  font-size: 10px;
-  color: var(--text-dim);
-  margin-left: auto;
-}
-
-/* Section headers inside tabs */
-
-.sp-section-title {
-  font-size: 9px;
-  text-transform: uppercase;
-  letter-spacing: 0.8px;
-  color: var(--text-dim);
-  margin: 10px 0 6px 0;
-  opacity: 0.7;
-}
-
-.sp-section-title:first-child {
-  margin-top: 0;
-}
-
-/* Buttons */
-
-.sp-btn {
-  width: 100%;
-  padding: 6px 0;
-  margin-top: 6px;
-  background: rgba(129, 140, 248, 0.08);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  color: var(--text-dim);
-  font-size: 11px;
-  font-family: inherit;
-  cursor: pointer;
-  transition: all 0.2s;
-}
-
-.sp-btn:hover {
-  background: rgba(129, 140, 248, 0.15);
-  border-color: var(--border-bright);
+body {
+  background:
+    radial-gradient(circle at 14% 12%, var(--glow-a), transparent 26%),
+    radial-gradient(circle at 82% 10%, var(--glow-b), transparent 22%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.02), transparent 26%),
+    var(--bg);
   color: var(--text);
+  font-family: 'IBM Plex Sans', sans-serif;
+  overflow: hidden;
 }
 
-.sp-btn-row {
-  display: flex;
-  gap: 8px;
-  margin-top: 8px;
-}
-
-.sp-btn-row .sp-btn {
-  margin-top: 0;
-}
-
-/* Preset list */
-
-.sp-preset-list {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  margin-top: 8px;
-}
-
-.sp-preset-item {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 6px 8px;
-  background: rgba(255, 255, 255, 0.02);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  font-size: 12px;
-  color: var(--text);
-}
-
-.sp-preset-item button {
-  background: none;
-  border: none;
-  color: var(--text-dim);
-  cursor: pointer;
-  font-size: 11px;
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-family: inherit;
-  transition: all 0.15s;
-}
-
-.sp-preset-item button:hover {
-  background: rgba(255, 255, 255, 0.06);
-  color: var(--text);
-}
-
-.sp-preset-item .sp-preset-delete:hover {
-  color: var(--danger);
-}
-
-/* Preset save row */
-
-.sp-preset-save {
-  display: flex;
-  gap: 6px;
-  margin-top: 8px;
-}
-
-.sp-preset-save input {
-  flex: 1;
-  padding: 5px 8px;
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  color: var(--text);
-  font-size: 11px;
-  font-family: inherit;
-  outline: none;
-}
-
-.sp-preset-save input:focus {
-  border-color: var(--accent);
-}
-
-.sp-preset-save button {
-  padding: 5px 12px;
-  background: rgba(129, 140, 248, 0.12);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  color: var(--text-dim);
-  font-size: 11px;
-  font-family: inherit;
-  cursor: pointer;
-  transition: all 0.2s;
-  white-space: nowrap;
-}
-
-.sp-preset-save button:hover {
-  background: rgba(129, 140, 248, 0.2);
-  color: var(--text);
-}
-
-/* Empty state */
-
-.sp-empty {
-  font-size: 11px;
-  color: var(--text-dim);
-  padding: 8px 0;
-  text-align: center;
-  opacity: 0.6;
-}
-
-/* -- Left sidebar -------------------------------------------------------- */
-
-#sidebar {
+body::before,
+body::after {
+  content: '';
+  inset: 0;
+  pointer-events: none;
   position: fixed;
-  top: 52px;
-  left: 0;
-  width: 240px;
-  bottom: 52px;
-  background: var(--surface);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
-  border-right: 1px solid var(--border);
-  padding: 14px;
-  z-index: 100;
-  overflow-y: auto;
-  transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-#search-container {
+body::before {
+  background:
+    linear-gradient(var(--line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--line) 1px, transparent 1px);
+  background-size: 64px 64px;
+  opacity: 0.16;
+}
+
+body::after {
+  background: repeating-linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.02),
+    rgba(255, 255, 255, 0.02) 1px,
+    transparent 1px,
+    transparent 4px
+  );
+  mix-blend-mode: soft-light;
+  opacity: 0.08;
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+.app-shell {
+  --left-panel-width: 304px;
+  --right-panel-width: 344px;
+  --bottom-panel-height: 82px;
+  --viewport-left-offset: calc(var(--left-panel-width) + 32px);
+  --viewport-right-offset: calc(var(--right-panel-width) + 28px);
+  --floating-bottom-offset: calc(var(--bottom-panel-height) + 54px);
+  height: 100%;
   position: relative;
-  margin-bottom: 18px;
 }
 
-#search-input {
-  width: 100%;
-  padding: 7px 10px;
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  color: var(--text);
-  font-size: 12px;
-  font-family: inherit;
-  outline: none;
-  transition: all 0.3s ease;
+.app-shell.left-collapsed {
+  --left-panel-width: 0px;
+  --viewport-left-offset: 24px;
 }
 
-#search-input:focus {
-  border-color: var(--accent);
-  box-shadow: 0 0 0 3px var(--accent-glow);
-  background: rgba(255, 255, 255, 0.06);
+.app-shell.right-collapsed {
+  --right-panel-width: 0px;
+  --viewport-right-offset: 24px;
 }
 
-#search-input::placeholder {
-  color: var(--text-dim);
+.app-shell.bottom-collapsed {
+  --bottom-panel-height: 0px;
+  --floating-bottom-offset: 24px;
 }
 
-#search-results {
+.graph-viewport {
+  inset: 0;
+  overflow: hidden;
   position: absolute;
-  top: 100%;
-  left: 0;
-  right: 0;
-  background: var(--surface-hover);
-  border: 1px solid var(--border-bright);
-  border-radius: 8px;
-  margin-top: 4px;
-  max-height: 280px;
-  overflow-y: auto;
-  display: none;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
 }
 
-#search-results.active {
+.graph-canvas {
+  height: 100%;
+  width: 100%;
+}
+
+.graph-canvas canvas {
   display: block;
 }
 
-.search-result {
-  padding: 7px 10px;
-  cursor: pointer;
-  border-bottom: 1px solid var(--border);
-  font-size: 12px;
-  transition: background 0.15s;
+.top-hud,
+.side-panel,
+.bottom-timeline,
+.overlay-panel,
+.hover-panel,
+.viewport-overlay {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.03), transparent 24%),
+    var(--panel);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
 }
 
-.search-result:hover {
-  background: rgba(129, 140, 248, 0.08);
+.top-hud,
+.side-panel,
+.bottom-timeline,
+.overlay-panel {
+  backdrop-filter: blur(12px);
 }
 
-.search-result:last-child {
-  border-bottom: none;
-}
-
-.search-result .result-type {
-  font-size: 9px;
-  text-transform: uppercase;
-  letter-spacing: 0.8px;
-  opacity: 0.5;
-  margin-right: 6px;
-}
-
-#filters h3 {
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 1.2px;
-  color: var(--text-dim);
-  margin-bottom: 6px;
-  margin-top: 14px;
-}
-
-.filter-item {
-  display: flex;
+.top-hud {
   align-items: center;
-  gap: 7px;
-  padding: 3px 0;
-  font-size: 12px;
-  cursor: pointer;
-  color: var(--text-dim);
-  transition: color 0.2s;
-}
-
-.filter-item:hover {
-  color: var(--text);
-}
-
-.filter-item input[type="checkbox"] {
-  accent-color: var(--accent);
-  width: 13px;
-  height: 13px;
-}
-
-.filter-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  display: inline-block;
-  box-shadow: 0 0 4px currentColor;
-  flex-shrink: 0;
-}
-
-.filter-dot[data-shape="square"] {
-  border-radius: 2px;
-}
-
-.filter-dot[data-shape="diamond"] {
-  border-radius: 2px;
-  transform: rotate(45deg);
-}
-
-.filter-dot[data-shape="ring"] {
-  background: transparent !important;
-  border: 2px solid currentColor;
-}
-
-/* -- Right detail panel -------------------------------------------------- */
-
-#detail-panel {
-  position: fixed;
-  top: 52px;
-  right: 0;
-  width: 340px;
-  bottom: 52px;
-  background: var(--surface);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
-  border-left: 1px solid var(--border);
-  padding: 18px;
-  z-index: 100;
-  overflow-y: auto;
-  transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-#detail-panel.hidden {
-  transform: translateX(100%);
-}
-
-#detail-close {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 10px;
+  height: 48px;
+  inset: 12px 12px auto 12px;
+  padding: 6px 10px;
   position: absolute;
-  top: 10px;
-  right: 10px;
-  background: none;
-  border: none;
-  color: var(--text-dim);
-  font-size: 22px;
-  cursor: pointer;
-  width: 28px;
-  height: 28px;
-  display: flex;
+  z-index: 20;
+}
+
+.hud-brand,
+.hud-mode-strip,
+.hud-stats,
+.hud-actions,
+.hud-brand-copy,
+.hud-db-switch,
+.panel-heading,
+.inspector-head,
+.metric-card,
+.breakdown-row,
+.info-row,
+.result-row,
+.timeline-block,
+.trace-readout > div {
   align-items: center;
-  justify-content: center;
-  border-radius: 6px;
-  transition: all 0.2s;
+  display: flex;
+  min-width: 0;
 }
 
-#detail-close:hover {
-  background: rgba(255, 255, 255, 0.08);
-  color: var(--text);
+.hud-brand {
+  flex: 0 1 360px;
+  gap: 10px;
+  min-width: 0;
 }
 
-.detail-header {
-  margin-bottom: 16px;
+.hud-logo {
+  display: block;
+  filter: drop-shadow(0 0 12px rgba(121, 219, 255, 0.14));
+  height: 24px;
+  width: auto;
 }
 
-.detail-header h2 {
-  font-size: 16px;
-  font-weight: 500;
-  margin-bottom: 3px;
+.hud-brand-copy {
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
 }
 
-.detail-header .detail-type {
+.hud-brand-copy strong,
+.hud-brand-copy span {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hud-brand-copy strong,
+.panel-heading strong,
+.metric-card strong,
+.result-row strong,
+.hover-panel strong,
+.timeline-block strong,
+.inspector-head strong {
+  color: #eef6fd;
+}
+
+.hud-brand-copy strong,
+.panel-heading strong,
+.inspector-head strong {
+  font-size: 13px;
+  line-height: 1.15;
+}
+
+.hud-brand-copy span,
+.panel-heading span,
+.hud-meta-label,
+.hud-stat span,
+.metric-card span,
+.result-row span,
+.breakdown-row span,
+.info-row span,
+.trace-readout span,
+.timeline-meta span,
+.viewport-overlay span,
+.hover-panel span,
+.empty-inline {
+  color: var(--text-muted);
+  font-family: 'IBM Plex Mono', monospace;
   font-size: 10px;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
-  letter-spacing: 1px;
-  color: var(--text-dim);
 }
 
-.detail-section {
-  margin-bottom: 14px;
+.hud-db-switch {
+  gap: 8px;
+  min-width: 0;
 }
 
-.detail-section h3 {
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.8px;
-  color: var(--text-dim);
-  margin-bottom: 6px;
+.hud-db-switch .hud-select {
+  min-width: 0;
+  width: 168px;
 }
 
-.detail-item {
-  padding: 7px 9px;
+.hud-select,
+.panel-input {
   background: rgba(255, 255, 255, 0.02);
   border: 1px solid var(--border);
-  border-radius: 8px;
-  margin-bottom: 5px;
-  font-size: 12px;
-  line-height: 1.5;
-  cursor: pointer;
-  transition: all 0.2s;
-}
-
-.detail-item:hover {
-  background: rgba(129, 140, 248, 0.06);
-  border-color: var(--border-bright);
-}
-
-.detail-meta {
-  font-size: 10px;
-  color: var(--text-dim);
-  margin-top: 3px;
-}
-
-.importance-bar {
-  display: inline-block;
-  height: 2px;
-  border-radius: 1px;
-  background: var(--accent);
-  vertical-align: middle;
-  margin-left: 6px;
-  box-shadow: 0 0 4px var(--accent-glow);
-}
-
-/* -- Bottom timeline ----------------------------------------------------- */
-
-#timeline-container {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  height: 48px;
-  background: var(--surface);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
-  border-top: 1px solid var(--border);
-  display: flex;
-  align-items: center;
-  padding: 0 20px;
-  gap: 14px;
-  z-index: 100;
-}
-
-#timeline-bar {
-  flex: 1;
-  position: relative;
-}
-
-#timeline-slider {
-  width: 100%;
-  -webkit-appearance: none;
-  appearance: none;
-  height: 3px;
-  background: rgba(129, 140, 248, 0.12);
-  border-radius: 2px;
+  color: var(--text);
+  min-height: 30px;
   outline: none;
+  padding: 0 10px;
 }
 
-#timeline-slider::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  width: 12px;
-  height: 12px;
-  background: var(--accent);
-  border-radius: 50%;
-  cursor: pointer;
-  box-shadow: 0 0 10px var(--accent-glow);
-  transition: box-shadow 0.2s;
+.panel-input {
+  width: 100%;
 }
 
-#timeline-slider::-webkit-slider-thumb:hover {
-  box-shadow: 0 0 16px var(--accent-glow);
+.panel-input-large {
+  font-size: 18px;
+  min-height: 50px;
 }
 
-#timeline-labels {
+.hud-select:focus,
+.panel-input:focus {
+  border-color: var(--border-strong);
+  box-shadow: 0 0 0 1px rgba(121, 219, 255, 0.16);
+}
+
+.hud-mode-strip {
+  border-left: 1px solid var(--line);
+  border-right: 1px solid var(--line);
+  flex: 0 0 auto;
+  gap: 6px;
+  justify-content: center;
+  min-width: 0;
+  padding: 0 10px;
+}
+
+.hud-chip,
+.hud-button,
+.panel-button,
+.filter-pill {
+  background: rgba(255, 255, 255, 0.025);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-size: 12px;
+  min-height: 28px;
+  padding: 0 10px;
+  transition: background 140ms ease, border-color 140ms ease, transform 140ms ease;
+}
+
+.hud-chip:hover,
+.hud-button:hover,
+.panel-button:hover,
+.filter-pill:hover,
+.result-row:hover {
+  background: var(--accent-soft);
+  border-color: var(--border-strong);
+  transform: translateY(-1px);
+}
+
+.hud-chip.is-active,
+.hud-button.is-active,
+.panel-button.is-active,
+.filter-pill.is-active {
+  background: linear-gradient(180deg, rgba(121, 219, 255, 0.18), rgba(121, 219, 255, 0.04));
+  border-color: var(--border-strong);
+}
+
+.hud-chip:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+
+.hud-stats {
+  flex: 1 1 auto;
+  flex-wrap: nowrap;
+  gap: 8px;
+  justify-content: center;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.hud-stat {
+  border: 1px solid var(--line);
+  display: grid;
+  gap: 2px;
+  min-width: 60px;
+  padding: 4px 6px;
+}
+
+.hud-stat strong {
+  font-size: 15px;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+.hud-actions {
+  align-items: center;
+  flex: 0 0 auto;
+  flex-wrap: nowrap;
+  gap: 6px;
+  justify-content: flex-end;
+  min-width: 0;
+  overflow: visible;
+}
+
+.hud-theme {
+  align-items: center;
   display: flex;
-  justify-content: space-between;
-  font-size: 9px;
+  flex: 0 0 auto;
+  gap: 8px;
+}
+
+.hud-theme .hud-meta-label {
+  display: none;
+}
+
+.hud-status {
+  border-left: 1px solid var(--line);
   color: var(--text-dim);
-  margin-top: 1px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 12px;
+  min-width: 68px;
+  padding-left: 10px;
+  text-align: right;
 }
 
-#timeline-controls {
+.hud-status.is-loading {
+  color: var(--accent);
+}
+
+.hud-status.is-error {
+  color: var(--danger);
+}
+
+.side-panel {
+  bottom: var(--floating-bottom-offset);
+  overflow: auto;
+  overscroll-behavior: contain;
+  padding: 10px;
+  position: absolute;
+  scrollbar-gutter: stable;
+  top: 72px;
+  width: var(--left-panel-width);
+  z-index: 18;
+}
+
+.left-sidebar {
+  left: 12px;
+}
+
+.right-inspector {
+  right: 12px;
+  width: var(--right-panel-width);
+}
+
+.panel-block,
+.timeline-block {
+  border: 1px solid var(--line);
+  display: grid;
+  gap: 10px;
+  margin-bottom: 10px;
+  min-width: 0;
+  overflow: hidden;
+  padding: 10px;
+}
+
+.panel-block:last-child,
+.timeline-block:last-child {
+  margin-bottom: 0;
+}
+
+.panel-heading {
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.panel-heading strong,
+.panel-heading span,
+.result-row strong,
+.result-row span,
+.metric-card strong,
+.metric-card span,
+.breakdown-row span,
+.breakdown-row strong,
+.info-row span,
+.info-row strong,
+.trace-readout span,
+.trace-readout strong,
+.inspector-copy,
+.empty-inline {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.metric-grid {
+  display: grid;
+  gap: 6px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.metric-card,
+.info-row,
+.breakdown-row,
+.trace-readout > div {
+  background: rgba(255, 255, 255, 0.018);
+  border: 1px solid var(--line);
+  align-items: center;
   display: flex;
+  gap: 8px;
+  justify-content: space-between;
+  padding: 8px 10px;
+}
+
+.metric-card strong,
+.info-row strong,
+.breakdown-row strong,
+.trace-readout strong {
+  font-size: 14px;
+  line-height: 1.1;
+  white-space: nowrap;
+}
+
+.result-stack,
+.breakdown-list,
+.info-list,
+.filter-list,
+.settings-grid,
+.settings-stack {
+  display: grid;
   gap: 6px;
 }
 
-#timeline-controls button {
-  background: rgba(255, 255, 255, 0.04);
+.filter-list {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.result-row {
+  background: rgba(255, 255, 255, 0.018);
+  border: 1px solid var(--line);
+  color: inherit;
+  display: grid;
+  gap: 3px;
+  justify-items: start;
+  line-height: 1.35;
+  padding: 8px 10px;
+  text-align: left;
+}
+
+.commitment-row {
+  border-color: rgba(255, 142, 119, 0.35);
+}
+
+.panel-button-wide {
+  width: 100%;
+}
+
+.inline-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.inspector-head {
+  align-items: flex-start;
+  border-bottom: 1px solid var(--line);
+  justify-content: space-between;
+  margin-bottom: 12px;
+  padding-bottom: 10px;
+}
+
+.inspector-head span {
+  display: block;
+}
+
+.inspector-close {
+  background: transparent;
   border: 1px solid var(--border);
   color: var(--text-dim);
-  padding: 3px 8px;
-  border-radius: 6px;
-  cursor: pointer;
-  font-size: 11px;
-  font-family: inherit;
-  transition: all 0.2s;
+  min-height: 30px;
+  padding: 0 10px;
 }
 
-#timeline-controls button:hover {
-  background: rgba(129, 140, 248, 0.08);
-  border-color: var(--border-bright);
-  color: var(--text);
+.inspector-copy {
+  color: var(--text-dim);
+  font-size: 12px;
+  line-height: 1.5;
+  margin: 0;
 }
 
-#timeline-density {
+.bottom-timeline {
+  bottom: 12px;
+  display: grid;
+  gap: 10px;
+  grid-template-columns: 1.35fr 0.9fr;
+  height: var(--bottom-panel-height);
+  inset-inline: 12px;
+  padding: 10px;
   position: absolute;
-  bottom: 28px;
-  left: 20px;
-  right: 120px;
-  height: 14px;
-  pointer-events: none;
-  opacity: 0.5;
+  z-index: 18;
 }
 
-/* -- Scrollbar ----------------------------------------------------------- */
-
-::-webkit-scrollbar {
-  width: 4px;
+.timeline-block {
+  align-content: center;
 }
 
-::-webkit-scrollbar-track {
+.timeline-meta {
+  display: flex;
+  justify-content: space-between;
+}
+
+.timeline-compact {
+  align-items: center;
+  display: grid;
+  gap: 8px;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+}
+
+.trace-inline {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.trace-inline span {
+  color: var(--text-dim);
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.overlay-backdrop {
+  align-items: center;
+  background: rgba(2, 4, 7, 0.72);
+  display: flex;
+  inset: 0;
+  justify-content: center;
+  position: fixed;
+  z-index: 30;
+}
+
+.overlay-panel {
+  max-height: min(82vh, calc(100vh - 56px));
+  overflow: auto;
+  padding: 14px;
+  width: min(760px, calc(100vw - 48px));
+}
+
+.search-panel {
+  max-width: 760px;
+}
+
+.settings-panel {
+  max-width: 920px;
+}
+
+.settings-panel-inline {
+  display: grid;
+  gap: 8px;
+}
+
+.settings-row,
+.settings-control {
+  display: grid;
+  gap: 6px;
+}
+
+.settings-section {
+  border: 1px solid var(--line);
+  padding: 10px;
+}
+
+.settings-stack {
+  margin-top: 8px;
+}
+
+.settings-note {
+  background: rgba(255, 255, 255, 0.018);
+  border: 1px dashed var(--line);
+  color: var(--text-dim);
+  font-size: 12px;
+  line-height: 1.45;
+  padding: 8px 9px;
+}
+
+.compact-list {
+  grid-template-columns: repeat(auto-fit, minmax(96px, 1fr));
+}
+
+.compact-list-3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.settings-colors {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 0;
+}
+
+.settings-colors-stack {
+  grid-template-columns: 1fr;
+}
+
+.settings-color-field {
+  display: grid;
+  gap: 6px;
+}
+
+.settings-color-field span,
+.settings-color-input code {
+  color: var(--text-muted);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.settings-color-input {
+  align-items: center;
+  background: rgba(255, 255, 255, 0.018);
+  border: 1px solid var(--line);
+  display: flex;
+  gap: 8px;
+  padding: 6px 8px;
+}
+
+.settings-color-input input[type='color'] {
   background: transparent;
+  border: 0;
+  height: 24px;
+  padding: 0;
+  width: 34px;
 }
 
-::-webkit-scrollbar-thumb {
-  background: rgba(129, 140, 248, 0.12);
-  border-radius: 2px;
+.settings-file-input {
+  display: none;
 }
 
-::-webkit-scrollbar-thumb:hover {
-  background: rgba(129, 140, 248, 0.2);
+.slider-head {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}
+
+.settings-slider {
+  background: rgba(255, 255, 255, 0.018);
+  border: 1px solid var(--line);
+  padding: 8px 9px;
+}
+
+.viewport-overlay,
+.hover-panel {
+  backdrop-filter: blur(10px);
+  position: absolute;
+  z-index: 12;
+}
+
+.viewport-overlay {
+  display: grid;
+  gap: 2px;
+  padding: 7px 9px;
+}
+
+.viewport-overlay strong,
+.hover-panel strong {
+  font-size: 13px;
+}
+
+.viewport-overlay-top {
+  left: var(--viewport-left-offset);
+  top: 72px;
+}
+
+.viewport-overlay-right {
+  right: var(--viewport-right-offset);
+  top: 72px;
+}
+
+.hover-panel {
+  bottom: var(--floating-bottom-offset);
+  display: grid;
+  gap: 6px;
+  left: var(--viewport-left-offset);
+  max-width: 420px;
+  max-height: 260px;
+  overflow: hidden;
+  padding: 10px;
+}
+
+.hover-panel strong {
+  overflow-wrap: anywhere;
+}
+
+.hover-panel-body {
+  color: var(--text-dim);
+  font-size: 13px;
+  line-height: 1.45;
+  margin: 0;
+  max-height: 136px;
+  overflow: auto;
+  padding-right: 4px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.hover-metrics {
+  display: flex;
+  gap: 12px;
+}
+
+.empty-inline {
+  border: 1px dashed var(--line);
+  padding: 12px;
+}
+
+.graph-node-label-wrap {
+  pointer-events: none;
+}
+
+.graph-node-label {
+  backdrop-filter: blur(8px);
+  background: rgba(5, 11, 18, 0.9);
+  border: 1px solid rgba(137, 210, 255, 0.42);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.34);
+  color: #f6fbff;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  line-height: 1.22;
+  max-width: 320px;
+  padding: 8px 12px;
+  text-align: center;
+  text-transform: uppercase;
+  white-space: normal;
+  word-break: break-word;
+}
+
+.graph-node-label.is-secondary {
+  border-color: rgba(104, 146, 178, 0.26);
+  color: var(--text-dim);
+}
+
+.result-copy {
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.45;
+  text-align: left;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.result-row.result-toned {
+  background:
+    linear-gradient(180deg, var(--result-tone-soft, rgba(255, 255, 255, 0.05)), rgba(255, 255, 255, 0.018)),
+    rgba(255, 255, 255, 0.018);
+  border-color: var(--result-tone-border, var(--line));
+  box-shadow: inset 0 0 0 1px var(--result-tone-soft, transparent);
+}
+
+.result-row.result-toned strong {
+  color: var(--result-tone, #eef6fd);
+}
+
+input[type='range'] {
+  accent-color: var(--accent);
+  width: 100%;
+}
+
+@media (max-width: 1600px) {
+  .app-shell {
+    --right-panel-width: 320px;
+    --viewport-right-offset: calc(var(--right-panel-width) + 28px);
+  }
+
+  .hud-stat-optional {
+    display: none;
+  }
+}
+
+@media (max-width: 1360px) {
+  .app-shell {
+    --left-panel-width: 278px;
+    --right-panel-width: 300px;
+    --viewport-left-offset: calc(var(--left-panel-width) + 28px);
+    --viewport-right-offset: calc(var(--right-panel-width) + 20px);
+  }
+}
+
+@media (max-width: 1220px) {
+  .hud-stats {
+    display: none;
+  }
+
+  .right-inspector {
+    right: 12px;
+    transform: translateX(calc(100% + 16px));
+    transition: transform 180ms ease;
+  }
+
+  .right-inspector.is-open {
+    transform: translateX(0);
+  }
+
+  .viewport-overlay-right {
+    right: 24px;
+  }
+}
+
+@media (max-width: 980px) {
+  .app-shell {
+    --left-panel-width: 258px;
+    --viewport-left-offset: calc(var(--left-panel-width) + 28px);
+    --bottom-panel-height: 156px;
+    --floating-bottom-offset: calc(var(--bottom-panel-height) + 24px);
+  }
+
+  .bottom-timeline {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-colors {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .compact-list-3 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }

--- a/visualizer/src/app/AppShell.jsx
+++ b/visualizer/src/app/AppShell.jsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from 'react';
+import { BottomTimeline } from '../components/BottomTimeline.jsx';
+import { GraphViewport } from '../components/GraphViewport.jsx';
+import { LeftSidebar } from '../components/LeftSidebar.jsx';
+import { RightInspector } from '../components/RightInspector.jsx';
+import { SearchPalette } from '../components/SearchPalette.jsx';
+import { TopHudBar } from '../components/TopHudBar.jsx';
+import { applyThemeToDocument } from '../lib/theme.js';
+import { useGraphStore } from '../store/useGraphStore.js';
+
+export function AppShell() {
+  const [timelineRange, setTimelineRange] = useState({ min: null, max: null });
+  const init = useGraphStore((state) => state.init);
+  const searchQuery = useGraphStore((state) => state.searchQuery);
+  const runSearch = useGraphStore((state) => state.runSearch);
+  const setSearchOpen = useGraphStore((state) => state.setSearchOpen);
+  const setSettingsOpen = useGraphStore((state) => state.setSettingsOpen);
+  const themeId = useGraphStore((state) => state.themeId);
+  const leftPanelOpen = useGraphStore((state) => state.leftPanelOpen);
+  const inspectorOpen = useGraphStore((state) => state.inspectorOpen);
+  const bottomPanelOpen = useGraphStore((state) => state.bottomPanelOpen);
+
+  useEffect(() => {
+    init();
+  }, [init]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      runSearch(searchQuery);
+    }, 140);
+    return () => window.clearTimeout(timer);
+  }, [runSearch, searchQuery]);
+
+  useEffect(() => {
+    const onKeyDown = (event) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+        event.preventDefault();
+        setSearchOpen(true);
+      }
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === ',') {
+        event.preventDefault();
+        setSettingsOpen(true);
+      }
+      if (event.key === 'Escape') {
+        setSearchOpen(false);
+        setSettingsOpen(false);
+      }
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [setSearchOpen, setSettingsOpen]);
+
+  useEffect(() => {
+    applyThemeToDocument(themeId);
+  }, [themeId]);
+
+  return (
+    <div className={`app-shell ${leftPanelOpen ? '' : 'left-collapsed'} ${inspectorOpen ? '' : 'right-collapsed'} ${bottomPanelOpen ? '' : 'bottom-collapsed'}`.trim()}>
+      <GraphViewport onTimelineRange={setTimelineRange} />
+      <TopHudBar />
+      {leftPanelOpen ? <LeftSidebar /> : null}
+      {inspectorOpen ? <RightInspector /> : null}
+      {bottomPanelOpen ? <BottomTimeline timelineRange={timelineRange} /> : null}
+      <SearchPalette />
+    </div>
+  );
+}

--- a/visualizer/src/components/BottomTimeline.jsx
+++ b/visualizer/src/components/BottomTimeline.jsx
@@ -1,0 +1,87 @@
+import { useEffect, useMemo, useState } from 'react';
+import { formatDateShort } from '../lib/theme.js';
+import { useGraphStore } from '../store/useGraphStore.js';
+
+function playbackDate(timelineRange, timelineWindow) {
+  if (!timelineRange.min || !timelineRange.max) return null;
+  const min = new Date(timelineRange.min).getTime();
+  const max = new Date(timelineRange.max).getTime();
+  if (!Number.isFinite(min) || !Number.isFinite(max)) return null;
+  const ratio = Number(timelineWindow || 100) / 100;
+  return new Date(min + (max - min) * ratio).toISOString();
+}
+
+export function BottomTimeline({ timelineRange }) {
+  const [playing, setPlaying] = useState(false);
+  const timelineWindow = useGraphStore((state) => state.timelineWindow);
+  const setTimelineWindow = useGraphStore((state) => state.setTimelineWindow);
+  const traceEndpoints = useGraphStore((state) => state.traceEndpoints);
+  const traceGraph = useGraphStore((state) => state.traceGraph);
+
+  useEffect(() => {
+    if (!playing) return undefined;
+    const timer = window.setInterval(() => {
+      setTimelineWindow((current) => {
+        const next = typeof current === 'number' ? current + 2 : timelineWindow + 2;
+        if (next >= 100) {
+          window.clearInterval(timer);
+          setPlaying(false);
+          return 100;
+        }
+        return next;
+      });
+    }, 180);
+
+    return () => window.clearInterval(timer);
+  }, [playing, setTimelineWindow, timelineWindow]);
+
+  const playbackAt = useMemo(() => playbackDate(timelineRange, timelineWindow), [timelineRange, timelineWindow]);
+  const traceSummary = traceGraph?.meta?.found
+    ? `${traceGraph.meta.hopCount} hops${traceGraph.meta.usedInferred ? ' (includes inferred links)' : ''}`
+    : traceEndpoints.from && traceEndpoints.to
+      ? 'No path found yet'
+      : 'Pick two entities to trace';
+
+  return (
+    <footer className="bottom-timeline">
+      <div className="timeline-block timeline-block-wide">
+        <div className="panel-heading">
+          <span>Memory Playback</span>
+          <strong>{playbackAt ? formatDateShort(playbackAt) : 'No dates'}</strong>
+        </div>
+        <div className="timeline-compact">
+          <button className="panel-button" onClick={() => setPlaying((value) => !value)}>
+            {playing ? 'Pause' : 'Play'}
+          </button>
+          <input
+            type="range"
+            min="10"
+            max="100"
+            step="1"
+            value={timelineWindow}
+            onChange={(event) => {
+              setPlaying(false);
+              setTimelineWindow(Number(event.target.value));
+            }}
+          />
+          <div className="timeline-meta">
+            <span>{formatDateShort(timelineRange.min)}</span>
+            <span>{timelineWindow}% visible</span>
+            <span>{formatDateShort(timelineRange.max)}</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="timeline-block timeline-block-narrow">
+        <div className="panel-heading">
+          <span>Path Builder</span>
+          <strong>{traceSummary}</strong>
+        </div>
+        <div className="trace-inline">
+          <span>{traceEndpoints.from || 'Start node not set'}</span>
+          <span>{traceEndpoints.to || 'End node not set'}</span>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/visualizer/src/components/DatabaseSwitcher.jsx
+++ b/visualizer/src/components/DatabaseSwitcher.jsx
@@ -1,0 +1,36 @@
+import { useMemo } from 'react';
+import { useGraphStore } from '../store/useGraphStore.js';
+
+function basename(value) {
+  return String(value || '').split('/').filter(Boolean).pop() || 'Default';
+}
+
+export function DatabaseSwitcher() {
+  const databases = useGraphStore((state) => state.databases);
+  const activeDatabasePath = useGraphStore((state) => state.activeDatabasePath);
+  const switchDatabase = useGraphStore((state) => state.switchDatabase);
+  const loading = useGraphStore((state) => state.loadingState.database);
+
+  const options = useMemo(() => (databases || []).map((entry) => ({
+    path: entry.path,
+    label: entry.name || basename(entry.path)
+  })), [databases]);
+
+  return (
+    <label className="hud-db-switch">
+      <span className="hud-meta-label">Database</span>
+      <select
+        className="hud-select"
+        value={activeDatabasePath || ''}
+        onChange={(event) => switchDatabase(event.target.value)}
+        disabled={loading}
+      >
+        {options.map((entry) => (
+          <option key={entry.path} value={entry.path}>
+            {entry.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/visualizer/src/components/FilterDrawer.jsx
+++ b/visualizer/src/components/FilterDrawer.jsx
@@ -1,0 +1,56 @@
+import { useGraphStore } from '../store/useGraphStore.js';
+import { ENTITY_SUBTYPES, MEMORY_SUBTYPES, PATTERN_SUBTYPES, titleCase } from '../lib/theme.js';
+
+function FilterGroup({ title, group, values }) {
+  const filters = useGraphStore((state) => state.activeFilters[group]);
+  const toggleFilter = useGraphStore((state) => state.toggleFilter);
+
+  return (
+    <section className="drawer-section">
+      <div className="section-head">
+        <h3>{title}</h3>
+      </div>
+      <div className="toggle-grid">
+        {values.map((value) => (
+          <button
+            key={value}
+            type="button"
+            className={`toggle-chip ${filters[value] ? 'is-active' : ''}`}
+            onClick={() => toggleFilter(group, value)}
+          >
+            {titleCase(value)}
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function FilterDrawer() {
+  const filtersOpen = useGraphStore((state) => state.filtersOpen);
+  const setFiltersOpen = useGraphStore((state) => state.setFiltersOpen);
+  const resetFilters = useGraphStore((state) => state.resetFilters);
+
+  if (!filtersOpen) return null;
+
+  return (
+    <div className="drawer-backdrop" onClick={() => setFiltersOpen(false)}>
+      <aside className="drawer-shell" onClick={(event) => event.stopPropagation()}>
+        <div className="drawer-head">
+          <div>
+            <div className="section-label">Filter Matrix</div>
+            <h2>Subtype visibility</h2>
+          </div>
+          <div className="inline-actions">
+            <button type="button" className="command-button" onClick={resetFilters}>Reset</button>
+            <button type="button" className="command-button" onClick={() => setFiltersOpen(false)}>Close</button>
+          </div>
+        </div>
+        <FilterGroup title="Entities" group="entities" values={ENTITY_SUBTYPES} />
+        <FilterGroup title="Memories" group="memories" values={MEMORY_SUBTYPES} />
+        <FilterGroup title="Patterns" group="patterns" values={PATTERN_SUBTYPES} />
+      </aside>
+    </div>
+  );
+}
+

--- a/visualizer/src/components/GraphViewport.jsx
+++ b/visualizer/src/components/GraphViewport.jsx
@@ -1,0 +1,137 @@
+import { useEffect, useMemo } from 'react';
+import { BrainScene } from '../engine/BrainScene.jsx';
+import {
+  buildInteractionContext,
+  buildVisibleGraphData,
+  mergeGraphData
+} from '../lib/graphAdapters.js';
+import { formatRelative, scorePercent, titleCase } from '../lib/theme.js';
+import { useGraphStore } from '../store/useGraphStore.js';
+
+function previewBody(node) {
+  const text = String(node?.description || '').trim();
+  if (text) return text;
+  return 'No additional note stored.';
+}
+
+export function GraphViewport({ onTimelineRange }) {
+  const overviewGraph = useGraphStore((state) => state.overviewGraph);
+  const neighborhoodGraph = useGraphStore((state) => state.neighborhoodGraph);
+  const traceGraph = useGraphStore((state) => state.traceGraph);
+  const selectedNodeId = useGraphStore((state) => state.selectedNodeId);
+  const hoveredNodeId = useGraphStore((state) => state.hoveredNodeId);
+  const pinnedNodeIds = useGraphStore((state) => state.pinnedNodeIds);
+  const activeFilters = useGraphStore((state) => state.activeFilters);
+  const renderSettings = useGraphStore((state) => state.renderSettings);
+  const graphMode = useGraphStore((state) => state.graphMode);
+  const tracePath = useGraphStore((state) => state.tracePath);
+  const traceEndpoints = useGraphStore((state) => state.traceEndpoints);
+  const cameraTarget = useGraphStore((state) => state.cameraTarget);
+  const cameraState = useGraphStore((state) => state.cameraState);
+  const fitNonce = useGraphStore((state) => state.fitNonce);
+  const timelineWindow = useGraphStore((state) => state.timelineWindow);
+  const themeId = useGraphStore((state) => state.themeId);
+  const sceneQuality = useGraphStore((state) => state.sceneQuality);
+  const reheatToken = useGraphStore((state) => state.layoutState.reheatToken);
+  const selectNode = useGraphStore((state) => state.selectNode);
+  const setHoveredNode = useGraphStore((state) => state.setHoveredNode);
+  const clearSelection = useGraphStore((state) => state.clearSelection);
+
+  const activeGraph = useMemo(() => {
+    if (graphMode === 'trace' && traceGraph) return mergeGraphData(overviewGraph, traceGraph);
+    if ((graphMode === 'neighborhood' || graphMode === 'evidence') && neighborhoodGraph) {
+      return mergeGraphData(overviewGraph, neighborhoodGraph);
+    }
+    return overviewGraph;
+  }, [graphMode, neighborhoodGraph, overviewGraph, traceGraph]);
+
+  const visibleGraph = useMemo(() => buildVisibleGraphData(activeGraph, {
+    activeFilters,
+    renderSettings,
+    selectedNodeId,
+    hoveredNodeId,
+    pinnedNodeIds,
+    traceEndpoints,
+    timelineWindow,
+    graphMode
+  }, themeId), [
+    activeFilters,
+    activeGraph,
+    graphMode,
+    hoveredNodeId,
+    pinnedNodeIds,
+    renderSettings,
+    selectedNodeId,
+    themeId,
+    timelineWindow,
+    traceEndpoints
+  ]);
+
+  const interactionContext = useMemo(() => buildInteractionContext(visibleGraph, {
+    selectedNodeId,
+    hoveredNodeId,
+    pinnedNodeIds,
+    graphMode,
+    tracePath,
+    renderSettings
+  }), [
+    graphMode,
+    hoveredNodeId,
+    pinnedNodeIds,
+    renderSettings,
+    selectedNodeId,
+    tracePath,
+    visibleGraph
+  ]);
+
+  const previewNode = hoveredNodeId
+    ? visibleGraph.nodeMap.get(hoveredNodeId) || null
+    : selectedNodeId
+      ? visibleGraph.nodeMap.get(selectedNodeId) || null
+      : null;
+
+  useEffect(() => {
+    onTimelineRange?.(visibleGraph.timelineRange);
+  }, [onTimelineRange, visibleGraph.timelineRange]);
+
+  return (
+    <section className="graph-viewport">
+      <BrainScene
+        graph={visibleGraph}
+        interactionContext={interactionContext}
+        themeId={themeId}
+        renderSettings={renderSettings}
+        sceneQuality={sceneQuality}
+        reheatToken={reheatToken}
+        cameraTarget={cameraTarget}
+        cameraMode={cameraState.mode}
+        fitNonce={fitNonce}
+        selectedNodeId={selectedNodeId}
+        onNodeSelect={selectNode}
+        onNodeHover={setHoveredNode}
+        onBackgroundClick={clearSelection}
+      />
+
+      <div className="viewport-overlay viewport-overlay-top">
+        <span>Mode {titleCase(graphMode)}</span>
+        <strong>{visibleGraph.counts.totalNodes} nodes / {visibleGraph.counts.totalEdges} links</strong>
+      </div>
+
+      <div className="viewport-overlay viewport-overlay-right">
+        <span>Shift-click two entities to trace</span>
+      </div>
+
+      {previewNode ? (
+        <div className="hover-panel">
+          <span>{titleCase(previewNode.kind)} / {titleCase(previewNode.subtype)}</span>
+          <strong>{previewNode.label}</strong>
+          <div className="hover-panel-body">{previewBody(previewNode)}</div>
+          <div className="hover-metrics">
+            <span>Signal {scorePercent(previewNode.signalScore)}</span>
+            <span>{formatRelative(previewNode.timestamps?.deadlineAt || previewNode.timestamps?.activityAt)}</span>
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/visualizer/src/components/LeftSidebar.jsx
+++ b/visualizer/src/components/LeftSidebar.jsx
@@ -1,0 +1,155 @@
+import { useMemo } from 'react';
+import { alpha, formatDateShort, kindLabel, resultTone, titleCase, trunc } from '../lib/theme.js';
+import { useGraphStore } from '../store/useGraphStore.js';
+
+function FilterGroup({ title, items, group, onToggle }) {
+  return (
+    <section className="panel-block">
+      <div className="panel-heading">
+        <span>{title}</span>
+      </div>
+      <div className="filter-list">
+        {Object.entries(items).map(([key, enabled]) => (
+          <button
+            key={key}
+            className={`filter-pill ${enabled ? 'is-active' : ''}`}
+            onClick={() => onToggle(group, key)}
+          >
+            {titleCase(key)}
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function LeftSidebar() {
+  const stats = useGraphStore((state) => state.stats);
+  const searchQuery = useGraphStore((state) => state.searchQuery);
+  const searchResults = useGraphStore((state) => state.searchResults);
+  const activeFilters = useGraphStore((state) => state.activeFilters);
+  const commitmentFeed = useGraphStore((state) => state.commitmentFeed);
+  const setSearchQuery = useGraphStore((state) => state.setSearchQuery);
+  const selectNode = useGraphStore((state) => state.selectNode);
+  const toggleFilter = useGraphStore((state) => state.toggleFilter);
+  const resetFilters = useGraphStore((state) => state.resetFilters);
+  const themeId = useGraphStore((state) => state.themeId);
+  const renderSettings = useGraphStore((state) => state.renderSettings);
+  const setRenderSetting = useGraphStore((state) => state.setRenderSetting);
+
+  const quickResults = useMemo(() => searchResults.slice(0, 6), [searchResults]);
+
+  return (
+    <aside className="side-panel left-sidebar">
+      <section className="panel-block">
+        <div className="panel-heading">
+          <span>Search</span>
+          <strong>Browse memory</strong>
+        </div>
+        <input
+          className="panel-input"
+          value={searchQuery}
+          onChange={(event) => setSearchQuery(event.target.value)}
+          placeholder="Search entities, commitments, patterns..."
+        />
+        <div className="result-stack">
+          {quickResults.length ? quickResults.map((result) => {
+            const tone = resultTone(result, themeId, renderSettings);
+            return (
+              <button
+                key={result.id}
+                className="result-row result-toned"
+                style={{
+                  '--result-tone': tone,
+                  '--result-tone-soft': alpha(tone, 0.14),
+                  '--result-tone-border': alpha(tone, 0.42)
+                }}
+                onClick={() => selectNode(result.id)}
+              >
+                <span>{kindLabel(result.kind)} / {titleCase(result.subtype)}</span>
+                <strong>{result.label}</strong>
+                <span>{trunc(result.description, 84)}</span>
+              </button>
+            );
+          }) : (
+            <div className="empty-inline">Type to search the local graph.</div>
+          )}
+        </div>
+      </section>
+
+      <section className="panel-block">
+        <div className="panel-heading">
+          <span>Overview</span>
+          <strong>Graph statistics</strong>
+        </div>
+        <div className="metric-grid">
+          <div className="metric-card"><span>Entities</span><strong>{stats?.entities ?? 0}</strong></div>
+          <div className="metric-card"><span>Memories</span><strong>{stats?.memories ?? 0}</strong></div>
+          <div className="metric-card"><span>Links</span><strong>{stats?.relationships ?? 0}</strong></div>
+          <div className="metric-card"><span>Patterns</span><strong>{stats?.patterns ?? 0}</strong></div>
+        </div>
+      </section>
+
+      <section className="panel-block">
+        <div className="panel-heading">
+          <span>Entity Breakdown</span>
+          <strong>By subtype</strong>
+        </div>
+        <div className="breakdown-list">
+          {(stats?.entityTypes || []).map((entry) => (
+            <div key={entry.type} className="breakdown-row">
+              <span>{titleCase(entry.type)}</span>
+              <strong>{entry.count}</strong>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="panel-block">
+        <div className="panel-heading">
+          <span>Memory Layer</span>
+          <strong>{renderSettings.showOverviewMemories ? 'Overview visible' : 'Overview hidden'}</strong>
+        </div>
+        <div className="inline-actions">
+          <button
+            className={`panel-button panel-button-wide ${renderSettings.showOverviewMemories ? 'is-active' : ''}`}
+            onClick={() => setRenderSetting('showOverviewMemories', !renderSettings.showOverviewMemories)}
+          >
+            {renderSettings.showOverviewMemories ? 'Hide overview memories' : 'Show all memory types'}
+          </button>
+        </div>
+        <div className="empty-inline">
+          Toggle the full memory layer, then use the subtype pills below to hide individual kinds.
+        </div>
+      </section>
+
+      <FilterGroup title="Entity Types" items={activeFilters.entities} group="entities" onToggle={toggleFilter} />
+      <FilterGroup title="Memory Types" items={activeFilters.memories} group="memories" onToggle={toggleFilter} />
+      <FilterGroup title="Pattern Types" items={activeFilters.patterns} group="patterns" onToggle={toggleFilter} />
+
+      <section className="panel-block">
+        <div className="panel-heading">
+          <span>Filters</span>
+          <strong>Reset visibility</strong>
+        </div>
+        <button className="panel-button panel-button-wide" onClick={resetFilters}>Reset Filters</button>
+      </section>
+
+      <section className="panel-block">
+        <div className="panel-heading">
+          <span>Commitments</span>
+          <strong>Active feed</strong>
+        </div>
+        <div className="result-stack">
+          {commitmentFeed.slice(0, 8).map((item) => (
+            <button key={item.id} className="result-row commitment-row" onClick={() => selectNode(item.id)}>
+              <span>{formatDateShort(item.timestamps?.deadlineAt || item.timestamps?.activityAt)}</span>
+              <strong>{item.label}</strong>
+              <span>{titleCase(item.status)}</span>
+            </button>
+          ))}
+        </div>
+      </section>
+    </aside>
+  );
+}

--- a/visualizer/src/components/RightInspector.jsx
+++ b/visualizer/src/components/RightInspector.jsx
@@ -1,0 +1,178 @@
+import { formatDateTime, formatRelative, scorePercent, titleCase } from '../lib/theme.js';
+import { SettingsContent } from './SettingsPanel.jsx';
+import {
+  selectSelectedNode,
+  useGraphStore
+} from '../store/useGraphStore.js';
+
+function anchorEntityId(node) {
+  if (!node) return null;
+  if (node.kind === 'entity') return Number(String(node.id).replace('entity-', ''));
+  if (node.anchorRef) return Number(String(node.anchorRef).replace('entity-', ''));
+  return Number(node.entityRefs?.[0] || 0) || null;
+}
+
+export function RightInspector() {
+  const selectedNode = useGraphStore(selectSelectedNode);
+  const entityDetails = useGraphStore((state) => state.entityDetails);
+  const inspectorCommitments = useGraphStore((state) => state.inspectorCommitments);
+  const traceGraph = useGraphStore((state) => state.traceGraph);
+  const graphMode = useGraphStore((state) => state.graphMode);
+  const togglePinNode = useGraphStore((state) => state.togglePinNode);
+  const pinnedNodeIds = useGraphStore((state) => state.pinnedNodeIds);
+  const revealEvidence = useGraphStore((state) => state.revealEvidence);
+  const clearSelection = useGraphStore((state) => state.clearSelection);
+  const selectNode = useGraphStore((state) => state.selectNode);
+  const inspectorOpen = useGraphStore((state) => state.inspectorOpen);
+  const setInspectorOpen = useGraphStore((state) => state.setInspectorOpen);
+  const settingsOpen = useGraphStore((state) => state.settingsOpen);
+  const setSettingsOpen = useGraphStore((state) => state.setSettingsOpen);
+
+  const entityId = anchorEntityId(selectedNode);
+  const detail = entityId ? entityDetails[entityId] : null;
+  const isPinned = selectedNode ? pinnedNodeIds.includes(selectedNode.id) : false;
+
+  return (
+    <aside className={`side-panel right-inspector ${inspectorOpen ? 'is-open' : ''}`}>
+      <div className="inspector-head">
+        <div>
+          <span>{settingsOpen ? 'Settings' : 'Inspector'}</span>
+          <strong>{settingsOpen ? 'Live tuning panel' : (selectedNode?.label || 'No selection')}</strong>
+        </div>
+        <div className="inline-actions">
+          {settingsOpen ? (
+            <button className="inspector-close" onClick={() => setSettingsOpen(false)}>Inspect</button>
+          ) : (
+            <button className="inspector-close" onClick={() => setSettingsOpen(true)}>Tune</button>
+          )}
+          <button className="inspector-close" onClick={() => setInspectorOpen(false)}>Hide</button>
+        </div>
+      </div>
+
+      {settingsOpen ? (
+        <SettingsContent />
+      ) : selectedNode ? (
+        <>
+          <section className="panel-block">
+            <div className="panel-heading">
+              <span>{titleCase(selectedNode.kind)} / {titleCase(selectedNode.subtype)}</span>
+              <strong>Signal {scorePercent(selectedNode.signalScore)}</strong>
+            </div>
+            <p className="inspector-copy">{selectedNode.description || 'No description available for this node.'}</p>
+            <div className="metric-grid">
+              <div className="metric-card"><span>Status</span><strong>{titleCase(selectedNode.status)}</strong></div>
+              <div className="metric-card"><span>Freshness</span><strong>{scorePercent(selectedNode.freshnessScore)}</strong></div>
+              <div className="metric-card"><span>Urgency</span><strong>{scorePercent(selectedNode.urgencyScore)}</strong></div>
+              <div className="metric-card"><span>Activity</span><strong>{formatRelative(selectedNode.timestamps?.activityAt)}</strong></div>
+            </div>
+            <div className="inline-actions">
+              <button className="panel-button" onClick={() => togglePinNode(selectedNode.id)}>
+                {isPinned ? 'Unpin' : 'Pin'}
+              </button>
+              <button className="panel-button" onClick={() => revealEvidence(selectedNode.id)}>Reveal Evidence</button>
+              <button className="panel-button" onClick={clearSelection}>Clear</button>
+            </div>
+          </section>
+
+          {detail ? (
+            <>
+              <section className="panel-block">
+                <div className="panel-heading">
+                  <span>Entity Context</span>
+                  <strong>{detail.entity?.name || 'Anchor entity'}</strong>
+                </div>
+                <div className="info-list">
+                  <div className="info-row"><span>Last updated</span><strong>{formatDateTime(detail.entity?.updated_at)}</strong></div>
+                  <div className="info-row"><span>Memories</span><strong>{detail.memories?.length || 0}</strong></div>
+                  <div className="info-row"><span>Relationships</span><strong>{detail.relationships?.length || 0}</strong></div>
+                </div>
+              </section>
+
+              <section className="panel-block">
+                <div className="panel-heading">
+                  <span>Relationships</span>
+                  <strong>Top linked entities</strong>
+                </div>
+                <div className="result-stack">
+                  {(detail.relationships || []).slice(0, 8).map((relationship) => (
+                    <button
+                      key={`${relationship.id}-${relationship.other_id}`}
+                      className="result-row"
+                      onClick={() => selectNode(`entity-${relationship.other_id}`)}
+                    >
+                      <span>{titleCase(relationship.relationship_type || relationship.direction)}</span>
+                      <strong>{relationship.other_name}</strong>
+                      <span>Strength {Number(relationship.strength || 0).toFixed(2)}</span>
+                    </button>
+                  ))}
+                </div>
+              </section>
+
+              <section className="panel-block">
+                <div className="panel-heading">
+                  <span>Evidence</span>
+                  <strong>Recent memory</strong>
+                </div>
+                <div className="result-stack">
+                  {(detail.memories || []).slice(0, 10).map((memory) => (
+                    <button
+                      key={memory.id}
+                      className="result-row"
+                      onClick={() => selectNode(`memory-${memory.id}`)}
+                    >
+                      <span>{titleCase(memory.type)}</span>
+                      <div className="result-copy">{memory.content || 'No memory content stored.'}</div>
+                      <span>{formatDateTime(memory.updated_at || memory.created_at)}</span>
+                    </button>
+                  ))}
+                </div>
+              </section>
+            </>
+          ) : null}
+
+          {inspectorCommitments.length ? (
+            <section className="panel-block">
+              <div className="panel-heading">
+                <span>Commitments</span>
+                <strong>Active obligations</strong>
+              </div>
+              <div className="result-stack">
+                {inspectorCommitments.map((item) => (
+                  <button key={item.id} className="result-row commitment-row" onClick={() => selectNode(item.id)}>
+                    <span>{formatDateTime(item.timestamps?.deadlineAt || item.timestamps?.activityAt)}</span>
+                    <div className="result-copy">{item.description || item.label}</div>
+                    <span>{titleCase(item.status)}</span>
+                  </button>
+                ))}
+              </div>
+            </section>
+          ) : null}
+
+          {graphMode === 'trace' && traceGraph?.evidence?.length ? (
+            <section className="panel-block">
+              <div className="panel-heading">
+                <span>Trace Support</span>
+                <strong>Path evidence</strong>
+              </div>
+              <div className="result-stack">
+                {traceGraph.evidence.map((item) => (
+                  <button key={item.id} className="result-row" onClick={() => selectNode(item.id)}>
+                    <span>{titleCase(item.kind)} / {titleCase(item.subtype)}</span>
+                    <div className="result-copy">{item.description || item.label}</div>
+                    <span>{item.entityRefs?.length || 0} anchors</span>
+                  </button>
+                ))}
+              </div>
+            </section>
+          ) : null}
+        </>
+      ) : (
+        <section className="panel-block">
+          <div className="empty-inline">
+            Select a node to inspect its local relationships, linked evidence, and active commitments.
+          </div>
+        </section>
+      )}
+    </aside>
+  );
+}

--- a/visualizer/src/components/SearchPalette.jsx
+++ b/visualizer/src/components/SearchPalette.jsx
@@ -1,0 +1,65 @@
+import { useEffect, useRef } from 'react';
+import { alpha, kindLabel, resultTone, titleCase, trunc } from '../lib/theme.js';
+import { useGraphStore } from '../store/useGraphStore.js';
+
+export function SearchPalette() {
+  const inputRef = useRef(null);
+  const searchOpen = useGraphStore((state) => state.searchOpen);
+  const searchQuery = useGraphStore((state) => state.searchQuery);
+  const searchResults = useGraphStore((state) => state.searchResults);
+  const setSearchOpen = useGraphStore((state) => state.setSearchOpen);
+  const setSearchQuery = useGraphStore((state) => state.setSearchQuery);
+  const selectNode = useGraphStore((state) => state.selectNode);
+  const themeId = useGraphStore((state) => state.themeId);
+  const renderSettings = useGraphStore((state) => state.renderSettings);
+
+  useEffect(() => {
+    if (searchOpen && inputRef.current) {
+      window.setTimeout(() => inputRef.current?.focus(), 10);
+    }
+  }, [searchOpen]);
+
+  if (!searchOpen) return null;
+
+  return (
+    <div className="overlay-backdrop" onClick={() => setSearchOpen(false)}>
+      <div className="overlay-panel search-panel" onClick={(event) => event.stopPropagation()}>
+        <div className="panel-heading">
+          <span>Search Palette</span>
+          <strong>Jump to graph nodes</strong>
+        </div>
+        <input
+          ref={inputRef}
+          className="panel-input panel-input-large"
+          value={searchQuery}
+          onChange={(event) => setSearchQuery(event.target.value)}
+          placeholder="Search the local Claudia database"
+        />
+        <div className="result-stack">
+          {searchResults.map((result) => {
+            const tone = resultTone(result, themeId, renderSettings);
+            return (
+              <button
+                key={result.id}
+                className="result-row result-toned"
+                style={{
+                  '--result-tone': tone,
+                  '--result-tone-soft': alpha(tone, 0.14),
+                  '--result-tone-border': alpha(tone, 0.42)
+                }}
+                onClick={async () => {
+                  await selectNode(result.id);
+                  setSearchOpen(false);
+                }}
+              >
+                <span>{kindLabel(result.kind)} / {titleCase(result.subtype)}</span>
+                <strong>{result.label}</strong>
+                <span>{trunc(result.description, 110)}</span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/visualizer/src/components/SettingsPanel.jsx
+++ b/visualizer/src/components/SettingsPanel.jsx
@@ -1,0 +1,258 @@
+import { useRef } from 'react';
+import { APP_THEMES } from '../lib/theme.js';
+import { useGraphStore } from '../store/useGraphStore.js';
+
+function Slider({ label, value, min, max, step = 0.05, onChange }) {
+  return (
+    <label className="settings-control settings-slider">
+      <div className="slider-head">
+        <span>{label}</span>
+        <strong>{typeof value === 'number' ? value.toFixed(2) : value}</strong>
+      </div>
+      <input type="range" min={min} max={max} step={step} value={value} onChange={onChange} />
+    </label>
+  );
+}
+
+function Toggle({ label, active, onClick }) {
+  return (
+    <button className={`filter-pill ${active ? 'is-active' : ''}`} onClick={onClick}>
+      {label}
+    </button>
+  );
+}
+
+function ColorField({ label, value, onChange }) {
+  return (
+    <label className="settings-color-field">
+      <span>{label}</span>
+      <div className="settings-color-input">
+        <input type="color" value={value} onChange={onChange} />
+        <code>{value}</code>
+      </div>
+    </label>
+  );
+}
+
+function Group({ eyebrow, title, children }) {
+  return (
+    <section className="settings-section">
+      <div className="panel-heading">
+        <span>{eyebrow}</span>
+        <strong>{title}</strong>
+      </div>
+      <div className="settings-stack">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+function Note({ children }) {
+  return <div className="settings-note">{children}</div>;
+}
+
+export function SettingsContent() {
+  const fileInputRef = useRef(null);
+  const themeId = useGraphStore((state) => state.themeId);
+  const renderSettings = useGraphStore((state) => state.renderSettings);
+  const sceneQuality = useGraphStore((state) => state.sceneQuality);
+  const setRenderSetting = useGraphStore((state) => state.setRenderSetting);
+  const setSceneEffectsEnabled = useGraphStore((state) => state.setSceneEffectsEnabled);
+  const setSceneQualityMode = useGraphStore((state) => state.setSceneQualityMode);
+  const resetRenderSettings = useGraphStore((state) => state.resetRenderSettings);
+  const applySettingsPreset = useGraphStore((state) => state.applySettingsPreset);
+
+  const exportSettings = () => {
+    const payload = {
+      version: 1,
+      exportedAt: new Date().toISOString(),
+      themeId,
+      renderSettings,
+      sceneQuality
+    };
+    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+    const url = window.URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = `claudia-graph-settings-${themeId}.json`;
+    anchor.click();
+    window.URL.revokeObjectURL(url);
+  };
+
+  const importSettings = async (event) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    try {
+      const text = await file.text();
+      const preset = JSON.parse(text);
+      applySettingsPreset(preset);
+    } catch {
+      window.alert('Could not import settings file.');
+    } finally {
+      event.target.value = '';
+    }
+  };
+
+  return (
+    <div className="settings-panel-inline">
+      <div className="panel-heading">
+        <span>Instrument Controls</span>
+        <strong>Saved locally</strong>
+      </div>
+
+      <div className="inline-actions">
+        <button className="panel-button" onClick={exportSettings}>Export settings</button>
+        <button className="panel-button" onClick={() => fileInputRef.current?.click()}>Import settings</button>
+        <button className="panel-button" onClick={resetRenderSettings}>Reset defaults</button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="application/json"
+          className="settings-file-input"
+          onChange={importSettings}
+        />
+      </div>
+
+      <Group eyebrow="Theme" title="Preset selection">
+        <Note>Switch the full visual system here. Scene colors, node tones, grid, fog, and highlights update together.</Note>
+        <label className="settings-control">
+          <div className="slider-head">
+            <span>Active theme</span>
+            <strong>{APP_THEMES[themeId]?.label || themeId}</strong>
+          </div>
+          <select
+            className="panel-input"
+            value={themeId}
+            onChange={(event) => applySettingsPreset({ themeId: event.target.value })}
+          >
+            {Object.values(APP_THEMES).map((theme) => (
+              <option key={theme.id} value={theme.id}>{theme.label}</option>
+            ))}
+          </select>
+        </label>
+        <label className="settings-control">
+          <div className="slider-head">
+            <span>Quality mode</span>
+            <strong>{sceneQuality.quality}</strong>
+          </div>
+          <select className="panel-input" value={sceneQuality.quality} onChange={(event) => setSceneQualityMode(event.target.value)}>
+            <option value="auto">Auto</option>
+            <option value="quality">Quality</option>
+            <option value="balanced">Balanced</option>
+            <option value="performance">Performance</option>
+          </select>
+        </label>
+      </Group>
+
+      <Group eyebrow="Nodes" title="Hierarchy and readability">
+        <Note>These control the scale balance between entities, memory nodes, and labels.</Note>
+        <Slider label="Entity size" value={renderSettings.entitySize} min={0.55} max={1.9} onChange={(event) => setRenderSetting('entitySize', Number(event.target.value))} />
+        <Slider label="Memory size" value={renderSettings.memorySize} min={0.45} max={1.5} onChange={(event) => setRenderSetting('memorySize', Number(event.target.value))} />
+        <Slider label="Pattern size" value={renderSettings.patternSize} min={0.45} max={1.5} onChange={(event) => setRenderSetting('patternSize', Number(event.target.value))} />
+        <Slider label="Node opacity" value={renderSettings.nodeOpacity} min={0.45} max={1.25} onChange={(event) => setRenderSetting('nodeOpacity', Number(event.target.value))} />
+        <Slider label="Label scale" value={renderSettings.labelScale} min={0.9} max={1.8} onChange={(event) => setRenderSetting('labelScale', Number(event.target.value))} />
+        <Slider label="Trace emphasis" value={renderSettings.traceEmphasis} min={1} max={2.4} onChange={(event) => setRenderSetting('traceEmphasis', Number(event.target.value))} />
+        <div className="settings-row">
+          <span className="hud-meta-label">Label Mode</span>
+          <div className="filter-list compact-list compact-list-3">
+            {['minimal', 'balanced', 'dense'].map((mode) => (
+              <Toggle key={mode} label={mode} active={renderSettings.labelMode === mode} onClick={() => setRenderSetting('labelMode', mode)} />
+            ))}
+          </div>
+        </div>
+      </Group>
+
+      <Group eyebrow="Lines" title="Connections and emphasis">
+        <Note>Use these for relationship readability. Changes should apply live to the graph without reload.</Note>
+        <Slider label="Line thickness" value={renderSettings.lineThickness} min={0.6} max={2.4} onChange={(event) => setRenderSetting('lineThickness', Number(event.target.value))} />
+        <Slider label="Selected thickness" value={renderSettings.selectedLineThickness} min={1} max={3} onChange={(event) => setRenderSetting('selectedLineThickness', Number(event.target.value))} />
+        <Slider label="Line opacity" value={renderSettings.edgeOpacity} min={0.35} max={1.35} onChange={(event) => setRenderSetting('edgeOpacity', Number(event.target.value))} />
+        <Slider label="Curve amount" value={renderSettings.lineCurvature} min={0} max={1.8} onChange={(event) => setRenderSetting('lineCurvature', Number(event.target.value))} />
+        <Slider label="Line intensity" value={renderSettings.edgeIntensity} min={0.4} max={2.2} onChange={(event) => setRenderSetting('edgeIntensity', Number(event.target.value))} />
+      </Group>
+
+      <Group eyebrow="Environment" title="Fog and grid">
+        <Note>These affect the floor reference plane and background atmosphere. They now remount live so changes are visible immediately.</Note>
+        <Slider label="Fog near" value={renderSettings.fogNear} min={0.35} max={1.8} onChange={(event) => setRenderSetting('fogNear', Number(event.target.value))} />
+        <Slider label="Fog far" value={renderSettings.fogFar} min={0.5} max={2.4} onChange={(event) => setRenderSetting('fogFar', Number(event.target.value))} />
+        <Slider label="Grid opacity" value={renderSettings.gridOpacity} min={0.08} max={0.8} onChange={(event) => setRenderSetting('gridOpacity', Number(event.target.value))} />
+        <Slider label="Grid density" value={renderSettings.gridDensity} min={0.55} max={2.4} onChange={(event) => setRenderSetting('gridDensity', Number(event.target.value))} />
+      </Group>
+
+      <Group eyebrow="Camera" title="Focus and motion">
+        <Note>Camera changes are live. Use low values for calmer orbit behavior.</Note>
+        <Slider label="Camera speed" value={renderSettings.cameraMoveSpeed} min={0.5} max={1.8} onChange={(event) => setRenderSetting('cameraMoveSpeed', Number(event.target.value))} />
+        <Slider label="Orbit speed" value={renderSettings.autoRotateSpeed} min={0.1} max={2} onChange={(event) => setRenderSetting('autoRotateSpeed', Number(event.target.value))} />
+        <div className="settings-row">
+          <span className="hud-meta-label">Motion</span>
+          <div className="filter-list compact-list">
+            {['full', 'restrained', 'reduced'].map((mode) => (
+              <Toggle key={mode} label={mode} active={renderSettings.motionLevel === mode} onClick={() => setRenderSetting('motionLevel', mode)} />
+            ))}
+          </div>
+        </div>
+        <div className="settings-row">
+          <span className="hud-meta-label">Orbit</span>
+          <div className="filter-list compact-list">
+            <Toggle label="Focus orbit" active={renderSettings.autoRotateEnabled} onClick={() => setRenderSetting('autoRotateEnabled', !renderSettings.autoRotateEnabled)} />
+            <Toggle label="Global orbit" active={renderSettings.autoRotateGlobal} onClick={() => setRenderSetting('autoRotateGlobal', !renderSettings.autoRotateGlobal)} />
+          </div>
+        </div>
+      </Group>
+
+      <Group eyebrow="Post FX" title="Bloom, chromatic, particles">
+        <Note>These are the cinematic accents. Reduce them if you want a sharper analytical look.</Note>
+        <Slider label="Bloom" value={renderSettings.bloomStrength} min={0} max={2.2} onChange={(event) => setRenderSetting('bloomStrength', Number(event.target.value))} />
+        <Slider label="Chromatic" value={renderSettings.chromaticStrength} min={0} max={2.2} onChange={(event) => setRenderSetting('chromaticStrength', Number(event.target.value))} />
+        <Slider label="Particle speed" value={renderSettings.particleSpeed} min={0.2} max={2.4} onChange={(event) => setRenderSetting('particleSpeed', Number(event.target.value))} />
+        <Slider label="Particle size" value={renderSettings.particleSize} min={0.4} max={2} onChange={(event) => setRenderSetting('particleSize', Number(event.target.value))} />
+        <div className="settings-row">
+          <span className="hud-meta-label">Visibility</span>
+          <div className="filter-list compact-list">
+            <Toggle label="Overview memories" active={renderSettings.showOverviewMemories} onClick={() => setRenderSetting('showOverviewMemories', !renderSettings.showOverviewMemories)} />
+            <Toggle label="Commitments" active={renderSettings.showCommitments} onClick={() => setRenderSetting('showCommitments', !renderSettings.showCommitments)} />
+            <Toggle label="Patterns" active={renderSettings.showPatterns} onClick={() => setRenderSetting('showPatterns', !renderSettings.showPatterns)} />
+            <Toggle label="Effects" active={sceneQuality.effectsEnabled} onClick={() => setSceneEffectsEnabled(!sceneQuality.effectsEnabled)} />
+            <Toggle label="Particles" active={renderSettings.showParticles} onClick={() => setRenderSetting('showParticles', !renderSettings.showParticles)} />
+          </div>
+        </div>
+      </Group>
+
+      <Group eyebrow="Entity Colors" title="Subtype overrides">
+        <Note>Override the default theme colors for the three primary entity classes.</Note>
+        <div className="settings-colors settings-colors-stack">
+          <ColorField label="People" value={renderSettings.personColor} onChange={(event) => setRenderSetting('personColor', event.target.value)} />
+          <ColorField label="Organizations" value={renderSettings.organizationColor} onChange={(event) => setRenderSetting('organizationColor', event.target.value)} />
+          <ColorField label="Projects" value={renderSettings.projectColor} onChange={(event) => setRenderSetting('projectColor', event.target.value)} />
+        </div>
+      </Group>
+
+      <Group eyebrow="Memory Nodes" title="Memory and commitment design">
+        <Note>These customize the secondary node families without changing the entity palette.</Note>
+        <div className="settings-colors settings-colors-stack">
+          <ColorField label="Memories" value={renderSettings.memoryColor} onChange={(event) => setRenderSetting('memoryColor', event.target.value)} />
+          <ColorField label="Commitments" value={renderSettings.commitmentColor} onChange={(event) => setRenderSetting('commitmentColor', event.target.value)} />
+        </div>
+        <div className="settings-row">
+          <span className="hud-meta-label">Memory shape</span>
+          <div className="filter-list compact-list">
+            <Toggle label="Orb" active={renderSettings.memoryStyle === 'orb'} onClick={() => setRenderSetting('memoryStyle', 'orb')} />
+            <Toggle label="Shard" active={renderSettings.memoryStyle === 'shard'} onClick={() => setRenderSetting('memoryStyle', 'shard')} />
+          </div>
+        </div>
+        <div className="settings-row">
+          <span className="hud-meta-label">Commitment shape</span>
+          <div className="filter-list compact-list">
+            <Toggle label="Beacon" active={renderSettings.commitmentStyle === 'beacon'} onClick={() => setRenderSetting('commitmentStyle', 'beacon')} />
+            <Toggle label="Diamond" active={renderSettings.commitmentStyle === 'diamond'} onClick={() => setRenderSetting('commitmentStyle', 'diamond')} />
+          </div>
+        </div>
+      </Group>
+    </div>
+  );
+}
+
+export function SettingsPanel() {
+  return null;
+}

--- a/visualizer/src/components/TopHudBar.jsx
+++ b/visualizer/src/components/TopHudBar.jsx
@@ -1,0 +1,117 @@
+import { APP_THEMES } from '../lib/theme.js';
+import { useGraphStore } from '../store/useGraphStore.js';
+import { DatabaseSwitcher } from './DatabaseSwitcher.jsx';
+
+export function TopHudBar() {
+  const stats = useGraphStore((state) => state.stats);
+  const graphMode = useGraphStore((state) => state.graphMode);
+  const traceGraph = useGraphStore((state) => state.traceGraph);
+  const themeId = useGraphStore((state) => state.themeId);
+  const loadingState = useGraphStore((state) => state.loadingState);
+  const errorMessage = useGraphStore((state) => state.errorMessage);
+  const setGraphMode = useGraphStore((state) => state.setGraphMode);
+  const clearTrace = useGraphStore((state) => state.clearTrace);
+  const requestFit = useGraphStore((state) => state.requestFit);
+  const clearSelection = useGraphStore((state) => state.clearSelection);
+  const setSearchOpen = useGraphStore((state) => state.setSearchOpen);
+  const setSettingsOpen = useGraphStore((state) => state.setSettingsOpen);
+  const setInspectorOpen = useGraphStore((state) => state.setInspectorOpen);
+  const setTheme = useGraphStore((state) => state.setTheme);
+  const leftPanelOpen = useGraphStore((state) => state.leftPanelOpen);
+  const inspectorOpen = useGraphStore((state) => state.inspectorOpen);
+  const bottomPanelOpen = useGraphStore((state) => state.bottomPanelOpen);
+  const toggleLeftPanel = useGraphStore((state) => state.toggleLeftPanel);
+  const toggleRightPanel = useGraphStore((state) => state.toggleRightPanel);
+  const toggleBottomPanel = useGraphStore((state) => state.toggleBottomPanel);
+
+  const activeLoading = Object.values(loadingState).some(Boolean);
+
+  return (
+    <header className="top-hud">
+      <div className="hud-brand">
+        <img src="/claudia-logo.png" alt="Claudia" className="hud-logo" />
+        <div className="hud-brand-copy">
+          <strong>Claudia Brain</strong>
+          <span>3D knowledge instrument</span>
+        </div>
+        <DatabaseSwitcher />
+      </div>
+
+      <div className="hud-mode-strip">
+        <button
+          className={`hud-chip ${graphMode === 'overview' ? 'is-active' : ''}`}
+          onClick={() => {
+            clearTrace();
+            setGraphMode('overview');
+          }}
+        >
+          Overview
+        </button>
+        <button
+          className={`hud-chip ${graphMode === 'neighborhood' || graphMode === 'evidence' ? 'is-active' : ''}`}
+          onClick={() => setGraphMode('neighborhood')}
+        >
+          Inspect
+        </button>
+        <button
+          className={`hud-chip ${graphMode === 'trace' ? 'is-active' : ''}`}
+          onClick={() => {
+            if (traceGraph) setGraphMode('trace');
+          }}
+          disabled={!traceGraph}
+        >
+          Trace
+        </button>
+      </div>
+
+      <div className="hud-stats">
+        <div className="hud-stat">
+          <span>Entities</span>
+          <strong>{stats?.entities ?? 0}</strong>
+        </div>
+        <div className="hud-stat">
+          <span>Memories</span>
+          <strong>{stats?.memories ?? 0}</strong>
+        </div>
+        <div className="hud-stat">
+          <span>Patterns</span>
+          <strong>{stats?.patterns ?? 0}</strong>
+        </div>
+        <div className="hud-stat hud-stat-optional">
+          <span>Links</span>
+          <strong>{stats?.relationships ?? 0}</strong>
+        </div>
+      </div>
+
+      <div className="hud-actions">
+        <label className="hud-theme">
+          <span className="hud-meta-label">Theme</span>
+          <select
+            className="hud-select"
+            value={themeId}
+            onChange={(event) => setTheme(event.target.value)}
+          >
+            {Object.values(APP_THEMES).map((theme) => (
+              <option key={theme.id} value={theme.id}>
+                {theme.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <button className={`hud-button ${leftPanelOpen ? 'is-active' : ''}`} onClick={toggleLeftPanel}>Left</button>
+        <button className={`hud-button ${inspectorOpen ? 'is-active' : ''}`} onClick={toggleRightPanel}>Right</button>
+        <button className={`hud-button ${bottomPanelOpen ? 'is-active' : ''}`} onClick={toggleBottomPanel}>Bottom</button>
+        <button className="hud-button" onClick={() => setSearchOpen(true)}>Search</button>
+        <button className="hud-button" onClick={requestFit}>Fit</button>
+        <button className="hud-button" onClick={clearSelection}>Clear</button>
+        <button className="hud-button" onClick={() => {
+          setInspectorOpen(true);
+          setSettingsOpen(true);
+        }}>Settings</button>
+        <div className={`hud-status ${errorMessage ? 'is-error' : activeLoading ? 'is-loading' : ''}`}>
+          {errorMessage || (activeLoading ? 'Syncing' : 'Live')}
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/visualizer/src/engine/BrainScene.jsx
+++ b/visualizer/src/engine/BrainScene.jsx
@@ -1,0 +1,104 @@
+import { Canvas } from '@react-three/fiber';
+import { useMemo } from 'react';
+import { EdgeLayer } from './EdgeLayer.jsx';
+import { InstrumentCamera } from './InstrumentCamera.jsx';
+import { LabelLayer } from './LabelLayer.jsx';
+import { NodeGlyphs } from './NodeGlyphs.jsx';
+import { SceneFx } from './SceneFx.jsx';
+import { useGraphLayout } from './useGraphLayout.js';
+
+function centerFor(nodeIds, positions) {
+  const resolved = nodeIds.map((id) => positions[id]).filter(Boolean);
+  if (!resolved.length) return { x: 0, y: 0, z: 0 };
+
+  const totals = resolved.reduce((acc, point) => ({
+    x: acc.x + point.x,
+    y: acc.y + point.y,
+    z: acc.z + point.z
+  }), { x: 0, y: 0, z: 0 });
+
+  return {
+    x: totals.x / resolved.length,
+    y: totals.y / resolved.length,
+    z: totals.z / resolved.length
+  };
+}
+
+export function BrainScene({
+  graph,
+  interactionContext,
+  themeId,
+  renderSettings,
+  sceneQuality,
+  reheatToken,
+  cameraTarget,
+  cameraMode,
+  fitNonce,
+  selectedNodeId,
+  onNodeSelect,
+  onNodeHover,
+  onBackgroundClick
+}) {
+  const { positions, rawPositions } = useGraphLayout(graph, reheatToken, renderSettings);
+  const qualityMode = sceneQuality?.quality || 'balanced';
+  const qualityDpr = qualityMode === 'quality'
+    ? [1, 1.75]
+    : qualityMode === 'performance'
+      ? [1, 1.2]
+      : [1, 1.45];
+  const antialias = qualityMode !== 'performance';
+
+  const traceNodeIds = useMemo(() => [...interactionContext.traceNodes], [interactionContext.traceNodes]);
+  const focusTarget = useMemo(() => {
+    if (cameraTarget && positions[cameraTarget]) return positions[cameraTarget];
+    if (selectedNodeId && positions[selectedNodeId]) return positions[selectedNodeId];
+    if (traceNodeIds.length) return centerFor(traceNodeIds, positions);
+    return centerFor(graph.nodes.map((node) => node.id), positions);
+  }, [cameraTarget, graph.nodes, positions, selectedNodeId, traceNodeIds]);
+  const focusLocked = Boolean(cameraTarget || selectedNodeId || traceNodeIds.length);
+
+  return (
+    <Canvas
+      className="graph-canvas"
+      gl={{ antialias, alpha: true, powerPreference: 'high-performance' }}
+      dpr={qualityDpr}
+      camera={{ position: [340, 180, 340], fov: 42, near: 1, far: 5600 }}
+      onPointerMissed={onBackgroundClick}
+    >
+      <SceneFx
+        themeId={themeId}
+        sceneQuality={sceneQuality}
+        renderSettings={renderSettings}
+        focusTarget={focusTarget}
+        focusLocked={focusLocked}
+      />
+      <EdgeLayer edges={graph.edges} positions={positions} interactionContext={interactionContext} renderSettings={renderSettings} />
+      <NodeGlyphs
+        nodes={graph.nodes}
+        positions={positions}
+        interactionContext={interactionContext}
+        renderSettings={renderSettings}
+        onNodeSelect={onNodeSelect}
+        onNodeHover={onNodeHover}
+      />
+      <LabelLayer
+        nodes={graph.nodes}
+        positions={positions}
+        interactionContext={interactionContext}
+        labelMode={renderSettings.labelMode}
+        labelScale={renderSettings.labelScale}
+      />
+      <InstrumentCamera
+        nodes={graph.nodes}
+        positions={positions}
+        rawPositions={rawPositions}
+        traceNodeIds={traceNodeIds}
+        cameraTarget={cameraTarget}
+        cameraMode={cameraMode}
+        fitNonce={fitNonce}
+        selectedNodeId={selectedNodeId}
+        renderSettings={renderSettings}
+      />
+    </Canvas>
+  );
+}

--- a/visualizer/src/engine/EdgeLayer.jsx
+++ b/visualizer/src/engine/EdgeLayer.jsx
@@ -1,0 +1,160 @@
+import { Line, Sphere } from '@react-three/drei';
+import { useFrame } from '@react-three/fiber';
+import { useMemo, useRef } from 'react';
+import { CubicBezierCurve3, Vector3 } from 'three';
+
+function stableHash(value) {
+  let hash = 0;
+  const text = String(value || '');
+  for (let index = 0; index < text.length; index += 1) {
+    hash = ((hash << 5) - hash) + text.charCodeAt(index);
+    hash |= 0;
+  }
+  return Math.abs(hash);
+}
+
+function bendNormal(start, end, seed) {
+  const direction = end.clone().sub(start).normalize();
+  const up = Math.abs(direction.y) > 0.92 ? new Vector3(1, 0, 0) : new Vector3(0, 1, 0);
+  const normal = new Vector3().crossVectors(direction, up).normalize();
+  const sign = stableHash(seed) % 2 === 0 ? 1 : -1;
+  return normal.multiplyScalar(sign || 1);
+}
+
+function anchoredEndpoints(edge, positions) {
+  const source = positions[edge.source];
+  const target = positions[edge.target];
+  if (!source || !target) return null;
+
+  const sourceCenter = new Vector3(source.x, source.y, source.z);
+  const targetCenter = new Vector3(target.x, target.y, target.z);
+  const direction = targetCenter.clone().sub(sourceCenter);
+  const span = direction.length();
+  if (span <= 0.001) return null;
+
+  direction.normalize();
+  const sourceRadius = Math.max(3.2, Number(edge.sourceNode?.size || 0) * 0.92);
+  const targetRadius = Math.max(3.2, Number(edge.targetNode?.size || 0) * 0.92);
+  const start = sourceCenter.clone().add(direction.clone().multiplyScalar(sourceRadius));
+  const end = targetCenter.clone().add(direction.clone().multiplyScalar(-targetRadius));
+
+  if (start.distanceTo(end) <= 0.001) return null;
+  return { start, end };
+}
+
+function buildCurve(edge, positions, renderSettings) {
+  const endpoints = anchoredEndpoints(edge, positions);
+  if (!endpoints) return null;
+
+  const { start, end } = endpoints;
+  const span = start.distanceTo(end);
+  const bend = bendNormal(start, end, edge.id);
+  const curveStrength = Number(renderSettings.lineCurvature || 1);
+  const lift = (edge.channel === 'relationship' ? 0.16 : edge.channel === 'trace' ? 0.22 : 0.11) * span * curveStrength;
+
+  const controlA = start.clone()
+    .lerp(end, 0.26)
+    .add(bend.clone().multiplyScalar(lift))
+    .add(new Vector3(0, lift * 0.22, 0));
+  const controlB = start.clone()
+    .lerp(end, 0.74)
+    .add(bend.clone().multiplyScalar(lift))
+    .add(new Vector3(0, lift * 0.22, 0));
+
+  const curve = new CubicBezierCurve3(start, controlA, controlB, end);
+  const segmentCount = edge.channel === 'trace' ? 20 : edge.channel === 'relationship' ? 14 : 10;
+  const points = curve.getPoints(segmentCount).map((point) => [point.x, point.y, point.z]);
+  return { curve, points };
+}
+
+function edgeHighlighted(edge, interactionContext) {
+  return interactionContext.traceEdges.has(edge.id)
+    || edge.source === interactionContext.selectedNodeId
+    || edge.target === interactionContext.selectedNodeId
+    || edge.source === interactionContext.hoveredNodeId
+    || edge.target === interactionContext.hoveredNodeId;
+}
+
+function edgeOpacity(edge, interactionContext, renderSettings) {
+  const highlighted = edgeHighlighted(edge, interactionContext);
+  const opacityScale = Number(renderSettings.edgeOpacity || 1);
+
+  if ((interactionContext.selectedNodeId || interactionContext.hoveredNodeId || interactionContext.graphMode === 'trace') && !highlighted) {
+    return (edge.channel === 'relationship' ? 0.14 : 0.08) * opacityScale;
+  }
+
+  const base = edge.channel === 'trace'
+    ? 0.98
+    : edge.channel === 'relationship'
+      ? 0.72
+      : edge.channel === 'commitment'
+        ? 0.62
+        : 0.28;
+
+  return base * opacityScale;
+}
+
+function EdgeParticle({ edge, curve, highlighted, renderSettings }) {
+  const particleRef = useRef(null);
+  const offset = useMemo(() => (stableHash(edge.id) % 1000) / 1000, [edge.id]);
+
+  useFrame(({ clock }) => {
+    if (!particleRef.current) return;
+    const speedBase = edge.channel === 'trace' ? 0.12 : edge.channel === 'relationship' ? 0.07 : 0.05;
+    const speed = speedBase * Number(renderSettings.particleSpeed || 1);
+    const t = (clock.elapsedTime * speed + offset) % 1;
+    const point = curve.getPointAt(t);
+    particleRef.current.position.copy(point);
+  });
+
+  const radius = 1.4 * Number(renderSettings.particleSize || 1) * (highlighted ? 1.16 : 1);
+  return (
+    <Sphere ref={particleRef} args={[radius, 10, 10]}>
+      <meshBasicMaterial color={edge.color} transparent opacity={highlighted ? 0.88 : 0.58} />
+    </Sphere>
+  );
+}
+
+function EdgeCurve({ edge, positions, interactionContext, renderSettings, allowParticles }) {
+  const built = useMemo(() => buildCurve(edge, positions, renderSettings), [edge, positions, renderSettings]);
+  if (!built) return null;
+
+  const { curve, points } = built;
+  const highlighted = edgeHighlighted(edge, interactionContext);
+  const highlightScale = highlighted ? Number(renderSettings.selectedLineThickness || 1.65) : 1;
+  const baseWidth = edge.channel === 'relationship' ? 0.8 : edge.channel === 'trace' ? 0.62 : 0.42;
+
+  return (
+    <group>
+      <Line
+        points={points}
+        color={edge.color}
+        lineWidth={Math.max(baseWidth, edge.size * (edge.channel === 'relationship' ? 0.12 : edge.channel === 'trace' ? 0.14 : 0.08)) * highlightScale}
+        transparent
+        opacity={edgeOpacity(edge, interactionContext, renderSettings)}
+        dashed={edge.channel === 'trace'}
+        dashScale={12}
+        dashSize={1.2}
+        gapSize={0.8}
+        worldUnits
+      />
+      {allowParticles && renderSettings.showParticles && (edge.channel === 'relationship' || edge.channel === 'trace' || edge.channel === 'commitment') ? (
+        <EdgeParticle edge={edge} curve={curve} highlighted={highlighted} renderSettings={renderSettings} />
+      ) : null}
+    </group>
+  );
+}
+
+export function EdgeLayer({ edges, positions, interactionContext, renderSettings }) {
+  const denseGraph = edges.length > 280;
+  return edges.map((edge) => (
+    <EdgeCurve
+      key={edge.id}
+      edge={edge}
+      positions={positions}
+      interactionContext={interactionContext}
+      renderSettings={renderSettings}
+      allowParticles={!denseGraph || edgeHighlighted(edge, interactionContext) || edge.channel === 'trace'}
+    />
+  ));
+}

--- a/visualizer/src/engine/InstrumentCamera.jsx
+++ b/visualizer/src/engine/InstrumentCamera.jsx
@@ -1,0 +1,161 @@
+import { OrbitControls } from '@react-three/drei';
+import { useFrame, useThree } from '@react-three/fiber';
+import { useEffect, useMemo, useRef } from 'react';
+import { Vector3 } from 'three';
+
+function boundsFor(nodeIds, positions) {
+  const vectors = nodeIds
+    .map((id) => positions[id])
+    .filter(Boolean);
+
+  if (!vectors.length) {
+    return {
+      center: new Vector3(0, 0, 0),
+      radius: 260
+    };
+  }
+
+  let minX = Infinity;
+  let minY = Infinity;
+  let minZ = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  let maxZ = -Infinity;
+
+  for (const point of vectors) {
+    minX = Math.min(minX, point.x);
+    minY = Math.min(minY, point.y);
+    minZ = Math.min(minZ, point.z);
+    maxX = Math.max(maxX, point.x);
+    maxY = Math.max(maxY, point.y);
+    maxZ = Math.max(maxZ, point.z);
+  }
+
+  const center = new Vector3(
+    (minX + maxX) / 2,
+    (minY + maxY) / 2,
+    (minZ + maxZ) / 2
+  );
+  const radius = Math.max(maxX - minX, maxY - minY, maxZ - minZ, 280) * 0.9;
+  return { center, radius };
+}
+
+export function InstrumentCamera({
+  nodes,
+  positions,
+  rawPositions,
+  traceNodeIds,
+  cameraTarget,
+  cameraMode,
+  fitNonce,
+  selectedNodeId,
+  renderSettings
+}) {
+  const controlsRef = useRef(null);
+  const desiredPosition = useRef(new Vector3(340, 180, 340));
+  const desiredTarget = useRef(new Vector3(0, 0, 0));
+  const hasFramed = useRef(false);
+  const animationStrength = useRef(0);
+  const lastFitNonce = useRef(fitNonce);
+  const lastTraceSignature = useRef('');
+  const lastCameraTarget = useRef(null);
+  const userInteracting = useRef(false);
+  const { camera } = useThree();
+
+  const allNodeIds = useMemo(() => nodes.map((node) => node.id), [nodes]);
+
+  const resolvedPositions = Object.keys(positions || {}).length ? positions : rawPositions || {};
+
+  const setCameraFrame = (center, radius, mode = 'overview') => {
+    const resolvedRadius = Math.max(120, radius);
+    const vertical = mode === 'trace' ? 0.28 : mode === 'inspect' ? 0.22 : 0.38;
+    const controlsTarget = controlsRef.current?.target || desiredTarget.current;
+    const lookDirection = camera.position.clone().sub(controlsTarget);
+    if (lookDirection.lengthSq() <= 0.0001) {
+      lookDirection.set(1, vertical, 1);
+    }
+    lookDirection.normalize();
+
+    desiredTarget.current.copy(center);
+    desiredPosition.current.copy(center)
+      .add(lookDirection.multiplyScalar(resolvedRadius * (mode === 'trace' ? 1.52 : 1.38)));
+    desiredPosition.current.y += resolvedRadius * vertical;
+    animationStrength.current = 1;
+  };
+
+  useEffect(() => {
+    if (!nodes.length || hasFramed.current) return;
+    hasFramed.current = true;
+    const { center, radius } = boundsFor(allNodeIds, resolvedPositions);
+    setCameraFrame(center, radius, 'overview');
+  }, [allNodeIds, nodes.length, resolvedPositions]);
+
+  useEffect(() => {
+    if (fitNonce === lastFitNonce.current) return;
+    lastFitNonce.current = fitNonce;
+    const focusIds = cameraMode === 'trace' && traceNodeIds.length ? traceNodeIds : allNodeIds;
+    const { center, radius } = boundsFor(focusIds, resolvedPositions);
+    setCameraFrame(center, radius, cameraMode);
+  }, [allNodeIds, cameraMode, fitNonce, resolvedPositions, traceNodeIds]);
+
+  useEffect(() => {
+    if (cameraMode !== 'trace' || !traceNodeIds.length) return;
+    const signature = traceNodeIds.join('|');
+    if (signature === lastTraceSignature.current) return;
+    lastTraceSignature.current = signature;
+    const { center, radius } = boundsFor(traceNodeIds, resolvedPositions);
+    setCameraFrame(center, radius * 0.9, 'trace');
+  }, [cameraMode, resolvedPositions, traceNodeIds]);
+
+  useEffect(() => {
+    if (!cameraTarget || !resolvedPositions[cameraTarget]) return;
+    if (lastCameraTarget.current === `${cameraMode}:${cameraTarget}`) return;
+    lastCameraTarget.current = `${cameraMode}:${cameraTarget}`;
+    const point = resolvedPositions[cameraTarget];
+    const center = new Vector3(point.x, point.y, point.z);
+    const radius = cameraMode === 'trace' ? 170 : 128;
+    setCameraFrame(center, radius, cameraMode === 'trace' ? 'trace' : 'inspect');
+  }, [cameraMode, cameraTarget, resolvedPositions]);
+
+  useFrame(() => {
+    const moveSpeed = 0.1 * Number(renderSettings.cameraMoveSpeed || 1);
+    if (!userInteracting.current && animationStrength.current > 0.002) {
+      camera.position.lerp(desiredPosition.current, moveSpeed);
+      animationStrength.current *= 0.9;
+    }
+    if (controlsRef.current) {
+      if (!userInteracting.current && animationStrength.current > 0.002) {
+        controlsRef.current.target.lerp(desiredTarget.current, Math.min(0.2, moveSpeed * 1.2));
+      } else if (userInteracting.current) {
+        desiredTarget.current.copy(controlsRef.current.target);
+        desiredPosition.current.copy(camera.position);
+      }
+      controlsRef.current.update();
+    }
+  });
+
+  return (
+    <OrbitControls
+      ref={controlsRef}
+      makeDefault
+      enableDamping
+      dampingFactor={0.08}
+      rotateSpeed={0.72}
+      zoomSpeed={0.8}
+      panSpeed={0.6}
+      autoRotate={Boolean(renderSettings.autoRotateEnabled) && (Boolean(selectedNodeId) || Boolean(renderSettings.autoRotateGlobal))}
+      autoRotateSpeed={Number(renderSettings.autoRotateSpeed || 0.55)}
+      minDistance={48}
+      maxDistance={2400}
+      onStart={() => {
+        userInteracting.current = true;
+        animationStrength.current = 0;
+      }}
+      onEnd={() => {
+        userInteracting.current = false;
+        desiredTarget.current.copy(controlsRef.current?.target || desiredTarget.current);
+        desiredPosition.current.copy(camera.position);
+      }}
+    />
+  );
+}

--- a/visualizer/src/engine/LabelLayer.jsx
+++ b/visualizer/src/engine/LabelLayer.jsx
@@ -1,0 +1,46 @@
+import { Html } from '@react-three/drei';
+import { alpha } from '../lib/theme.js';
+
+function visibleLabels(nodes, interactionContext, mode) {
+  const filtered = nodes.filter((node) =>
+    interactionContext.selectedNodeId === node.id
+    || interactionContext.hoveredNodeId === node.id
+    || interactionContext.traceNodes.has(node.id)
+    || interactionContext.pinnedNodeIds.has(node.id)
+  );
+
+  const max = mode === 'dense' ? 24 : mode === 'minimal' ? 8 : 14;
+  return filtered.slice(0, max);
+}
+
+export function LabelLayer({ nodes, positions, interactionContext, labelMode, labelScale = 1.15 }) {
+  return visibleLabels(nodes, interactionContext, labelMode).map((node) => {
+    if (node.kind === 'entity') return null;
+    const position = positions[node.id];
+    if (!position) return null;
+
+    const style = {
+      background: `linear-gradient(180deg, ${alpha(node.accent, 0.18)}, rgba(8, 13, 20, 0.9))`,
+      borderColor: alpha(node.accent, 0.56),
+      boxShadow: `0 8px 18px ${alpha(node.accent, 0.16)}`,
+      fontSize: `${Math.round(13 * Number(labelScale || 1.15))}px`,
+      padding: `${Math.round(7 * Number(labelScale || 1.15))}px ${Math.round(10 * Number(labelScale || 1.15))}px`,
+      maxWidth: `${Math.round(320 * Number(labelScale || 1.15))}px`
+    };
+
+    return (
+      <Html
+        key={`label-${node.id}`}
+        position={[position.x, position.y + node.size + 12, position.z]}
+        transform
+        sprite
+        distanceFactor={26}
+        className="graph-node-label-wrap"
+        zIndexRange={[5, 0]}
+        occlude
+      >
+        <div className="graph-node-label is-secondary" style={style} title={node.labelText}>{node.labelText}</div>
+      </Html>
+    );
+  });
+}

--- a/visualizer/src/engine/NodeGlyphs.jsx
+++ b/visualizer/src/engine/NodeGlyphs.jsx
@@ -1,0 +1,217 @@
+import { useFrame } from '@react-three/fiber';
+import { Html } from '@react-three/drei';
+import { useMemo, useRef } from 'react';
+import { Color } from 'three';
+import { alpha } from '../lib/theme.js';
+
+function glyphFor(node) {
+  if (node.kind === 'entity') {
+    if (node.subtype === 'organization') return 'box';
+    if (node.subtype === 'project') return 'octahedron';
+    return 'sphere';
+  }
+  if (node.kind === 'pattern') return 'icosahedron';
+  if (node.kind === 'commitment') return 'commitment';
+  return 'memory';
+}
+
+function emphasis(node, interactionContext) {
+  return interactionContext.selectedNodeId === node.id
+    || interactionContext.hoveredNodeId === node.id
+    || interactionContext.pinnedNodeIds.has(node.id)
+    || interactionContext.traceNodes.has(node.id)
+    || interactionContext.selectedNeighbors.has(node.id)
+    || interactionContext.hoveredNeighbors.has(node.id);
+}
+
+function AnimatedNodeMotion({ groupRef, pulseRingRef, node, motionLevel }) {
+  useFrame(({ clock }, delta) => {
+    if (groupRef.current && motionLevel !== 'reduced') {
+      groupRef.current.rotation.y += delta * (node.kind === 'pattern' ? 0.24 : 0.1);
+    }
+
+    if (pulseRingRef.current) {
+      const pulse = 1 + Math.sin(clock.elapsedTime * (node.kind === 'commitment' ? 3.2 : 1.4)) * 0.08;
+      pulseRingRef.current.scale.setScalar(pulse);
+    }
+  });
+
+  return null;
+}
+
+function NodeGlyph({ node, position, interactionContext, renderSettings, onNodeSelect, onNodeHover }) {
+  const groupRef = useRef(null);
+  const pulseRingRef = useRef(null);
+  const highlighted = emphasis(node, interactionContext);
+  const selected = interactionContext.selectedNodeId === node.id;
+  const hovered = interactionContext.hoveredNodeId === node.id;
+  const traceNode = interactionContext.traceNodes.has(node.id);
+  const pinned = interactionContext.pinnedNodeIds.has(node.id);
+  const scale = node.size * (selected ? 1.16 : hovered ? 1.1 : traceNode ? 1.08 : 1);
+  const opacityScale = Number(renderSettings.nodeOpacity || 1);
+  const opacity = interactionContext.selectedNodeId || interactionContext.hoveredNodeId || interactionContext.graphMode === 'trace'
+    ? (highlighted ? 1 : 0.18) * opacityScale
+    : 1 * opacityScale;
+  const accent = new Color(node.accent);
+  const core = new Color(selected ? '#f5fbff' : node.color);
+  const motionLevel = renderSettings.motionLevel || 'full';
+  const memoryGlyph = renderSettings.memoryStyle === 'shard' ? 'shard' : 'orb';
+  const commitmentGlyph = renderSettings.commitmentStyle === 'diamond' ? 'diamond' : 'beacon';
+  const resolvedGlyph = useMemo(() => {
+    const baseGlyph = glyphFor(node);
+    if (baseGlyph === 'memory') return memoryGlyph;
+    if (baseGlyph === 'commitment') return commitmentGlyph;
+    return baseGlyph;
+  }, [commitmentGlyph, memoryGlyph, node]);
+  const labelStyle = {
+    background: `linear-gradient(180deg, ${alpha(node.accent, 0.26)}, rgba(7, 12, 18, 0.92))`,
+    borderColor: alpha(node.accent, 0.72),
+    boxShadow: `0 10px 24px ${alpha(node.accent, 0.22)}`,
+    fontSize: `${Math.round(15 * Number(renderSettings.labelScale || 1.15))}px`,
+    padding: `${Math.round(8 * Number(renderSettings.labelScale || 1.15))}px ${Math.round(12 * Number(renderSettings.labelScale || 1.15))}px`,
+    maxWidth: `${Math.round(360 * Number(renderSettings.labelScale || 1.15))}px`
+  };
+  const animateNode = selected
+    || hovered
+    || traceNode
+    || pinned
+    || node.kind === 'pattern'
+    || resolvedGlyph === 'beacon'
+    || resolvedGlyph === 'diamond';
+
+  const eventFlags = (event) => ({
+    shiftKey: Boolean(event.shiftKey || event.nativeEvent?.shiftKey)
+  });
+
+  return (
+    <group
+      ref={groupRef}
+      position={[position.x, position.y, position.z]}
+      onPointerOver={(event) => {
+        event.stopPropagation();
+        onNodeHover(node.id);
+      }}
+      onPointerOut={(event) => {
+        event.stopPropagation();
+        onNodeHover(null);
+      }}
+      onClick={(event) => {
+        event.stopPropagation();
+        onNodeSelect(node.id, eventFlags(event));
+      }}
+      onDoubleClick={(event) => {
+        event.stopPropagation();
+        onNodeSelect(node.id, { ...eventFlags(event), doubleClick: true });
+      }}
+    >
+      {animateNode ? (
+        <AnimatedNodeMotion
+          groupRef={groupRef}
+          pulseRingRef={pulseRingRef}
+          node={node}
+          motionLevel={motionLevel}
+        />
+      ) : null}
+
+      {resolvedGlyph === 'sphere' ? (
+        <mesh scale={scale}>
+          <sphereGeometry args={[1, 24, 24]} />
+          <meshStandardMaterial color={core} emissive={accent} emissiveIntensity={selected ? 1.18 : traceNode ? 0.94 : 0.34} metalness={0.24} roughness={0.34} transparent opacity={Math.max(opacity, 0.28)} />
+        </mesh>
+      ) : null}
+
+      {resolvedGlyph === 'box' ? (
+        <mesh scale={[scale * 1.22, scale * 1.22, scale * 1.22]}>
+          <boxGeometry args={[1.5, 1.5, 1.5]} />
+          <meshStandardMaterial color={core} emissive={accent} emissiveIntensity={selected ? 1.12 : 0.32} metalness={0.26} roughness={0.3} transparent opacity={Math.max(opacity, 0.28)} />
+        </mesh>
+      ) : null}
+
+      {resolvedGlyph === 'octahedron' ? (
+        <mesh scale={scale * 1.2}>
+          <octahedronGeometry args={[1.1]} />
+          <meshStandardMaterial color={core} emissive={accent} emissiveIntensity={selected ? 1.1 : 0.32} metalness={0.22} roughness={0.28} transparent opacity={Math.max(opacity, 0.28)} />
+        </mesh>
+      ) : null}
+
+      {resolvedGlyph === 'icosahedron' ? (
+        <mesh scale={scale * 1.14}>
+          <icosahedronGeometry args={[1.05, 0]} />
+          <meshStandardMaterial color={core} emissive={accent} emissiveIntensity={traceNode ? 1.02 : 0.32} wireframe metalness={0.12} roughness={0.22} transparent opacity={Math.max(opacity, 0.28)} />
+        </mesh>
+      ) : null}
+
+      {resolvedGlyph === 'orb' ? (
+        <mesh scale={[scale * 0.9, scale * 1.14, scale * 0.9]}>
+          <sphereGeometry args={[0.82, 18, 18]} />
+          <meshStandardMaterial color={core} emissive={accent} emissiveIntensity={hovered ? 0.78 : 0.22} metalness={0.18} roughness={0.56} transparent opacity={Math.max(opacity * 0.96, 0.24)} />
+        </mesh>
+      ) : null}
+
+      {resolvedGlyph === 'shard' ? (
+        <mesh scale={[scale * 0.86, scale * 1.18, scale * 0.86]}>
+          <octahedronGeometry args={[0.92]} />
+          <meshStandardMaterial color={core} emissive={accent} emissiveIntensity={hovered ? 0.82 : 0.26} metalness={0.2} roughness={0.44} transparent opacity={Math.max(opacity * 0.96, 0.24)} />
+        </mesh>
+      ) : null}
+
+      {resolvedGlyph === 'beacon' ? (
+        <>
+          <mesh scale={[scale * 0.72, scale * 1.3, scale * 0.72]}>
+            <cylinderGeometry args={[0.72, 0.95, 1.95, 6]} />
+            <meshStandardMaterial color={core} emissive={accent} emissiveIntensity={1.32} metalness={0.2} roughness={0.24} transparent opacity={Math.max(opacity, 0.32)} />
+          </mesh>
+          <mesh ref={pulseRingRef} rotation={[Math.PI / 2, 0, 0]} position={[0, 0, 0]}>
+            <torusGeometry args={[scale * 1.34, scale * 0.14, 10, 40]} />
+            <meshBasicMaterial color={accent} transparent opacity={0.5 * opacity} />
+          </mesh>
+        </>
+      ) : null}
+
+      {resolvedGlyph === 'diamond' ? (
+        <>
+          <mesh scale={[scale * 0.92, scale * 1.28, scale * 0.92]}>
+            <octahedronGeometry args={[1.05]} />
+            <meshStandardMaterial color={core} emissive={accent} emissiveIntensity={1.22} metalness={0.24} roughness={0.22} transparent opacity={Math.max(opacity, 0.32)} />
+          </mesh>
+          <mesh ref={pulseRingRef} rotation={[Math.PI / 2, 0, 0]} position={[0, -0.2, 0]}>
+            <torusGeometry args={[scale * 1.2, scale * 0.11, 10, 40]} />
+            <meshBasicMaterial color={accent} transparent opacity={0.45 * opacity} />
+          </mesh>
+        </>
+      ) : null}
+
+      {node.kind === 'entity' && (selected || hovered || traceNode || pinned) ? (
+        <Html
+          position={[0, scale + 14, 0]}
+          transform
+          sprite
+          distanceFactor={28}
+          className="graph-node-label-wrap"
+          zIndexRange={[6, 0]}
+          occlude
+        >
+          <div className="graph-node-label" style={labelStyle} title={node.labelText}>{node.labelText}</div>
+        </Html>
+      ) : null}
+    </group>
+  );
+}
+
+export function NodeGlyphs(props) {
+  const { nodes, positions, interactionContext, renderSettings, onNodeSelect, onNodeHover } = props;
+  return nodes.map((node) => {
+    const position = positions[node.id] || { x: node.x || 0, y: node.y || 0, z: node.z || 0 };
+    return (
+      <NodeGlyph
+        key={node.id}
+        node={node}
+        position={position}
+        interactionContext={interactionContext}
+        renderSettings={renderSettings}
+        onNodeSelect={onNodeSelect}
+        onNodeHover={onNodeHover}
+      />
+    );
+  });
+}

--- a/visualizer/src/engine/SceneFx.jsx
+++ b/visualizer/src/engine/SceneFx.jsx
@@ -1,0 +1,99 @@
+import { Grid, Stars } from '@react-three/drei';
+import { Bloom, ChromaticAberration, DepthOfField, EffectComposer, Noise, Vignette } from '@react-three/postprocessing';
+import { BlendFunction } from 'postprocessing';
+import { Vector2 } from 'three';
+import { getTheme } from '../lib/theme.js';
+
+function mixHex(left, right, ratio = 0.5) {
+  const parse = (value) => {
+    const normalized = String(value || '#000000').replace('#', '');
+    const full = normalized.length === 3
+      ? normalized.split('').map((char) => `${char}${char}`).join('')
+      : normalized;
+    const int = Number.parseInt(full, 16);
+    return {
+      r: (int >> 16) & 255,
+      g: (int >> 8) & 255,
+      b: int & 255
+    };
+  };
+
+  const a = parse(left);
+  const b = parse(right);
+  const t = Math.max(0, Math.min(1, ratio));
+  const toHex = (value) => value.toString(16).padStart(2, '0');
+  const r = Math.round(a.r + (b.r - a.r) * t);
+  const g = Math.round(a.g + (b.g - a.g) * t);
+  const bValue = Math.round(a.b + (b.b - a.b) * t);
+  return `#${toHex(r)}${toHex(g)}${toHex(bValue)}`;
+}
+
+export function SceneFx({ themeId, sceneQuality, renderSettings, focusTarget, focusLocked = false }) {
+  const theme = getTheme(themeId);
+  const enableEffects = sceneQuality.effectsEnabled && sceneQuality.quality !== 'performance';
+  const bloomStrength = Number(renderSettings.bloomStrength || 1);
+  const chromaticStrength = Number(renderSettings.chromaticStrength || 1);
+  const fogNearScale = Number(renderSettings.fogNear || 1);
+  const fogFarScale = Number(renderSettings.fogFar || 1);
+  const fogNear = 900 * fogNearScale;
+  const fogFar = Math.max(fogNear + 1200, 4200 * fogFarScale);
+  const gridOpacity = Number(renderSettings.gridOpacity || 0.34);
+  const gridDensity = Number(renderSettings.gridDensity || 1.15);
+  const cellSize = 32 / gridDensity;
+  const sectionSize = 160 / gridDensity;
+  const desaturatedGrid = mixHex(theme.scene.grid, theme.scene.fog, 0.7);
+  const softSection = mixHex(theme.css['--border-strong'], theme.scene.fog, 0.58);
+  const cellThickness = 0.34 + gridOpacity * 0.7;
+  const sectionThickness = 0.8 + gridOpacity * 1.1;
+  const gridKey = `${themeId}:${gridDensity.toFixed(2)}:${gridOpacity.toFixed(2)}`;
+  const chromaticAttenuation = focusLocked ? 0.42 : 0.72;
+  const dofTarget = focusTarget ? [focusTarget.x, focusTarget.y, focusTarget.z] : [0, 0, 0];
+  const dofBokeh = focusLocked ? 0.46 : 0.18;
+  const dofFocalLength = focusLocked ? 0.014 : 0.008;
+
+  return (
+    <>
+      <color attach="background" args={[theme.scene.clear]} />
+      <fog attach="fog" args={[theme.scene.fog, fogNear, fogFar]} />
+      <ambientLight intensity={0.7} color={theme.scene.ambient} />
+      <directionalLight position={[220, 190, 180]} intensity={1.3} color={theme.scene.key} />
+      <directionalLight position={[-160, 110, -220]} intensity={0.65} color={theme.scene.rim} />
+      <Grid
+        key={gridKey}
+        args={[1800, 1800]}
+        position={[0, -180, 0]}
+        cellColor={desaturatedGrid}
+        sectionColor={softSection}
+        cellThickness={cellThickness}
+        sectionThickness={sectionThickness}
+        fadeDistance={2600}
+        fadeStrength={0.95 - Math.min(gridOpacity * 0.4, 0.28)}
+        infiniteGrid
+        cellSize={Math.max(10, cellSize)}
+        sectionSize={Math.max(56, sectionSize)}
+      />
+      <Stars radius={880} depth={280} count={1700} factor={4} saturation={0} fade speed={0.4} />
+      {enableEffects ? (
+        <EffectComposer multisampling={sceneQuality.quality === 'quality' ? 8 : 4}>
+          <DepthOfField
+            target={dofTarget}
+            focalLength={dofFocalLength}
+            bokehScale={dofBokeh}
+            focusRange={0.08}
+            resolutionScale={1}
+          />
+          <Bloom intensity={theme.scene.bloom * bloomStrength} luminanceThreshold={0.28} luminanceSmoothing={0.2} />
+          <ChromaticAberration
+            blendFunction={BlendFunction.NORMAL}
+            offset={new Vector2(
+              theme.scene.chromatic * chromaticStrength * chromaticAttenuation,
+              theme.scene.chromatic * 0.35 * chromaticStrength * chromaticAttenuation
+            )}
+          />
+          <Noise opacity={0.03} />
+          <Vignette eskil={false} offset={0.18} darkness={0.5} />
+        </EffectComposer>
+      ) : null}
+    </>
+  );
+}

--- a/visualizer/src/engine/layoutWorker.js
+++ b/visualizer/src/engine/layoutWorker.js
@@ -1,0 +1,147 @@
+import {
+  forceCollide,
+  forceLink,
+  forceManyBody,
+  forceSimulation,
+  forceX,
+  forceY,
+  forceZ
+} from 'd3-force-3d';
+
+function stableHash(value) {
+  let hash = 2166136261;
+  const text = String(value ?? '');
+  for (let index = 0; index < text.length; index += 1) {
+    hash ^= text.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function orbitOffset(seed, radius) {
+  const angle = ((stableHash(`${seed}:a`) % 360) * Math.PI) / 180;
+  const pitch = (((stableHash(`${seed}:p`) % 120) - 60) * Math.PI) / 180;
+  const spread = radius + (stableHash(`${seed}:r`) % 24);
+  return {
+    x: Math.cos(angle) * Math.cos(pitch) * spread,
+    y: Math.sin(pitch) * spread * 0.72,
+    z: Math.sin(angle) * Math.cos(pitch) * spread
+  };
+}
+
+function homeFor(node, nodeMap) {
+  const seed = {
+    x: Number(node.layout?.seedX ?? 0),
+    y: Number(node.layout?.seedY ?? 0),
+    z: Number(node.layout?.seedZ ?? 0)
+  };
+  const anchor = node.anchorRef ? nodeMap.get(node.anchorRef) : null;
+
+  if (node.kind === 'entity') return seed;
+  if (!anchor) return seed;
+
+  if (node.kind === 'commitment') {
+    const offset = orbitOffset(node.id, 34);
+    return { x: anchor.x + offset.x * 0.6, y: anchor.y + 48 + offset.y, z: anchor.z + 30 + offset.z * 0.45 };
+  }
+
+  if (node.kind === 'pattern') {
+    const offset = orbitOffset(node.id, 72);
+    return { x: anchor.x + offset.x, y: anchor.y + offset.y * 0.7, z: anchor.z - 56 + offset.z };
+  }
+
+  const offset = orbitOffset(node.id, 46);
+  return { x: anchor.x + offset.x * 0.75, y: anchor.y + 18 + offset.y, z: anchor.z + offset.z * 0.75 };
+}
+
+function chargeFor(node) {
+  if (node.kind === 'entity') return -180 - Number(node.importance || 0) * 90;
+  if (node.kind === 'pattern') return -70;
+  if (node.kind === 'commitment') return -55;
+  return -26;
+}
+
+function collisionFor(node) {
+  return Math.max(16, Number(node.size || 5) * (node.kind === 'entity' ? 3.2 : 2.4));
+}
+
+function linkDistance(edge) {
+  if (edge.channel === 'trace') return 54;
+  if (edge.channel === 'relationship') return 84 - Math.min(Number(edge.strength || 0) * 22, 22);
+  if (edge.channel === 'commitment') return 40;
+  return 34;
+}
+
+function linkStrength(edge) {
+  if (edge.channel === 'trace') return 0.4;
+  if (edge.channel === 'relationship') return 0.12 + Number(edge.strength || 0) * 0.16;
+  if (edge.channel === 'commitment') return 0.22;
+  return 0.16;
+}
+
+function toSnapshot(nodes) {
+  const positions = {};
+  const velocities = {};
+  for (const node of nodes) {
+    positions[node.id] = { x: node.x || 0, y: node.y || 0, z: node.z || 0 };
+    velocities[node.id] = { x: node.vx || 0, y: node.vy || 0, z: node.vz || 0 };
+  }
+  return { positions, velocities };
+}
+
+self.onmessage = (event) => {
+  const { type, jobId, nodes = [], edges = [], previousPositions = {}, motionLevel = 'full' } = event.data || {};
+  if (type !== 'layout') return;
+
+  const nodeMap = new Map(nodes.map((node) => [node.id, {
+    ...node,
+    x: Number(previousPositions?.[node.id]?.x ?? node.layout?.seedX ?? 0),
+    y: Number(previousPositions?.[node.id]?.y ?? node.layout?.seedY ?? 0),
+    z: Number(previousPositions?.[node.id]?.z ?? node.layout?.seedZ ?? 0)
+  }]));
+
+  const simNodes = [...nodeMap.values()];
+  const simEdges = edges
+    .filter((edge) => nodeMap.has(edge.source) && nodeMap.has(edge.target))
+    .map((edge) => ({ ...edge }));
+
+  const reusedNodes = nodes.filter((node) => previousPositions?.[node.id]).length;
+  const reuseRatio = nodes.length ? reusedNodes / nodes.length : 0;
+  const baseIterations = reuseRatio > 0.7
+    ? (motionLevel === 'reduced' ? 18 : motionLevel === 'restrained' ? 24 : 30)
+    : (motionLevel === 'reduced' ? 90 : motionLevel === 'restrained' ? 120 : 160);
+  const densityFactor = nodes.length > 900 ? 0.48 : nodes.length > 500 ? 0.62 : nodes.length > 260 ? 0.82 : 1;
+  const iterations = Math.max(16, Math.round(baseIterations * densityFactor));
+  const positionalStrength = reuseRatio > 0.7
+    ? 0.018
+    : motionLevel === 'reduced'
+      ? 0.09
+      : 0.05;
+
+  const simulation = forceSimulation(simNodes, 3)
+    .alpha(reuseRatio > 0.7 ? 0.22 : 1)
+    .alphaDecay(reuseRatio > 0.7 ? 0.14 : motionLevel === 'full' ? 0.038 : 0.05)
+    .velocityDecay(motionLevel === 'full' ? 0.22 : 0.3)
+    .force('charge', forceManyBody().strength(chargeFor).distanceMax(520))
+    .force('collide', forceCollide().radius(collisionFor).strength(0.85))
+    .force('link', forceLink(simEdges).id((node) => node.id).distance(linkDistance).strength(linkStrength))
+    .force('homeX', forceX((node) => homeFor(node, nodeMap).x).strength(positionalStrength))
+    .force('homeY', forceY((node) => homeFor(node, nodeMap).y).strength(positionalStrength))
+    .force('homeZ', forceZ((node) => homeFor(node, nodeMap).z).strength(positionalStrength));
+
+  for (let tick = 0; tick < iterations; tick += 1) {
+    simulation.tick();
+    if (tick === 0 || tick % 10 === 0 || tick === iterations - 1) {
+      const snapshot = toSnapshot(simNodes);
+      self.postMessage({
+        type: 'snapshot',
+        jobId,
+        positions: snapshot.positions,
+        velocities: snapshot.velocities,
+        done: tick === iterations - 1
+      });
+    }
+  }
+
+  simulation.stop();
+};

--- a/visualizer/src/engine/useGraphLayout.js
+++ b/visualizer/src/engine/useGraphLayout.js
@@ -1,0 +1,163 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useGraphStore } from '../store/useGraphStore.js';
+
+function seedPositions(nodes) {
+  return Object.fromEntries((nodes || []).map((node) => [
+    node.id,
+    {
+      x: Number(node.layout?.seedX ?? node.x ?? 0),
+      y: Number(node.layout?.seedY ?? node.y ?? 0),
+      z: Number(node.layout?.seedZ ?? node.z ?? 0)
+    }
+  ]));
+}
+
+export function useGraphLayout(graph, reheatToken, renderSettings) {
+  const workerRef = useRef(null);
+  const activeJobRef = useRef(0);
+  const rawPositionsRef = useRef({});
+  const displayPositionsRef = useRef({});
+  const setLayoutSnapshot = useGraphStore((state) => state.setLayoutSnapshot);
+  const previousPositions = useGraphStore((state) => state.layoutState.positions);
+  const structureKey = useMemo(() => JSON.stringify({
+    nodes: graph.nodes.map((node) => [
+      node.id,
+      node.layout?.seedX ?? node.x ?? 0,
+      node.layout?.seedY ?? node.y ?? 0,
+      node.layout?.seedZ ?? node.z ?? 0
+    ]),
+    edges: graph.edges.map((edge) => [edge.id, edge.source, edge.target, edge.channel])
+  }), [graph.edges, graph.nodes]);
+  const initialPositions = useMemo(() => seedPositions(graph.nodes), [structureKey]);
+  const [positions, setPositions] = useState(initialPositions);
+  const [displayPositions, setDisplayPositions] = useState(initialPositions);
+  const [layoutReady, setLayoutReady] = useState(false);
+
+  useEffect(() => {
+    setPositions(initialPositions);
+    setDisplayPositions(initialPositions);
+    rawPositionsRef.current = initialPositions;
+    displayPositionsRef.current = initialPositions;
+    setLayoutReady(false);
+  }, [initialPositions]);
+
+  useEffect(() => {
+    rawPositionsRef.current = positions;
+  }, [positions]);
+
+  useEffect(() => {
+    const worker = new Worker(new URL('./layoutWorker.js', import.meta.url), { type: 'module' });
+    workerRef.current = worker;
+
+    worker.onmessage = (event) => {
+      const { type, jobId, positions: nextPositions, velocities, done } = event.data || {};
+      if (type !== 'snapshot' || jobId !== activeJobRef.current) return;
+      setPositions(nextPositions || {});
+      setLayoutSnapshot(nextPositions || {}, velocities || {}, false);
+      if (done) setLayoutReady(true);
+    };
+
+    return () => {
+      worker.terminate();
+      workerRef.current = null;
+    };
+  }, [setLayoutSnapshot]);
+
+  useEffect(() => {
+    if (!workerRef.current) return;
+    const jobId = activeJobRef.current + 1;
+    activeJobRef.current = jobId;
+
+    workerRef.current.postMessage({
+      type: 'layout',
+      jobId,
+      nodes: graph.nodes.map((node) => ({
+        id: node.id,
+        kind: node.kind,
+        subtype: node.subtype,
+        anchorRef: node.anchorRef,
+        clusterKey: node.clusterKey,
+        size: node.size,
+        layout: node.layout,
+        importance: node.importance
+      })),
+      edges: graph.edges.map((edge) => ({
+        id: edge.id,
+        source: edge.source,
+        target: edge.target,
+        strength: edge.strength,
+        channel: edge.channel,
+        status: edge.status
+      })),
+      previousPositions,
+      motionLevel: renderSettings.motionLevel,
+      reheatToken
+    });
+  }, [previousPositions, reheatToken, renderSettings.motionLevel, structureKey]);
+
+  useEffect(() => {
+    const smoothing = renderSettings.motionLevel === 'reduced'
+      ? 0.34
+      : renderSettings.motionLevel === 'restrained'
+        ? 0.22
+        : 0.16;
+    let frameId = 0;
+    let cancelled = false;
+
+    const step = () => {
+      if (cancelled) return;
+
+      const targetPositions = rawPositionsRef.current || {};
+      const currentPositions = displayPositionsRef.current || {};
+      const targetIds = Object.keys(targetPositions);
+      const nextPositions = {};
+      let changed = targetIds.length !== Object.keys(currentPositions).length;
+      let moving = false;
+
+      for (const id of targetIds) {
+        const target = targetPositions[id];
+        const current = currentPositions[id] || target;
+        const dx = target.x - current.x;
+        const dy = target.y - current.y;
+        const dz = target.z - current.z;
+        const delta = Math.max(Math.abs(dx), Math.abs(dy), Math.abs(dz));
+
+        if (delta <= 0.02) {
+          nextPositions[id] = target;
+          if (current !== target) changed = true;
+          continue;
+        }
+
+        moving = true;
+        changed = true;
+        nextPositions[id] = {
+          x: current.x + dx * smoothing,
+          y: current.y + dy * smoothing,
+          z: current.z + dz * smoothing
+        };
+      }
+
+      if (changed) {
+        displayPositionsRef.current = nextPositions;
+        setDisplayPositions(nextPositions);
+      }
+
+      if (moving) {
+        frameId = window.requestAnimationFrame(step);
+      }
+    };
+
+    frameId = window.requestAnimationFrame(step);
+
+    return () => {
+      cancelled = true;
+      window.cancelAnimationFrame(frameId);
+    };
+  }, [positions, renderSettings.motionLevel]);
+
+  return {
+    positions: displayPositions,
+    rawPositions: positions,
+    layoutReady
+  };
+}

--- a/visualizer/src/lib/graphAdapters.js
+++ b/visualizer/src/lib/graphAdapters.js
@@ -1,0 +1,254 @@
+import { alpha, edgeTone, getTheme, nodeAccent, nodeTone } from './theme.js';
+
+function nodeColorOverride(node, settings) {
+  if (node.kind === 'entity') {
+    if (node.subtype === 'person') return settings.personColor || null;
+    if (node.subtype === 'organization') return settings.organizationColor || null;
+    if (node.subtype === 'project') return settings.projectColor || null;
+  }
+  if (node.kind === 'memory') return settings.memoryColor || null;
+  if (node.kind === 'commitment') return settings.commitmentColor || null;
+  return null;
+}
+
+function timestampForNode(node) {
+  return node?.timestamps?.activityAt || node?.timestamps?.updatedAt || node?.timestamps?.createdAt || null;
+}
+
+function nodePassesKindFilter(node, state) {
+  const { activeFilters, renderSettings } = state;
+
+  if (node.kind === 'entity') {
+    return activeFilters.entities[node.subtype] !== false;
+  }
+
+  if (node.kind === 'pattern') {
+    return renderSettings.showPatterns && activeFilters.patterns[node.subtype] !== false;
+  }
+
+  if (node.kind === 'commitment') {
+    return renderSettings.showCommitments && activeFilters.memories[node.subtype] !== false;
+  }
+
+  return activeFilters.memories[node.subtype] !== false;
+}
+
+function computeTimelineRange(nodes) {
+  const values = nodes
+    .map(timestampForNode)
+    .filter(Boolean)
+    .map((value) => new Date(value).getTime())
+    .filter((value) => Number.isFinite(value));
+
+  if (!values.length) {
+    return { min: null, max: null };
+  }
+
+  return {
+    min: Math.min(...values),
+    max: Math.max(...values)
+  };
+}
+
+function nodePassesTimeline(node, state, range) {
+  if (!range.min || !range.max) return true;
+
+  const essential = node.id === state.selectedNodeId
+    || state.pinnedNodeIds.includes(node.id)
+    || state.traceEndpoints.from === node.id
+    || state.traceEndpoints.to === node.id;
+  if (essential) return true;
+
+  if (node.kind === 'entity' || node.kind === 'pattern') return true;
+
+  const timestamp = timestampForNode(node);
+  if (!timestamp) return true;
+
+  const value = new Date(timestamp).getTime();
+  if (!Number.isFinite(value)) return true;
+
+  const span = range.max - range.min;
+  if (span <= 0) return true;
+
+  const ratio = Number(state.timelineWindow ?? 100) / 100;
+  const cutoff = range.max - span * ratio;
+  return value >= cutoff;
+}
+
+function computeNodeSize(node, settings) {
+  const base = Number(node.size || 5.5);
+  const multiplier = node.kind === 'entity'
+    ? settings.entitySize
+    : node.kind === 'pattern'
+      ? settings.patternSize * 0.64
+      : settings.memorySize * (node.kind === 'commitment' ? 0.68 : 0.52);
+  return Math.max(2.1, base * multiplier);
+}
+
+function computeEdgeSize(edge, settings) {
+  const base = edge.channel === 'relationship'
+    ? 2 + Number(edge.strength || 0.4) * 1.9
+    : edge.channel === 'trace'
+      ? 2.4 + Number(edge.strength || 0.6) * 1.8
+      : edge.channel === 'commitment'
+        ? 1.4 + Number(edge.strength || 0.5) * 1.1
+        : 0.7 + Number(edge.strength || 0.3) * 0.7;
+  return base * Number(settings.edgeIntensity || 1) * Number(settings.lineThickness || 1);
+}
+
+function computeLabelBase(node, settings) {
+  const mode = settings.labelMode || 'balanced';
+  if (mode === 'dense') return true;
+  if (mode === 'minimal') {
+    return node.kind === 'entity' && Number(node.importance || 0) >= 0.82;
+  }
+  if (node.kind === 'entity' && Number(node.importance || 0) >= 0.72) return true;
+  if (node.kind === 'commitment' && Number(node.urgencyScore || 0) >= 0.8) return true;
+  return false;
+}
+
+function groupCounts(nodes) {
+  const entityTypes = {};
+  const memoryTypes = {};
+  const patternTypes = {};
+
+  for (const node of nodes) {
+    if (node.kind === 'entity') {
+      entityTypes[node.subtype] = (entityTypes[node.subtype] || 0) + 1;
+    } else if (node.kind === 'pattern') {
+      patternTypes[node.subtype] = (patternTypes[node.subtype] || 0) + 1;
+    } else {
+      memoryTypes[node.subtype] = (memoryTypes[node.subtype] || 0) + 1;
+    }
+  }
+
+  return { entityTypes, memoryTypes, patternTypes };
+}
+
+export function mergeGraphData(baseGraph, overlayGraph) {
+  const nodes = new Map();
+  const edges = new Map();
+
+  for (const graph of [baseGraph, overlayGraph].filter(Boolean)) {
+    for (const node of graph.nodes || []) nodes.set(node.id, node);
+    for (const edge of graph.edges || []) edges.set(edge.id, edge);
+  }
+
+  return {
+    meta: overlayGraph?.meta || baseGraph?.meta || {},
+    nodes: [...nodes.values()],
+    edges: [...edges.values()]
+  };
+}
+
+export function buildVisibleGraphData(graphData, state, themeId = 'claudia') {
+  const theme = getTheme(themeId);
+  const range = computeTimelineRange(graphData.nodes || []);
+  const visibleNodes = new Map();
+  const activeNodeIds = new Set([
+    state.selectedNodeId,
+    state.hoveredNodeId,
+    state.traceEndpoints.from,
+    state.traceEndpoints.to,
+    ...state.pinnedNodeIds
+  ].filter(Boolean));
+
+  for (const node of graphData.nodes || []) {
+    if (!nodePassesKindFilter(node, state)) continue;
+    if (!nodePassesTimeline(node, state, range)) continue;
+
+    const overrideColor = nodeColorOverride(node, state.renderSettings);
+    const color = overrideColor || nodeTone(node, themeId);
+    const accent = overrideColor || nodeAccent(node, themeId);
+    const size = computeNodeSize(node, state.renderSettings);
+    visibleNodes.set(node.id, {
+      ...node,
+      size,
+      color,
+      accent,
+      baseLabelVisible: computeLabelBase(node, state.renderSettings) || activeNodeIds.has(node.id),
+      labelText: node.label,
+      x: Number(node.layout?.seedX ?? node.x ?? 0),
+      y: Number(node.layout?.seedY ?? node.y ?? 0),
+      z: Number(node.layout?.seedZ ?? node.z ?? 0)
+    });
+  }
+
+  const visibleEdges = [];
+  for (const edge of graphData.edges || []) {
+    if (!visibleNodes.has(edge.source) || !visibleNodes.has(edge.target)) continue;
+    const sourceNode = visibleNodes.get(edge.source);
+    const targetNode = visibleNodes.get(edge.target);
+    const baseColor = edgeTone(edge, themeId);
+    const faded = (state.selectedNodeId || state.hoveredNodeId || state.graphMode === 'trace')
+      && edge.status !== 'trace'
+      && edge.source !== state.selectedNodeId
+      && edge.target !== state.selectedNodeId
+      && edge.source !== state.hoveredNodeId
+      && edge.target !== state.hoveredNodeId;
+
+    visibleEdges.push({
+      ...edge,
+      sourceNode,
+      targetNode,
+      size: computeEdgeSize(edge, state.renderSettings),
+      color: faded ? alpha(theme.css['--text-muted'], 0.14 * Number(state.renderSettings.edgeOpacity || 1)) : baseColor
+    });
+  }
+
+  const nodes = [...visibleNodes.values()];
+  const counts = {
+    totalNodes: nodes.length,
+    totalEdges: visibleEdges.length,
+    entities: nodes.filter((node) => node.kind === 'entity').length,
+    memories: nodes.filter((node) => node.kind === 'memory').length,
+    commitments: nodes.filter((node) => node.kind === 'commitment').length,
+    patterns: nodes.filter((node) => node.kind === 'pattern').length,
+    relationships: visibleEdges.filter((edge) => edge.channel === 'relationship').length
+  };
+
+  return {
+    nodes,
+    edges: visibleEdges,
+    nodeMap: visibleNodes,
+    counts,
+    breakdown: groupCounts(nodes),
+    timelineRange: {
+      min: range.min ? new Date(range.min).toISOString() : null,
+      max: range.max ? new Date(range.max).toISOString() : null
+    }
+  };
+}
+
+export function buildInteractionContext(graphData, state) {
+  const selectedNodeId = state.selectedNodeId;
+  const hoveredNodeId = state.hoveredNodeId;
+  const selectedNeighbors = new Set();
+  const hoveredNeighbors = new Set();
+  const traceNodes = new Set(state.tracePath || []);
+  const traceEdges = new Set();
+
+  for (const edge of graphData.edges || []) {
+    if (edge.status === 'trace' || edge.channel === 'trace') {
+      traceEdges.add(edge.id);
+      traceNodes.add(edge.source);
+      traceNodes.add(edge.target);
+    }
+    if (edge.source === selectedNodeId) selectedNeighbors.add(edge.target);
+    if (edge.target === selectedNodeId) selectedNeighbors.add(edge.source);
+    if (edge.source === hoveredNodeId) hoveredNeighbors.add(edge.target);
+    if (edge.target === hoveredNodeId) hoveredNeighbors.add(edge.source);
+  }
+
+  return {
+    selectedNodeId,
+    hoveredNodeId,
+    pinnedNodeIds: new Set(state.pinnedNodeIds),
+    selectedNeighbors,
+    hoveredNeighbors,
+    traceNodes,
+    traceEdges,
+    graphMode: state.graphMode,
+    traceEmphasis: state.renderSettings.traceEmphasis
+  };
+}

--- a/visualizer/src/lib/search.js
+++ b/visualizer/src/lib/search.js
@@ -1,0 +1,12 @@
+export async function querySearch(query, limit = 16) {
+  const params = new URLSearchParams({
+    q: query,
+    limit: String(limit)
+  });
+  const response = await fetch(`/api/search?${params.toString()}`);
+  if (!response.ok) {
+    throw new Error(`Search failed: ${response.status}`);
+  }
+  return response.json();
+}
+

--- a/visualizer/src/lib/theme.js
+++ b/visualizer/src/lib/theme.js
@@ -1,0 +1,504 @@
+export const ENTITY_SUBTYPES = ['person', 'organization', 'project', 'concept', 'location'];
+export const MEMORY_SUBTYPES = ['fact', 'commitment', 'learning', 'observation', 'preference', 'pattern'];
+export const PATTERN_SUBTYPES = ['relationship', 'behavioral', 'communication', 'scheduling'];
+
+export const APP_THEMES = {
+  claudia: {
+    id: 'claudia',
+    label: 'Claudia Core',
+    css: {
+      '--bg': '#05090d',
+      '--bg-elevated': '#0b1117',
+      '--panel': 'rgba(10, 16, 22, 0.9)',
+      '--panel-strong': 'rgba(7, 11, 16, 0.96)',
+      '--panel-muted': 'rgba(18, 28, 38, 0.82)',
+      '--border': 'rgba(104, 146, 178, 0.24)',
+      '--border-strong': 'rgba(137, 210, 255, 0.42)',
+      '--line': 'rgba(94, 127, 153, 0.17)',
+      '--text': '#d7e7f2',
+      '--text-dim': '#9ab3c7',
+      '--text-muted': '#678095',
+      '--accent': '#79dbff',
+      '--accent-secondary': '#f7c16b',
+      '--accent-soft': 'rgba(121, 219, 255, 0.12)',
+      '--success': '#6ef0bf',
+      '--danger': '#ff8e77',
+      '--glow-a': 'rgba(74, 165, 255, 0.14)',
+      '--glow-b': 'rgba(247, 193, 107, 0.07)'
+    },
+    colors: {
+      entity: '#7fd8ff',
+      memory: '#8aa3b8',
+      commitment: '#ff956f',
+      pattern: '#ae98ff',
+      trace: '#f7c16b',
+      selected: '#f5fbff'
+    },
+    subtypes: {
+      person: '#f0cf72',
+      organization: '#7fb9ff',
+      project: '#77efbf',
+      concept: '#d59fff',
+      location: '#f7c16b',
+      fact: '#8aa3b8',
+      commitment: '#ff956f',
+      learning: '#6ef0bf',
+      observation: '#7fd8ff',
+      preference: '#f7d589',
+      pattern: '#c094ff',
+      relationship: '#99afff',
+      behavioral: '#67e6bd',
+      communication: '#7fd8ff',
+      scheduling: '#f7c16b'
+    },
+    scene: {
+      clear: '#04080c',
+      fog: '#04080c',
+      ambient: '#9ab5cb',
+      key: '#82dfff',
+      rim: '#f7c16b',
+      grid: '#173040',
+      stars: ['#6fd8ff', '#8fb0ff', '#f7c16b', '#dcd9ff'],
+      bloom: 0.58,
+      chromatic: 0.0006
+    }
+  },
+  infrared: {
+    id: 'infrared',
+    label: 'Infrared Ops',
+    css: {
+      '--bg': '#0b0908',
+      '--bg-elevated': '#150f0d',
+      '--panel': 'rgba(23, 15, 13, 0.9)',
+      '--panel-strong': 'rgba(16, 10, 9, 0.96)',
+      '--panel-muted': 'rgba(35, 24, 22, 0.84)',
+      '--border': 'rgba(193, 124, 93, 0.24)',
+      '--border-strong': 'rgba(255, 171, 117, 0.42)',
+      '--line': 'rgba(152, 102, 76, 0.17)',
+      '--text': '#f0ddd3',
+      '--text-dim': '#c3a394',
+      '--text-muted': '#8d6d62',
+      '--accent': '#ffae76',
+      '--accent-secondary': '#ff6f66',
+      '--accent-soft': 'rgba(255, 174, 118, 0.12)',
+      '--success': '#8cebc0',
+      '--danger': '#ff7f6d',
+      '--glow-a': 'rgba(255, 111, 102, 0.11)',
+      '--glow-b': 'rgba(255, 174, 118, 0.08)'
+    },
+    colors: {
+      entity: '#ffb37d',
+      memory: '#c89f8a',
+      commitment: '#ff6f66',
+      pattern: '#ffd26f',
+      trace: '#ffdca2',
+      selected: '#fff6f2'
+    },
+    subtypes: {
+      person: '#ffd27b',
+      organization: '#8bb8ff',
+      project: '#81efb9',
+      concept: '#ff9c86',
+      location: '#ffd8ad',
+      fact: '#c89f8a',
+      commitment: '#ff6f66',
+      learning: '#8cebc0',
+      observation: '#ffba8e',
+      preference: '#ffe08c',
+      pattern: '#ffd26f',
+      relationship: '#ffae76',
+      behavioral: '#ff9279',
+      communication: '#ffba8e',
+      scheduling: '#ffe08c'
+    },
+    scene: {
+      clear: '#0a0807',
+      fog: '#0a0807',
+      ambient: '#c09383',
+      key: '#ffb37d',
+      rim: '#ff6f66',
+      grid: '#3a221c',
+      stars: ['#ff6f66', '#ffb37d', '#ffd26f', '#ffead4'],
+      bloom: 0.54,
+      chromatic: 0.0005
+    }
+  },
+  polar: {
+    id: 'polar',
+    label: 'Polar Signal',
+    css: {
+      '--bg': '#041015',
+      '--bg-elevated': '#071821',
+      '--panel': 'rgba(7, 20, 27, 0.9)',
+      '--panel-strong': 'rgba(5, 15, 20, 0.96)',
+      '--panel-muted': 'rgba(14, 32, 40, 0.83)',
+      '--border': 'rgba(97, 166, 182, 0.25)',
+      '--border-strong': 'rgba(145, 232, 244, 0.42)',
+      '--line': 'rgba(75, 126, 139, 0.17)',
+      '--text': '#d7eef4',
+      '--text-dim': '#9abdc5',
+      '--text-muted': '#678f98',
+      '--accent': '#7ef1ff',
+      '--accent-secondary': '#8acbff',
+      '--accent-soft': 'rgba(126, 241, 255, 0.12)',
+      '--success': '#8dffd1',
+      '--danger': '#ffa088',
+      '--glow-a': 'rgba(126, 241, 255, 0.12)',
+      '--glow-b': 'rgba(138, 203, 255, 0.08)'
+    },
+    colors: {
+      entity: '#8aeaff',
+      memory: '#8db8c0',
+      commitment: '#ffa088',
+      pattern: '#8acbff',
+      trace: '#d5fbff',
+      selected: '#f3fdff'
+    },
+    subtypes: {
+      person: '#f5dc87',
+      organization: '#8acbff',
+      project: '#8dffd1',
+      concept: '#a3b9ff',
+      location: '#d8fff5',
+      fact: '#8db8c0',
+      commitment: '#ffa088',
+      learning: '#8dffd1',
+      observation: '#8aeaff',
+      preference: '#d8ffc5',
+      pattern: '#8acbff',
+      relationship: '#8acbff',
+      behavioral: '#8dffd1',
+      communication: '#8aeaff',
+      scheduling: '#d8ffc5'
+    },
+    scene: {
+      clear: '#041015',
+      fog: '#041015',
+      ambient: '#8fbfca',
+      key: '#8aeaff',
+      rim: '#8acbff',
+      grid: '#16333c',
+      stars: ['#8aeaff', '#8acbff', '#8dffd1', '#f0ffff'],
+      bloom: 0.5,
+      chromatic: 0.0004
+    }
+  },
+  matrix: {
+    id: 'matrix',
+    label: 'Matrix Construct',
+    css: {
+      '--bg': '#030906',
+      '--bg-elevated': '#07110b',
+      '--panel': 'rgba(6, 18, 12, 0.9)',
+      '--panel-strong': 'rgba(4, 12, 8, 0.96)',
+      '--panel-muted': 'rgba(12, 28, 18, 0.82)',
+      '--border': 'rgba(84, 166, 112, 0.24)',
+      '--border-strong': 'rgba(123, 255, 173, 0.42)',
+      '--line': 'rgba(62, 110, 74, 0.16)',
+      '--text': '#d9f5e1',
+      '--text-dim': '#9ed0ae',
+      '--text-muted': '#5f8d6d',
+      '--accent': '#76ffab',
+      '--accent-secondary': '#b5ffd0',
+      '--accent-soft': 'rgba(118, 255, 171, 0.12)',
+      '--success': '#76ffab',
+      '--danger': '#ff8f7a',
+      '--glow-a': 'rgba(84, 255, 153, 0.14)',
+      '--glow-b': 'rgba(181, 255, 208, 0.07)'
+    },
+    colors: {
+      entity: '#7cffaf',
+      memory: '#7ea892',
+      commitment: '#ff8f7a',
+      pattern: '#afffc4',
+      trace: '#dfffe9',
+      selected: '#f5fff9'
+    },
+    subtypes: {
+      person: '#d7ff78',
+      organization: '#71f0c2',
+      project: '#7cffaf',
+      concept: '#a8ff8f',
+      location: '#b5ffd0',
+      fact: '#7ea892',
+      commitment: '#ff8f7a',
+      learning: '#7cffaf',
+      observation: '#71f0c2',
+      preference: '#d7ff78',
+      pattern: '#afffc4',
+      relationship: '#76ffab',
+      behavioral: '#98ffb1',
+      communication: '#71f0c2',
+      scheduling: '#d7ff78'
+    },
+    scene: {
+      clear: '#020704',
+      fog: '#020704',
+      ambient: '#88b698',
+      key: '#76ffab',
+      rim: '#b5ffd0',
+      grid: '#143221',
+      stars: ['#76ffab', '#afffc4', '#d7ff78', '#f2fff6'],
+      bloom: 0.46,
+      chromatic: 0.00025
+    }
+  },
+  tron: {
+    id: 'tron',
+    label: 'Lightcycle Grid',
+    css: {
+      '--bg': '#040812',
+      '--bg-elevated': '#071122',
+      '--panel': 'rgba(7, 17, 34, 0.9)',
+      '--panel-strong': 'rgba(4, 10, 22, 0.96)',
+      '--panel-muted': 'rgba(10, 26, 48, 0.83)',
+      '--border': 'rgba(96, 164, 255, 0.24)',
+      '--border-strong': 'rgba(102, 240, 255, 0.44)',
+      '--line': 'rgba(76, 126, 195, 0.16)',
+      '--text': '#dfeeff',
+      '--text-dim': '#9eb9db',
+      '--text-muted': '#6581a5',
+      '--accent': '#66f0ff',
+      '--accent-secondary': '#ff9f6f',
+      '--accent-soft': 'rgba(102, 240, 255, 0.12)',
+      '--success': '#8ff6cf',
+      '--danger': '#ff8f7a',
+      '--glow-a': 'rgba(102, 240, 255, 0.15)',
+      '--glow-b': 'rgba(255, 159, 111, 0.08)'
+    },
+    colors: {
+      entity: '#71d6ff',
+      memory: '#7a98b8',
+      commitment: '#ff9f6f',
+      pattern: '#7cb3ff',
+      trace: '#f5fbff',
+      selected: '#ffffff'
+    },
+    subtypes: {
+      person: '#ffd36f',
+      organization: '#71a9ff',
+      project: '#66f0ff',
+      concept: '#b18cff',
+      location: '#9de3ff',
+      fact: '#7a98b8',
+      commitment: '#ff9f6f',
+      learning: '#8ff6cf',
+      observation: '#71d6ff',
+      preference: '#ffd36f',
+      pattern: '#7cb3ff',
+      relationship: '#66f0ff',
+      behavioral: '#8ff6cf',
+      communication: '#71d6ff',
+      scheduling: '#ffd36f'
+    },
+    scene: {
+      clear: '#030713',
+      fog: '#030713',
+      ambient: '#86a4cf',
+      key: '#66f0ff',
+      rim: '#ff9f6f',
+      grid: '#123257',
+      stars: ['#66f0ff', '#71a9ff', '#ff9f6f', '#f5fbff'],
+      bloom: 0.62,
+      chromatic: 0.00075
+    }
+  },
+  offworld: {
+    id: 'offworld',
+    label: 'Offworld Noir',
+    css: {
+      '--bg': '#08070d',
+      '--bg-elevated': '#110d17',
+      '--panel': 'rgba(18, 13, 23, 0.9)',
+      '--panel-strong': 'rgba(12, 9, 17, 0.96)',
+      '--panel-muted': 'rgba(28, 22, 36, 0.84)',
+      '--border': 'rgba(207, 117, 88, 0.24)',
+      '--border-strong': 'rgba(255, 160, 120, 0.42)',
+      '--line': 'rgba(110, 82, 96, 0.16)',
+      '--text': '#f2ddd5',
+      '--text-dim': '#c7aaa1',
+      '--text-muted': '#8f736c',
+      '--accent': '#ff9b73',
+      '--accent-secondary': '#ffd26b',
+      '--accent-soft': 'rgba(255, 155, 115, 0.12)',
+      '--success': '#8be2c0',
+      '--danger': '#ff7d73',
+      '--glow-a': 'rgba(255, 155, 115, 0.13)',
+      '--glow-b': 'rgba(255, 210, 107, 0.08)'
+    },
+    colors: {
+      entity: '#ffab84',
+      memory: '#b29390',
+      commitment: '#ff7d73',
+      pattern: '#ffd26b',
+      trace: '#fff0de',
+      selected: '#fff9f3'
+    },
+    subtypes: {
+      person: '#ffd26b',
+      organization: '#75b7ff',
+      project: '#8be2c0',
+      concept: '#d7a2ff',
+      location: '#ffab84',
+      fact: '#b29390',
+      commitment: '#ff7d73',
+      learning: '#8be2c0',
+      observation: '#75b7ff',
+      preference: '#ffe08c',
+      pattern: '#ffd26b',
+      relationship: '#ffab84',
+      behavioral: '#ff7d73',
+      communication: '#75b7ff',
+      scheduling: '#ffe08c'
+    },
+    scene: {
+      clear: '#07060b',
+      fog: '#07060b',
+      ambient: '#c39b8f',
+      key: '#ff9b73',
+      rim: '#ffd26b',
+      grid: '#3a242b',
+      stars: ['#ff9b73', '#ffd26b', '#75b7ff', '#fff0de'],
+      bloom: 0.56,
+      chromatic: 0.00055
+    }
+  }
+};
+
+export const DEFAULT_THEME_ID = 'claudia';
+
+export function getTheme(themeId = DEFAULT_THEME_ID) {
+  return APP_THEMES[themeId] || APP_THEMES[DEFAULT_THEME_ID];
+}
+
+export function alpha(hex, opacity) {
+  if (!hex) return `rgba(255, 255, 255, ${opacity})`;
+  const value = hex.replace('#', '');
+  const normalized = value.length === 3
+    ? value.split('').map((char) => `${char}${char}`).join('')
+    : value;
+  const int = Number.parseInt(normalized, 16);
+  const red = (int >> 16) & 255;
+  const green = (int >> 8) & 255;
+  const blue = int & 255;
+  return `rgba(${red}, ${green}, ${blue}, ${opacity})`;
+}
+
+export function applyThemeToDocument(themeId = DEFAULT_THEME_ID) {
+  if (typeof document === 'undefined') return;
+  const theme = getTheme(themeId);
+  document.documentElement.dataset.theme = theme.id;
+  for (const [key, value] of Object.entries(theme.css)) {
+    document.documentElement.style.setProperty(key, value);
+  }
+}
+
+export function nodeTone(node, themeId = DEFAULT_THEME_ID) {
+  const theme = getTheme(themeId);
+  if (node.status === 'trace') return theme.colors.trace;
+  return theme.subtypes[node.subtype] || theme.colors[node.kind] || '#8fa4bf';
+}
+
+export function resultTone(result, themeId = DEFAULT_THEME_ID, renderSettings = {}) {
+  const theme = getTheme(themeId);
+  if (result.kind === 'entity') {
+    if (result.subtype === 'person') return renderSettings.personColor || theme.subtypes.person;
+    if (result.subtype === 'organization') return renderSettings.organizationColor || theme.subtypes.organization;
+    if (result.subtype === 'project') return renderSettings.projectColor || theme.subtypes.project;
+  }
+  if (result.kind === 'commitment') {
+    return renderSettings.commitmentColor || theme.colors.commitment;
+  }
+  if (result.kind === 'memory') {
+    return renderSettings.memoryColor || theme.colors.memory;
+  }
+  return theme.subtypes[result.subtype] || theme.colors[result.kind] || theme.colors.entity;
+}
+
+export function nodeAccent(node, themeId = DEFAULT_THEME_ID) {
+  const theme = getTheme(themeId);
+  if (node.kind === 'commitment') return theme.colors.commitment;
+  if (node.kind === 'pattern') return theme.colors.pattern;
+  if (node.status === 'trace') return theme.colors.trace;
+  return theme.colors.entity;
+}
+
+export function edgeTone(edge, themeId = DEFAULT_THEME_ID) {
+  const theme = getTheme(themeId);
+  if (edge.channel === 'trace' || edge.status === 'trace') return theme.colors.trace;
+  if (edge.channel === 'commitment') return theme.colors.commitment;
+  if (edge.channel === 'relationship') return alpha(theme.colors.entity, 0.55);
+  return alpha(theme.colors.memory, 0.36);
+}
+
+export function kindLabel(kind) {
+  switch (kind) {
+    case 'entity':
+      return 'Entity';
+    case 'memory':
+      return 'Memory';
+    case 'commitment':
+      return 'Commitment';
+    case 'pattern':
+      return 'Pattern';
+    default:
+      return kind;
+  }
+}
+
+export function titleCase(value) {
+  return String(value || '')
+    .replace(/[_-]+/g, ' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+export function scorePercent(value) {
+  return `${Math.round(Number(value || 0) * 100)}%`;
+}
+
+export function formatNumber(value) {
+  return new Intl.NumberFormat().format(Number(value || 0));
+}
+
+export function formatDateTime(value) {
+  if (!value) return 'Unknown';
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return 'Unknown';
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit'
+  }).format(parsed);
+}
+
+export function formatDateShort(value) {
+  if (!value) return 'Unknown';
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return 'Unknown';
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric'
+  }).format(parsed);
+}
+
+export function formatRelative(value) {
+  if (!value) return 'No recent activity';
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return 'No recent activity';
+  const delta = parsed.getTime() - Date.now();
+  const abs = Math.abs(delta);
+  const minute = 60000;
+  const hour = minute * 60;
+  const day = hour * 24;
+  if (abs < hour) return `${Math.round(delta / minute)}m`;
+  if (abs < day) return `${Math.round(delta / hour)}h`;
+  return `${Math.round(delta / day)}d`;
+}
+
+export function trunc(value, max = 120) {
+  const text = String(value || '').trim();
+  if (!text) return '';
+  return text.length > max ? `${text.slice(0, max).trimEnd()}...` : text;
+}

--- a/visualizer/src/main.jsx
+++ b/visualizer/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { AppShell } from './app/AppShell.jsx';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <AppShell />
+  </React.StrictMode>
+);
+

--- a/visualizer/src/store/useGraphStore.js
+++ b/visualizer/src/store/useGraphStore.js
@@ -1,0 +1,794 @@
+import { create } from 'zustand';
+import { mergeGraphData } from '../lib/graphAdapters.js';
+import { querySearch } from '../lib/search.js';
+import { DEFAULT_THEME_ID, ENTITY_SUBTYPES, MEMORY_SUBTYPES, PATTERN_SUBTYPES } from '../lib/theme.js';
+
+const EMPTY_GRAPH = {
+  meta: {},
+  nodes: [],
+  edges: []
+};
+
+const defaultFilters = {
+  entities: Object.fromEntries(ENTITY_SUBTYPES.map((type) => [type, true])),
+  memories: Object.fromEntries(MEMORY_SUBTYPES.map((type) => [type, type !== 'fact'])),
+  patterns: Object.fromEntries(PATTERN_SUBTYPES.map((type) => [type, true]))
+};
+
+const defaultRenderSettings = {
+  entitySize: 0.6,
+  memorySize: 0.5,
+  patternSize: 0.45,
+  edgeIntensity: 1,
+  lineThickness: 1.25,
+  selectedLineThickness: 3,
+  edgeOpacity: 1,
+  lineCurvature: 1,
+  nodeOpacity: 1,
+  labelDensity: 0.55,
+  labelMode: 'balanced',
+  labelScale: 1.8,
+  showCommitments: true,
+  showPatterns: true,
+  traceEmphasis: 1.45,
+  motionReduced: false,
+  motionLevel: 'full',
+  bloomStrength: 0.2,
+  chromaticStrength: 0.85,
+  cameraMoveSpeed: 0.5,
+  autoRotateEnabled: true,
+  autoRotateGlobal: false,
+  autoRotateSpeed: 0.1,
+  showParticles: true,
+  particleSpeed: 1.8,
+  particleSize: 0.65,
+  showOverviewMemories: true,
+  gridOpacity: 0.34,
+  gridDensity: 1.15,
+  fogNear: 1,
+  fogFar: 1,
+  memoryColor: '#8aa3b8',
+  commitmentColor: '#ff956f',
+  memoryStyle: 'shard',
+  commitmentStyle: 'diamond',
+  personColor: '#f0cf72',
+  organizationColor: '#7fb9ff',
+  projectColor: '#77efbf'
+};
+
+const STORAGE_KEYS = {
+  defaultsRevision: 'claudia-defaults-revision',
+  themeId: 'claudia-theme-id',
+  renderSettings: 'claudia-render-settings',
+  sceneQuality: 'claudia-scene-quality'
+};
+const DEFAULTS_REVISION = '2026-02-28-claudia-preset-3';
+
+function readStoredJson(key, fallback) {
+  if (typeof window === 'undefined') return fallback;
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return fallback;
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? { ...fallback, ...parsed } : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function persistSettingBundle(key, value) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // ignore storage failures
+  }
+}
+
+function mergeFilterKeys(current = {}, keys = []) {
+  const next = { ...current };
+  for (const key of keys) {
+    if (!key || key in next) continue;
+    next[key] = true;
+  }
+  return next;
+}
+
+function mergeFilterGroups(activeFilters, additions = {}) {
+  return {
+    entities: mergeFilterKeys(activeFilters.entities, additions.entities),
+    memories: mergeFilterKeys(activeFilters.memories, additions.memories),
+    patterns: mergeFilterKeys(activeFilters.patterns, additions.patterns)
+  };
+}
+
+function enabledFilterGroup(group = {}, groupName = '') {
+  return Object.fromEntries(Object.keys(group).map((key) => [
+    key,
+    groupName === 'memories' && key === 'fact' ? false : true
+  ]));
+}
+
+function subtypeGroupsFromStats(stats) {
+  return {
+    entities: (stats?.entityTypes || []).map((entry) => entry.type),
+    memories: (stats?.memoryTypes || []).map((entry) => entry.type),
+    patterns: PATTERN_SUBTYPES
+  };
+}
+
+function subtypeGroupsFromGraph(graph) {
+  const groups = {
+    entities: new Set(),
+    memories: new Set(),
+    patterns: new Set()
+  };
+
+  for (const node of graph?.nodes || []) {
+    if (!node?.subtype) continue;
+    if (node.kind === 'entity') groups.entities.add(node.subtype);
+    else if (node.kind === 'pattern') groups.patterns.add(node.subtype);
+    else groups.memories.add(node.subtype);
+  }
+
+  return {
+    entities: [...groups.entities],
+    memories: [...groups.memories],
+    patterns: [...groups.patterns]
+  };
+}
+
+async function fetchJson(url, options) {
+  const response = await fetch(url, options);
+  if (!response.ok) {
+    let message = `${response.status}`;
+    try {
+      const body = await response.json();
+      message = body.error || body.message || message;
+    } catch {
+      // ignore JSON parse failures
+    }
+    throw new Error(message);
+  }
+  return response.json();
+}
+
+function nodeIndexFromGraphs(...graphs) {
+  const index = new Map();
+  for (const graph of graphs.filter(Boolean)) {
+    for (const node of graph.nodes || []) {
+      index.set(node.id, node);
+    }
+  }
+  return index;
+}
+
+function getNodeById(state, nodeId = state.selectedNodeId) {
+  if (!nodeId) return null;
+  return nodeIndexFromGraphs(state.overviewGraph, state.neighborhoodGraph, state.traceGraph).get(nodeId) || null;
+}
+
+function primaryEntityGraphId(node) {
+  if (!node) return null;
+  if (node.kind === 'entity') return node.id;
+  if (node.anchorRef) return node.anchorRef;
+  const entityId = node.entityRefs?.[0];
+  return entityId ? `entity-${entityId}` : null;
+}
+
+export function selectActiveGraph(state) {
+  if (state.graphMode === 'trace' && state.traceGraph) {
+    return mergeGraphData(state.overviewGraph, state.traceGraph);
+  }
+  if ((state.graphMode === 'neighborhood' || state.graphMode === 'evidence') && state.neighborhoodGraph) {
+    return mergeGraphData(state.overviewGraph, state.neighborhoodGraph);
+  }
+  return state.overviewGraph || EMPTY_GRAPH;
+}
+
+export function selectSelectedNode(state) {
+  return getNodeById(state, state.selectedNodeId);
+}
+
+export function selectHoveredNode(state) {
+  return getNodeById(state, state.hoveredNodeId);
+}
+
+export function selectPinnedNodes(state) {
+  const index = nodeIndexFromGraphs(state.overviewGraph, state.neighborhoodGraph, state.traceGraph);
+  return state.pinnedNodeIds.map((id) => index.get(id)).filter(Boolean);
+}
+
+export const useGraphStore = create((set, get) => ({
+  initialized: false,
+  themeId: DEFAULT_THEME_ID,
+  stats: null,
+  databases: [],
+  activeDatabasePath: null,
+  overviewGraph: EMPTY_GRAPH,
+  neighborhoodGraph: null,
+  traceGraph: null,
+  graphMode: 'overview',
+  selectedNodeId: null,
+  hoveredNodeId: null,
+  pinnedNodeIds: [],
+  expandedNeighborhoodIds: [],
+  activeFilters: defaultFilters,
+  renderSettings: defaultRenderSettings,
+  searchQuery: '',
+  searchResults: [],
+  searchOpen: false,
+  settingsOpen: false,
+  timelineWindow: 100,
+  traceEndpoints: {
+    from: null,
+    to: null
+  },
+  tracePath: [],
+  entityDetails: {},
+  inspectorCommitments: [],
+  commitmentFeed: [],
+  neighborhoodCache: {},
+  traceCache: {},
+  loadingState: {
+    boot: false,
+    overview: false,
+    neighborhood: false,
+    trace: false,
+    search: false,
+    detail: false,
+    database: false
+  },
+  errorMessage: '',
+  cameraTarget: null,
+  cameraState: {
+    targetNodeId: null,
+    mode: 'overview'
+  },
+  layoutState: {
+    positions: {},
+    velocities: {},
+    reheatToken: 0
+  },
+  sceneQuality: {
+    quality: 'balanced',
+    effectsEnabled: true
+  },
+  fitNonce: 0,
+  leftPanelOpen: true,
+  inspectorOpen: true,
+  bottomPanelOpen: true,
+
+  init: async () => {
+    if (get().initialized || get().loadingState.boot) return;
+    const defaultsRevision = typeof window !== 'undefined' ? window.localStorage.getItem(STORAGE_KEYS.defaultsRevision) : null;
+    const storedTheme = typeof window !== 'undefined' ? window.localStorage.getItem(STORAGE_KEYS.themeId) : null;
+    const storedRenderSettings = readStoredJson(STORAGE_KEYS.renderSettings, defaultRenderSettings);
+    const storedSceneQuality = readStoredJson(STORAGE_KEYS.sceneQuality, {
+      quality: 'balanced',
+      effectsEnabled: true
+    });
+    if (defaultsRevision !== DEFAULTS_REVISION && typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEYS.defaultsRevision, DEFAULTS_REVISION);
+      window.localStorage.setItem(STORAGE_KEYS.themeId, DEFAULT_THEME_ID);
+      persistSettingBundle(STORAGE_KEYS.renderSettings, defaultRenderSettings);
+      persistSettingBundle(STORAGE_KEYS.sceneQuality, {
+        quality: 'balanced',
+        effectsEnabled: true
+      });
+      set({
+        themeId: DEFAULT_THEME_ID,
+        renderSettings: defaultRenderSettings,
+        sceneQuality: {
+          quality: 'balanced',
+          effectsEnabled: true
+        }
+      });
+    } else if (storedTheme || storedRenderSettings || storedSceneQuality) {
+      set((state) => ({
+        themeId: storedTheme || state.themeId,
+        renderSettings: storedRenderSettings,
+        sceneQuality: storedSceneQuality
+      }));
+    }
+
+    set((state) => ({
+      loadingState: { ...state.loadingState, boot: true },
+      errorMessage: ''
+    }));
+
+    try {
+      await Promise.all([
+        get().loadOverview(),
+        get().loadStats(),
+        get().loadDatabases(),
+        get().loadGlobalCommitments()
+      ]);
+      set({ initialized: true });
+    } catch (error) {
+      set({ errorMessage: error.message || 'Failed to initialize graph explorer' });
+    } finally {
+      set((state) => ({
+        loadingState: { ...state.loadingState, boot: false }
+      }));
+    }
+  },
+
+  loadStats: async () => {
+    const stats = await fetchJson('/api/stats');
+    set((state) => ({
+      stats,
+      activeFilters: mergeFilterGroups(state.activeFilters, subtypeGroupsFromStats(stats))
+    }));
+  },
+
+  loadDatabases: async () => {
+    const result = await fetchJson('/api/databases');
+    set({
+      databases: result.databases || [],
+      activeDatabasePath: result.current || null
+    });
+  },
+
+  loadOverview: async () => {
+    set((state) => ({
+      loadingState: { ...state.loadingState, overview: true },
+      errorMessage: ''
+    }));
+    try {
+      const params = new URLSearchParams();
+      if (get().renderSettings.showOverviewMemories) {
+        params.set('includeMemories', '1');
+      }
+      const overviewGraph = await fetchJson(`/api/graph/overview${params.size ? `?${params.toString()}` : ''}`);
+      set((state) => ({
+        overviewGraph,
+        activeFilters: mergeFilterGroups(state.activeFilters, subtypeGroupsFromGraph(overviewGraph)),
+        graphMode: state.graphMode === 'trace' ? 'overview' : state.graphMode,
+        cameraState: { ...state.cameraState, mode: 'overview' },
+        layoutState: {
+          ...state.layoutState,
+          reheatToken: state.layoutState.reheatToken + 1
+        },
+        loadingState: { ...state.loadingState, overview: false }
+      }));
+    } catch (error) {
+      set((state) => ({
+        loadingState: { ...state.loadingState, overview: false },
+        errorMessage: error.message || 'Failed to load overview graph'
+      }));
+    }
+  },
+
+  loadGlobalCommitments: async () => {
+    const result = await fetchJson('/api/commitments/active?limit=12');
+    set({ commitmentFeed: result.items || [] });
+  },
+
+  switchDatabase: async (path) => {
+    if (!path || path === get().activeDatabasePath) return;
+    set((state) => ({
+      loadingState: { ...state.loadingState, database: true },
+      errorMessage: ''
+    }));
+    try {
+      await fetchJson('/api/database/switch', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path })
+      });
+
+      set((state) => ({
+        neighborhoodGraph: null,
+        traceGraph: null,
+        neighborhoodCache: {},
+        traceCache: {},
+        selectedNodeId: null,
+        hoveredNodeId: null,
+        pinnedNodeIds: [],
+        traceEndpoints: { from: null, to: null },
+        tracePath: [],
+        entityDetails: {},
+        inspectorCommitments: [],
+        graphMode: 'overview',
+        cameraTarget: null,
+        cameraState: { targetNodeId: null, mode: 'overview' },
+        layoutState: { positions: {}, velocities: {}, reheatToken: state.layoutState.reheatToken + 1 }
+      }));
+
+      await Promise.all([
+        get().loadOverview(),
+        get().loadStats(),
+        get().loadDatabases(),
+        get().loadGlobalCommitments()
+      ]);
+    } catch (error) {
+      set({ errorMessage: error.message || 'Failed to switch database' });
+    } finally {
+      set((state) => ({
+        loadingState: { ...state.loadingState, database: false }
+      }));
+    }
+  },
+
+  setGraphMode: (graphMode) => set((state) => ({
+    graphMode,
+    cameraState: { ...state.cameraState, mode: graphMode === 'trace' ? 'trace' : graphMode === 'overview' ? 'overview' : 'inspect' }
+  })),
+
+  setHoveredNode: (hoveredNodeId) => set({ hoveredNodeId }),
+
+  requestFit: () => set((state) => ({
+    fitNonce: state.fitNonce + 1,
+    cameraState: { ...state.cameraState, mode: 'overview' }
+  })),
+
+  setTheme: (themeId) => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEYS.defaultsRevision, DEFAULTS_REVISION);
+      window.localStorage.setItem(STORAGE_KEYS.themeId, themeId);
+    }
+    set({ themeId });
+  },
+
+  requestFocus: (cameraTarget, mode = 'inspect') => set({
+    cameraTarget,
+    cameraState: {
+      targetNodeId: cameraTarget,
+      mode
+    }
+  }),
+
+  setSearchOpen: (searchOpen) => set({ searchOpen }),
+  setSettingsOpen: (settingsOpen) => set({ settingsOpen }),
+  setLeftPanelOpen: (leftPanelOpen) => set({ leftPanelOpen }),
+  setInspectorOpen: (inspectorOpen) => set({ inspectorOpen }),
+  setBottomPanelOpen: (bottomPanelOpen) => set({ bottomPanelOpen }),
+  toggleLeftPanel: () => set((state) => ({ leftPanelOpen: !state.leftPanelOpen })),
+  toggleRightPanel: () => set((state) => ({ inspectorOpen: !state.inspectorOpen })),
+  toggleBottomPanel: () => set((state) => ({ bottomPanelOpen: !state.bottomPanelOpen })),
+  setSearchQuery: (searchQuery) => set({ searchQuery }),
+
+  runSearch: async (query) => {
+    const trimmed = String(query || '').trim();
+    set((state) => ({
+      loadingState: { ...state.loadingState, search: Boolean(trimmed) }
+    }));
+
+    if (!trimmed) {
+      set((state) => ({
+        searchResults: [],
+        loadingState: { ...state.loadingState, search: false }
+      }));
+      return;
+    }
+
+    try {
+      const result = await querySearch(trimmed, 18);
+      if (get().searchQuery.trim() !== trimmed) return;
+      set((state) => ({
+        searchResults: result.results || [],
+        loadingState: { ...state.loadingState, search: false }
+      }));
+    } catch (error) {
+      set((state) => ({
+        loadingState: { ...state.loadingState, search: false },
+        errorMessage: error.message || 'Search failed'
+      }));
+    }
+  },
+
+  toggleFilter: (group, key) => set((state) => ({
+    activeFilters: {
+      ...state.activeFilters,
+      [group]: {
+        ...state.activeFilters[group],
+        [key]: !state.activeFilters[group][key]
+      }
+    }
+  })),
+
+  resetFilters: () => set((state) => ({
+    activeFilters: {
+      entities: enabledFilterGroup(state.activeFilters.entities, 'entities'),
+      memories: enabledFilterGroup(state.activeFilters.memories, 'memories'),
+      patterns: enabledFilterGroup(state.activeFilters.patterns, 'patterns')
+    }
+  })),
+
+  setTimelineWindow: (timelineWindow) => set((state) => ({
+    timelineWindow: typeof timelineWindow === 'function'
+      ? timelineWindow(state.timelineWindow)
+      : timelineWindow
+  })),
+
+  setRenderSetting: (key, value) => set((state) => {
+    const renderSettings = {
+      ...state.renderSettings,
+      [key]: value
+    };
+    persistSettingBundle(STORAGE_KEYS.renderSettings, renderSettings);
+    if (key === 'showOverviewMemories') {
+      queueMicrotask(() => {
+        get().loadOverview();
+      });
+    }
+    return { renderSettings };
+  }),
+
+  setSceneEffectsEnabled: (effectsEnabled) => set((state) => {
+    const sceneQuality = { ...state.sceneQuality, effectsEnabled };
+    persistSettingBundle(STORAGE_KEYS.sceneQuality, sceneQuality);
+    return { sceneQuality };
+  }),
+
+  setSceneQualityMode: (quality) => set((state) => {
+    const sceneQuality = { ...state.sceneQuality, quality };
+    persistSettingBundle(STORAGE_KEYS.sceneQuality, sceneQuality);
+    return { sceneQuality };
+  }),
+
+  resetRenderSettings: () => set((state) => {
+    persistSettingBundle(STORAGE_KEYS.renderSettings, defaultRenderSettings);
+    persistSettingBundle(STORAGE_KEYS.sceneQuality, {
+      quality: 'balanced',
+      effectsEnabled: true
+    });
+    if (state.renderSettings.showOverviewMemories !== defaultRenderSettings.showOverviewMemories) {
+      queueMicrotask(() => {
+        get().loadOverview();
+      });
+    }
+    return {
+      renderSettings: defaultRenderSettings,
+      sceneQuality: {
+        quality: 'balanced',
+        effectsEnabled: true
+      }
+    };
+  }),
+
+  applySettingsPreset: (preset) => set((state) => {
+    const nextThemeId = typeof preset?.themeId === 'string' ? preset.themeId : state.themeId;
+    const nextRenderSettings = {
+      ...defaultRenderSettings,
+      ...state.renderSettings,
+      ...(preset?.renderSettings && typeof preset.renderSettings === 'object' ? preset.renderSettings : {})
+    };
+    const nextSceneQuality = {
+      quality: 'balanced',
+      effectsEnabled: true,
+      ...state.sceneQuality,
+      ...(preset?.sceneQuality && typeof preset.sceneQuality === 'object' ? preset.sceneQuality : {})
+    };
+
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEYS.defaultsRevision, DEFAULTS_REVISION);
+      window.localStorage.setItem(STORAGE_KEYS.themeId, nextThemeId);
+    }
+    persistSettingBundle(STORAGE_KEYS.renderSettings, nextRenderSettings);
+    persistSettingBundle(STORAGE_KEYS.sceneQuality, nextSceneQuality);
+    if (state.renderSettings.showOverviewMemories !== nextRenderSettings.showOverviewMemories) {
+      queueMicrotask(() => {
+        get().loadOverview();
+      });
+    }
+
+    return {
+      themeId: nextThemeId,
+      renderSettings: nextRenderSettings,
+      sceneQuality: nextSceneQuality
+    };
+  }),
+
+  setLayoutSnapshot: (positions, velocities = {}, bumpReheat = false) => set((state) => ({
+    layoutState: {
+      positions,
+      velocities,
+      reheatToken: bumpReheat ? state.layoutState.reheatToken + 1 : state.layoutState.reheatToken
+    }
+  })),
+
+  reheatLayout: () => set((state) => ({
+    layoutState: {
+      ...state.layoutState,
+      reheatToken: state.layoutState.reheatToken + 1
+    }
+  })),
+
+  togglePinNode: (nodeId) => set((state) => ({
+    pinnedNodeIds: state.pinnedNodeIds.includes(nodeId)
+      ? state.pinnedNodeIds.filter((value) => value !== nodeId)
+      : [...state.pinnedNodeIds, nodeId]
+  })),
+
+  clearSelection: () => set((state) => ({
+    selectedNodeId: null,
+    hoveredNodeId: null,
+    inspectorCommitments: [],
+    cameraState: { ...state.cameraState, targetNodeId: null, mode: 'overview' }
+  })),
+
+  clearTrace: () => set((state) => ({
+    traceGraph: null,
+    graphMode: 'overview',
+    traceEndpoints: { from: null, to: null },
+    tracePath: [],
+    cameraState: { ...state.cameraState, mode: 'overview' },
+    layoutState: { ...state.layoutState, reheatToken: state.layoutState.reheatToken + 1 }
+  })),
+
+  loadNeighborhood: async (nodeId, depth = 1) => {
+    if (!nodeId) return;
+    const cacheKey = `${nodeId}:${depth}`;
+    const cached = get().neighborhoodCache[cacheKey];
+    if (cached) {
+      set((state) => ({
+        neighborhoodGraph: cached,
+        graphMode: depth > 1 ? 'evidence' : 'neighborhood',
+        cameraState: { ...state.cameraState, mode: 'inspect', targetNodeId: nodeId },
+        layoutState: { ...state.layoutState, reheatToken: state.layoutState.reheatToken + 1 }
+      }));
+      return;
+    }
+
+    set((state) => ({
+      loadingState: { ...state.loadingState, neighborhood: true }
+    }));
+    try {
+      const graph = await fetchJson(`/api/graph/neighborhood/${nodeId}?depth=${depth}`);
+      set((state) => ({
+        neighborhoodGraph: graph,
+        neighborhoodCache: {
+          ...state.neighborhoodCache,
+          [cacheKey]: graph
+        },
+        expandedNeighborhoodIds: state.expandedNeighborhoodIds.includes(nodeId)
+          ? state.expandedNeighborhoodIds
+          : [...state.expandedNeighborhoodIds, nodeId],
+        graphMode: depth > 1 ? 'evidence' : 'neighborhood',
+        cameraState: { ...state.cameraState, mode: 'inspect', targetNodeId: nodeId },
+        layoutState: { ...state.layoutState, reheatToken: state.layoutState.reheatToken + 1 },
+        loadingState: { ...state.loadingState, neighborhood: false }
+      }));
+    } catch (error) {
+      set((state) => ({
+        loadingState: { ...state.loadingState, neighborhood: false },
+        errorMessage: error.message || 'Failed to load neighborhood'
+      }));
+    }
+  },
+
+  loadTrace: async (from, to) => {
+    if (!from || !to) return;
+    const cacheKey = `${from}:${to}`;
+    const cached = get().traceCache[cacheKey];
+    if (cached) {
+      set((state) => ({
+        traceGraph: cached,
+        graphMode: 'trace',
+        tracePath: cached.path || [],
+        cameraState: { ...state.cameraState, mode: 'trace', targetNodeId: to },
+        layoutState: { ...state.layoutState, reheatToken: state.layoutState.reheatToken + 1 }
+      }));
+      return;
+    }
+
+    set((state) => ({
+      loadingState: { ...state.loadingState, trace: true }
+    }));
+    try {
+      const graph = await fetchJson(`/api/graph/trace?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}&maxDepth=4`);
+      set((state) => ({
+        traceGraph: graph,
+        traceCache: {
+          ...state.traceCache,
+          [cacheKey]: graph
+        },
+        graphMode: 'trace',
+        tracePath: graph.path || [],
+        cameraState: { ...state.cameraState, mode: 'trace', targetNodeId: to },
+        layoutState: { ...state.layoutState, reheatToken: state.layoutState.reheatToken + 1 },
+        loadingState: { ...state.loadingState, trace: false }
+      }));
+    } catch (error) {
+      set((state) => ({
+        loadingState: { ...state.loadingState, trace: false },
+        errorMessage: error.message || 'Failed to trace relationship path'
+      }));
+    }
+  },
+
+  hydrateInspector: async (nodeId) => {
+    const node = getNodeById(get(), nodeId);
+    const entityId = primaryEntityGraphId(node);
+
+    if (!entityId) {
+      set({ inspectorCommitments: [] });
+      return;
+    }
+
+    const numericEntityId = Number(entityId.replace('entity-', ''));
+    set((state) => ({
+      loadingState: { ...state.loadingState, detail: true }
+    }));
+    try {
+      const cachedDetail = get().entityDetails[numericEntityId];
+      const detailPromise = cachedDetail
+        ? Promise.resolve(cachedDetail)
+        : fetchJson(`/api/entity/${numericEntityId}`);
+      const commitmentsPromise = fetchJson(`/api/commitments/active?entityId=entity-${numericEntityId}&limit=8`);
+      const [detail, commitmentData] = await Promise.all([detailPromise, commitmentsPromise]);
+
+      set((state) => ({
+        entityDetails: cachedDetail ? state.entityDetails : {
+          ...state.entityDetails,
+          [numericEntityId]: detail
+        },
+        inspectorCommitments: commitmentData.items || [],
+        loadingState: { ...state.loadingState, detail: false }
+      }));
+    } catch (error) {
+      set((state) => ({
+        loadingState: { ...state.loadingState, detail: false },
+        errorMessage: error.message || 'Failed to load inspector details'
+      }));
+    }
+  },
+
+  revealEvidence: async (nodeId) => {
+    await get().loadNeighborhood(nodeId, 2);
+    set((state) => ({
+      selectedNodeId: nodeId,
+      cameraTarget: nodeId,
+      cameraState: { ...state.cameraState, targetNodeId: nodeId, mode: 'inspect' }
+    }));
+  },
+
+  selectNode: async (nodeId, options = {}) => {
+    const node = getNodeById(get(), nodeId);
+    if (!node) return;
+
+    if (options.shiftKey && node.kind === 'entity') {
+      const current = get().traceEndpoints;
+      if (!current.from || current.to) {
+        set((state) => ({
+          selectedNodeId: nodeId,
+          traceEndpoints: { from: nodeId, to: null },
+          graphMode: 'overview',
+          cameraTarget: nodeId,
+          cameraState: { ...state.cameraState, targetNodeId: nodeId, mode: 'overview' }
+        }));
+        await get().hydrateInspector(nodeId);
+        return;
+      }
+
+      if (current.from !== nodeId) {
+        set((state) => ({
+          selectedNodeId: nodeId,
+          traceEndpoints: { from: current.from, to: nodeId },
+          cameraTarget: nodeId,
+          cameraState: { ...state.cameraState, targetNodeId: nodeId, mode: 'trace' }
+        }));
+        await get().loadTrace(current.from, nodeId);
+        await get().hydrateInspector(nodeId);
+      }
+      return;
+    }
+
+    set((state) => ({
+      selectedNodeId: nodeId,
+      cameraTarget: nodeId,
+      graphMode: state.graphMode === 'trace' ? 'overview' : state.graphMode,
+      cameraState: { ...state.cameraState, targetNodeId: nodeId, mode: 'inspect' },
+      inspectorOpen: true
+    }));
+
+    await get().hydrateInspector(nodeId);
+
+    if (options.doubleClick) {
+      await get().loadNeighborhood(nodeId, 2);
+      return;
+    }
+  }
+}));

--- a/visualizer/vite.config.js
+++ b/visualizer/vite.config.js
@@ -1,23 +1,21 @@
 import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+const apiProxy = process.env.VITE_API_PROXY || 'http://localhost:3849';
 
 export default defineConfig({
+  plugins: [react()],
   root: '.',
   publicDir: 'public',
   server: {
     port: 5173,
     proxy: {
-      '/api': 'http://localhost:3849',
-      '/health': 'http://localhost:3849'
+      '/api': apiProxy,
+      '/health': apiProxy
     }
   },
   build: {
     outDir: 'dist',
     sourcemap: true
-  },
-  optimizeDeps: {
-    exclude: ['public-legacy']
-  },
-  resolve: {
-    alias: {}
   }
 });


### PR DESCRIPTION
## Summary

This PR proposes the rebuilt `visualizer/` app as Claudia's primary `/brain` experience.

The goal is to replace the older experimental visualizer runtime path with a relationship-first 3D knowledge graph explorer that is actually useful for browsing the local Claudia database, while keeping the rest of Claudia's core architecture intact.

## What changes

- rebuilds the visualizer UI around a React + `react-three-fiber` scene
- adds normalized graph APIs for overview, neighborhood, trace, search, and commitments
- makes the graph entity-first by default, with optional memory overlays and memory-type filters
- adds live tuning for labels, lines, particles, grid, fog, and themes
- improves `/brain` docs and adds a rollout/deprecation note in `docs/visualizer-rollout.md`
- preserves the rest of Claudia's installer, template, and memory-daemon codepaths

## Why this should replace prior visualizers

The old graph paths were useful experiments, but this version is the first one that is positioned as a maintainable primary explorer:

- relationship tracing is a first-class workflow
- evidence and commitments are inspectable instead of decorative
- local database switching is built in
- the shell is organized for search, inspection, and tuning
- the runtime is scoped to `visualizer/` instead of spreading changes through Claudia core

## Non-destructive rollout

This PR is intentionally scoped so maintainers can adopt the new visualizer without destabilizing the rest of Claudia:

- Claudia installer stays intact
- Claudia template and commands stay intact
- Claudia memory daemon stays intact
- SQLite schema is not rewritten for this PR
- legacy visualizer paths are deprecated in docs/positioning, not treated as Claudia-wide breakage

See: `docs/visualizer-rollout.md`

## Verification

- `cd visualizer && npm run build`
- `GET /api/graph/overview`
- `GET /api/graph/overview?includeMemories=1`
- `GET /api/graph/neighborhood/:graphId`
- `GET /api/graph/trace`
- `GET /api/search`
- `GET /api/commitments/active`

## Known limitation

The included Playwright smoke test is only a shell-level check. In headless Chromium, WebGL context creation can fail, so final visual validation still needs a normal desktop browser session.

## Maintainer framing

I am intentionally proposing this as the new primary `/brain` explorer, not as a rewrite of Claudia itself.

If accepted, the next maintainer step should be to treat this visualizer as the preferred graph surface and retire older visualizer paths over time, while leaving the rest of the Claudia codebase untouched unless there is a separate reason to change it.
