### PR TITLE
feat(memory): Node.js CLI replacing Python MCP daemon

### DIFF
--- a/cli/commands/cognitive.js
+++ b/cli/commands/cognitive.js
@@ -1,0 +1,134 @@
+/**
+ * Cognitive commands for Claudia CLI.
+ * Implements: claudia cognitive ingest
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { resolveProjectDir } from '../core/paths.js';
+import { getDatabase } from '../core/database.js';
+import { getConfig } from '../core/config.js';
+import { outputJson, outputError } from '../core/output.js';
+import { ingest } from '../services/ingest.js';
+import { extractAll } from '../services/extraction.js';
+
+/**
+ * claudia cognitive ingest --text "..." | --file <path>
+ * Extract entities, facts, commitments from text using Ollama LLM.
+ * Falls back to regex extraction if LLM unavailable.
+ */
+export async function cognitiveIngestCommand(opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+
+    // Get text from --text or --file
+    let text = opts.text;
+    if (!text && opts.file) {
+      const filePath = resolve(opts.file);
+      text = readFileSync(filePath, 'utf-8');
+    }
+
+    if (!text) {
+      outputError('No text provided. Use --text or --file.');
+      process.exitCode = 1;
+      return;
+    }
+
+    // Determine source type from option or auto-detect
+    const sourceType = opts.type || _detectSourceType(text);
+
+    // Try LLM extraction first
+    const result = await ingest(text, {
+      sourceType,
+      context: opts.context,
+    });
+
+    // If LLM unavailable, fall back to regex extraction
+    if (result.status === 'llm_unavailable') {
+      const regexResult = extractAll(text);
+      outputJson({
+        status: 'regex_fallback',
+        source_type: sourceType,
+        data: {
+          entities: regexResult.entities,
+          memories: regexResult.memories,
+        },
+        message: 'LLM unavailable — used regex extraction. Install Ollama and pull the language model for richer extraction.',
+      });
+      return;
+    }
+
+    // If LLM returned but parse failed, include regex as supplement
+    if (result.status === 'parse_error') {
+      const regexResult = extractAll(text);
+      outputJson({
+        status: 'parse_error_with_fallback',
+        source_type: sourceType,
+        data: {
+          entities: regexResult.entities,
+          memories: regexResult.memories,
+        },
+        raw_output: result.raw_output,
+        message: 'LLM output could not be parsed. Regex extraction included as fallback.',
+      });
+      return;
+    }
+
+    // Successful LLM extraction — augment with regex entities if needed
+    const regexResult = extractAll(text);
+    const llmEntities = result.data.entities || [];
+    const regexEntities = regexResult.entities || [];
+
+    // Merge: add regex entities not already found by LLM
+    const llmNames = new Set(llmEntities.map(e => (e.name || '').toLowerCase()));
+    const supplemental = regexEntities.filter(e => !llmNames.has(e.name.toLowerCase()));
+
+    if (supplemental.length > 0) {
+      result.data.entities = [...llmEntities, ...supplemental.map(e => ({
+        name: e.name,
+        type: e.type,
+        description: null,
+      }))];
+    }
+
+    outputJson(result);
+  } catch (err) {
+    outputError('Cognitive ingest failed', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+// ----- Helpers -----
+
+/**
+ * Auto-detect source type from text content.
+ */
+function _detectSourceType(text) {
+  const lower = text.toLowerCase();
+
+  // Meeting detection
+  if (
+    /\b(meeting|standup|sync|call|discussion|agenda|attendees?)\b/.test(lower) &&
+    /\b(action items?|next steps?|follow.?up|decided|agreed)\b/.test(lower)
+  ) {
+    return 'meeting';
+  }
+
+  // Email detection
+  if (
+    /^(from|to|subject|date|cc|bcc)\s*:/im.test(text) ||
+    /\b(dear |hi |hello |regards|sincerely|best wishes)\b/i.test(lower)
+  ) {
+    return 'email';
+  }
+
+  // Document detection (structured content with headings)
+  if (
+    /^#{1,3}\s/m.test(text) ||
+    /\b(abstract|introduction|conclusion|references|table of contents)\b/.test(lower)
+  ) {
+    return 'document';
+  }
+
+  return 'general';
+}

--- a/cli/commands/memory.js
+++ b/cli/commands/memory.js
@@ -1,0 +1,1181 @@
+/**
+ * Memory commands for Claudia CLI.
+ * Wires all memory subcommands to service layer functions.
+ *
+ * Every handler:
+ *  1. Resolves project dir from global opts
+ *  2. Gets database and config
+ *  3. Validates inputs with guards (where applicable)
+ *  4. Calls the appropriate service function
+ *  5. Outputs JSON result
+ *  6. Handles errors with outputError
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { createHash } from 'node:crypto';
+import { resolveProjectDir } from '../core/paths.js';
+import { getDatabase } from '../core/database.js';
+import { getConfig } from '../core/config.js';
+import { outputJson, outputError, outputSuccess } from '../core/output.js';
+import { validateMemory, validateEntity, validateRelationship, canonicalName } from '../core/guards.js';
+
+import {
+  rememberFact,
+  rememberEntity,
+  relateEntities,
+  invalidateRelationship,
+  correctMemory,
+  invalidateMemory,
+  bufferTurn,
+  endSession,
+  storeReflection,
+  updateReflection,
+  deleteReflection,
+  getUnsummarizedTurns,
+  mergeEntities,
+  deleteEntity,
+  batchOperations,
+} from '../services/remember.js';
+
+import {
+  recall,
+  recallAbout,
+  recallSince,
+  recallTemporal,
+  recallTimeline,
+  recallUpcomingDeadlines,
+  searchEntities,
+  getProjectNetwork,
+  findPath,
+  getHubEntities,
+  getDormantRelationships,
+  getReflections,
+  searchReflections,
+  fetchByIds,
+  traceMemory,
+  getBriefing,
+  getProjectHealth,
+  getRecentMemories,
+  entityOverview,
+  getActiveReflections,
+} from '../services/recall.js';
+
+import {
+  runFullConsolidation,
+  runDecay,
+} from '../services/consolidate.js';
+
+import {
+  fileDocument,
+  searchDocuments,
+} from '../services/documents.js';
+
+import {
+  getAuditRecent,
+  getEntityAuditHistory,
+  getMemoryAuditHistory,
+} from '../services/audit.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Read all data from stdin as a string.
+ * @returns {Promise<string>}
+ */
+async function readStdin() {
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks).toString('utf-8');
+}
+
+// ---------------------------------------------------------------------------
+// Core Memory Commands
+// ---------------------------------------------------------------------------
+
+/**
+ * claudia memory save <content>
+ * Validate via guards, call rememberFact.
+ */
+export async function memorySaveCommand(content, opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    // Validate
+    const validation = validateMemory(content, opts.type, opts.importance);
+    if (!validation.isValid) {
+      outputError(validation.warnings.join('; '));
+      process.exitCode = 1;
+      return;
+    }
+
+    // Apply adjustments from validation
+    const finalContent = validation.adjustments.content || content;
+    const finalImportance = validation.adjustments.importance != null
+      ? validation.adjustments.importance
+      : opts.importance;
+
+    const result = await rememberFact(db, finalContent, {
+      memoryType: opts.type,
+      importance: finalImportance,
+      source: opts.source,
+      sourceContext: opts.sourceContext,
+      sourceChannel: opts.sourceChannel,
+      person: opts.person,
+      entities: opts.entity,
+      critical: opts.critical || false,
+    });
+
+    outputJson({ ...result, warnings: validation.warnings });
+  } catch (err) {
+    outputError('Failed to save memory', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+/**
+ * claudia memory recall <query>
+ * Call recall with options.
+ */
+export async function memoryRecallCommand(query, opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    const results = await recall(db, config, query, {
+      limit: opts.limit,
+      memoryTypes: opts.type,
+      entityName: opts.entity,
+      since: opts.since,
+      before: opts.before,
+      includeArchived: opts.includeArchived || false,
+    });
+
+    outputJson(results);
+  } catch (err) {
+    outputError('Failed to recall memories', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+/**
+ * claudia memory about <entity>
+ * Call recallAbout.
+ */
+export async function memoryAboutCommand(entity, opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    const results = recallAbout(db, config, entity, {
+      limit: opts.limit,
+      includeHistorical: opts.includeHistorical || false,
+    });
+
+    outputJson(results);
+  } catch (err) {
+    outputError('Failed to recall about entity', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+/**
+ * claudia memory relate --source <name> --target <name> --type <type>
+ * Validate via guards, call relateEntities.
+ */
+export async function memoryRelateCommand(opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    if (!opts.source || !opts.target || !opts.type) {
+      outputError('--source, --target, and --type are all required');
+      process.exitCode = 1;
+      return;
+    }
+
+    // Validate relationship strength
+    const strength = opts.strength != null ? opts.strength : 1.0;
+    const originType = opts.origin || 'extracted';
+    const validation = validateRelationship(strength, originType);
+    if (!validation.isValid) {
+      outputError(validation.warnings.join('; '));
+      process.exitCode = 1;
+      return;
+    }
+
+    const finalStrength = validation.adjustments.strength != null
+      ? validation.adjustments.strength
+      : strength;
+
+    const result = relateEntities(db, opts.source, opts.target, opts.type, {
+      strength: finalStrength,
+      originType,
+      reason: opts.reason,
+    });
+
+    outputJson({ ...result, warnings: validation.warnings });
+  } catch (err) {
+    outputError('Failed to relate entities', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+/**
+ * claudia memory batch --file <path> | stdin
+ * Read JSON operations, call batchOperations.
+ */
+export async function memoryBatchCommand(opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    let jsonText;
+    if (opts.file) {
+      const filePath = resolve(opts.file);
+      jsonText = readFileSync(filePath, 'utf-8');
+    } else {
+      jsonText = await readStdin();
+    }
+
+    if (!jsonText || !jsonText.trim()) {
+      outputError('No operations provided. Use --file or pipe JSON to stdin.');
+      process.exitCode = 1;
+      return;
+    }
+
+    let operations;
+    try {
+      operations = JSON.parse(jsonText);
+    } catch (parseErr) {
+      outputError('Invalid JSON input', { error: parseErr.message });
+      process.exitCode = 1;
+      return;
+    }
+
+    const result = await batchOperations(db, operations, {
+      sourceChannel: opts.sourceChannel,
+    });
+
+    outputJson(result);
+  } catch (err) {
+    outputError('Batch operations failed', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+/**
+ * claudia memory end-session --episode-id <id> --narrative <text> | --file <path>
+ * Read from opts or file, call endSession.
+ */
+export async function memoryEndSessionCommand(opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    let episodeId = opts.episodeId;
+    let narrative = opts.narrative;
+    let extractions = undefined;
+    let facts = undefined;
+    let entities = undefined;
+    let relationships = undefined;
+
+    // If a file is provided, load structured session data from it
+    if (opts.file) {
+      const filePath = resolve(opts.file);
+      const data = JSON.parse(readFileSync(filePath, 'utf-8'));
+      episodeId = data.episodeId ?? episodeId;
+      narrative = data.narrative ?? narrative;
+      extractions = data.extractions;
+      facts = data.facts;
+      entities = data.entities;
+      relationships = data.relationships;
+    }
+
+    if (!narrative) {
+      outputError('--narrative or --file with narrative is required');
+      process.exitCode = 1;
+      return;
+    }
+
+    const result = await endSession(db, episodeId, narrative, {
+      extractions,
+      facts,
+      entities,
+      relationships,
+    });
+
+    outputJson(result);
+  } catch (err) {
+    outputError('Failed to end session', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+/**
+ * claudia memory consolidate [--lightweight]
+ * If --lightweight: runDecay, else runFullConsolidation.
+ */
+export async function memoryConsolidateCommand(opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    let result;
+    if (opts.lightweight) {
+      result = runDecay(db, config);
+    } else {
+      result = await runFullConsolidation(db, config);
+    }
+
+    outputJson(result);
+  } catch (err) {
+    outputError('Consolidation failed', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+/**
+ * claudia memory briefing
+ * Call getBriefing.
+ */
+export async function memoryBriefingCommand(opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    const result = getBriefing(db, config);
+
+    outputJson(result);
+  } catch (err) {
+    outputError('Failed to get briefing', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+/**
+ * claudia memory summary --entity <name>
+ * If --entity: call entityOverview with [entity], else error.
+ */
+export async function memorySummaryCommand(opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    if (!opts.entity) {
+      outputError('--entity is required for summary');
+      process.exitCode = 1;
+      return;
+    }
+
+    const result = entityOverview(db, config, [opts.entity], {
+      includeNetwork: true,
+      includeSummaries: true,
+    });
+
+    outputJson(result);
+  } catch (err) {
+    outputError('Failed to get summary', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+/**
+ * claudia memory reflections
+ * Dispatch based on --save/--update/--delete/--query or list all.
+ */
+export async function memoryReflectionsCommand(opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    // --save: store a new reflection
+    if (opts.save) {
+      const result = await storeReflection(db, opts.save, opts.type || 'observation', {
+        importance: opts.importance,
+        source: opts.source,
+        tags: opts.tags,
+      });
+      outputJson(result);
+      return;
+    }
+
+    // --update <id>: update existing reflection
+    if (opts.update != null) {
+      const result = await updateReflection(db, opts.update, {
+        content: opts.content,
+        importance: opts.importance,
+        type: opts.type,
+        tags: opts.tags,
+      });
+      outputJson(result);
+      return;
+    }
+
+    // --delete <id>: delete a reflection
+    if (opts.delete != null) {
+      const result = deleteReflection(db, opts.delete);
+      outputJson(result);
+      return;
+    }
+
+    // --query: search reflections
+    if (opts.query) {
+      const results = await searchReflections(db, config, opts.query, {
+        limit: opts.limit,
+        reflectionTypes: opts.type ? [opts.type] : undefined,
+      });
+      outputJson(results);
+      return;
+    }
+
+    // Default: list all reflections
+    const results = getReflections(db, config, {
+      reflectionTypes: opts.type ? [opts.type] : undefined,
+      limit: opts.limit,
+      minImportance: opts.minImportance,
+    });
+
+    outputJson(results);
+  } catch (err) {
+    outputError('Reflections operation failed', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+/**
+ * claudia memory project-health --entity <name>
+ * Call getProjectHealth.
+ */
+export async function memoryProjectHealthCommand(opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    if (!opts.entity) {
+      outputError('--entity is required for project health');
+      process.exitCode = 1;
+      return;
+    }
+
+    const result = getProjectHealth(db, config, opts.entity, {
+      daysAhead: opts.daysAhead,
+    });
+
+    outputJson(result);
+  } catch (err) {
+    outputError('Failed to get project health', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Temporal Commands
+// ---------------------------------------------------------------------------
+
+/**
+ * claudia memory temporal upcoming
+ * Call recallUpcomingDeadlines.
+ */
+export async function temporalUpcomingCommand(opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    const result = recallUpcomingDeadlines(db, config, {
+      daysAhead: opts.days,
+      includeOverdue: opts.includeOverdue || false,
+    });
+
+    outputJson(result);
+  } catch (err) {
+    outputError('Failed to get upcoming deadlines', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+/**
+ * claudia memory temporal since <date>
+ * Call recallSince.
+ */
+export async function temporalSinceCommand(date, opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    const result = recallSince(db, config, date, {
+      entityName: opts.entity,
+      limit: opts.limit,
+    });
+
+    outputJson(result);
+  } catch (err) {
+    outputError('Failed to recall since date', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+/**
+ * claudia memory temporal timeline <entity>
+ * Call recallTimeline.
+ */
+export async function temporalTimelineCommand(entity, opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    const result = recallTimeline(db, config, entity, {
+      limit: opts.limit,
+    });
+
+    outputJson(result);
+  } catch (err) {
+    outputError('Failed to get timeline', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+/**
+ * claudia memory temporal morning
+ * Composite: getBriefing + getRecentMemories + recallUpcomingDeadlines.
+ */
+export async function temporalMorningCommand(opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    const briefing = getBriefing(db, config);
+    const recentMemories = getRecentMemories(db, config, {
+      limit: 10,
+      hours: 24,
+    });
+    const upcoming = recallUpcomingDeadlines(db, config, {
+      daysAhead: 7,
+      includeOverdue: true,
+    });
+
+    outputJson({
+      briefing,
+      recent_memories: recentMemories,
+      upcoming_deadlines: upcoming,
+    });
+  } catch (err) {
+    outputError('Failed to get morning digest', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Graph Commands
+// ---------------------------------------------------------------------------
+
+/**
+ * claudia memory graph network <entity>
+ * Call getProjectNetwork.
+ */
+export async function graphNetworkCommand(entity, opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    const result = getProjectNetwork(db, config, entity);
+
+    outputJson(result);
+  } catch (err) {
+    outputError('Failed to get project network', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+/**
+ * claudia memory graph path <entityA> <entityB>
+ * Call findPath.
+ */
+export async function graphPathCommand(entityA, entityB, opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    const result = findPath(db, config, entityA, entityB, {
+      maxDepth: opts.maxDepth,
+    });
+
+    outputJson(result);
+  } catch (err) {
+    outputError('Failed to find path', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+/**
+ * claudia memory graph hubs
+ * Call getHubEntities.
+ */
+export async function graphHubsCommand(opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    const result = getHubEntities(db, config, {
+      minConnections: opts.minConnections,
+      entityType: opts.type,
+      limit: opts.limit,
+    });
+
+    outputJson(result);
+  } catch (err) {
+    outputError('Failed to get hub entities', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+/**
+ * claudia memory graph dormant
+ * Call getDormantRelationships.
+ */
+export async function graphDormantCommand(opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    const result = getDormantRelationships(db, config, {
+      days: opts.days,
+      minStrength: opts.minStrength,
+      limit: opts.limit,
+    });
+
+    outputJson(result);
+  } catch (err) {
+    outputError('Failed to get dormant relationships', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+/**
+ * claudia memory graph reconnect
+ * Query patterns table for reconnect-type patterns.
+ */
+export async function graphReconnectCommand(opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    const limit = opts.limit || 10;
+
+    // Query patterns table for reconnect-type patterns
+    const patterns = db.query(
+      `SELECT p.*, e.name as entity_name, e.type as entity_type
+       FROM patterns p
+       LEFT JOIN entities e ON p.entity_id = e.id
+       WHERE p.pattern_type IN ('cooling_relationship', 'dormant_contact', 'reconnect_suggestion')
+         AND (e.deleted_at IS NULL OR e.deleted_at IS NULL)
+       ORDER BY p.detected_at DESC
+       LIMIT ?`,
+      [limit],
+    );
+
+    const results = (patterns || []).map(p => {
+      let details = null;
+      try { details = JSON.parse(p.details); } catch { /* ignore */ }
+      return {
+        id: p.id,
+        pattern_type: p.pattern_type,
+        description: p.description,
+        entity_name: p.entity_name,
+        entity_type: p.entity_type,
+        confidence: p.confidence,
+        detected_at: p.detected_at,
+        details,
+      };
+    });
+
+    outputJson({ patterns: results, count: results.length });
+  } catch (err) {
+    outputError('Failed to get reconnection suggestions', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Entities Commands
+// ---------------------------------------------------------------------------
+
+/**
+ * claudia memory entities create <name>
+ * Validate via guards, call rememberEntity.
+ */
+export async function entitiesCreateCommand(name, opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    // Validate entity
+    const validation = validateEntity(name, opts.type);
+    if (!validation.isValid) {
+      outputError(validation.warnings.join('; '));
+      process.exitCode = 1;
+      return;
+    }
+
+    const finalType = validation.adjustments.type || opts.type || 'person';
+
+    const result = await rememberEntity(db, name, finalType, {
+      description: opts.description,
+      aliases: opts.aliases,
+    });
+
+    outputJson({ ...result, warnings: validation.warnings });
+  } catch (err) {
+    outputError('Failed to create entity', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+/**
+ * claudia memory entities search <query>
+ * Call searchEntities.
+ */
+export async function entitiesSearchCommand(query, opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    const result = searchEntities(db, config, query, {
+      entityTypes: opts.type,
+      limit: opts.limit,
+    });
+
+    outputJson(result);
+  } catch (err) {
+    outputError('Failed to search entities', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+/**
+ * claudia memory entities overview <names...>
+ * Call entityOverview.
+ */
+export async function entitiesOverviewCommand(names, opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    const result = entityOverview(db, config, names, {
+      includeNetwork: true,
+      includeSummaries: true,
+    });
+
+    outputJson(result);
+  } catch (err) {
+    outputError('Failed to get entity overview', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+/**
+ * claudia memory entities merge --source <id> --target <id>
+ * Validate --source, --target, call mergeEntities.
+ */
+export async function entitiesMergeCommand(opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    if (!opts.source || !opts.target) {
+      outputError('--source and --target entity IDs are required');
+      process.exitCode = 1;
+      return;
+    }
+
+    const result = mergeEntities(db, opts.source, opts.target, {
+      reason: opts.reason,
+    });
+
+    outputJson(result);
+  } catch (err) {
+    outputError('Failed to merge entities', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+/**
+ * claudia memory entities delete <id>
+ * Call deleteEntity.
+ */
+export async function entitiesDeleteCommand(id, opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    const result = deleteEntity(db, id, {
+      reason: opts.reason,
+    });
+
+    outputJson(result);
+  } catch (err) {
+    outputError('Failed to delete entity', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Modify Commands
+// ---------------------------------------------------------------------------
+
+/**
+ * claudia memory modify correct <id> <correction>
+ * Call correctMemory.
+ */
+export async function modifyCorrectCommand(id, correction, opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    const result = await correctMemory(db, id, correction, {
+      reason: opts.reason,
+    });
+
+    outputJson(result);
+  } catch (err) {
+    outputError('Failed to correct memory', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+/**
+ * claudia memory modify invalidate <id>
+ * Call invalidateMemory.
+ */
+export async function modifyInvalidateCommand(id, opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    const result = invalidateMemory(db, id, {
+      reason: opts.reason,
+    });
+
+    outputJson(result);
+  } catch (err) {
+    outputError('Failed to invalidate memory', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+/**
+ * claudia memory modify invalidate-relationship --source <name> --target <name> --type <type>
+ * Call invalidateRelationship.
+ */
+export async function modifyInvalidateRelationshipCommand(opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    if (!opts.source || !opts.target || !opts.type) {
+      outputError('--source, --target, and --type are all required');
+      process.exitCode = 1;
+      return;
+    }
+
+    const result = invalidateRelationship(db, opts.source, opts.target, opts.type, {
+      reason: opts.reason,
+    });
+
+    outputJson(result);
+  } catch (err) {
+    outputError('Failed to invalidate relationship', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Session Commands
+// ---------------------------------------------------------------------------
+
+/**
+ * claudia memory session buffer
+ * Call bufferTurn.
+ */
+export async function sessionBufferCommand(opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    const result = bufferTurn(db, {
+      userContent: opts.user,
+      assistantContent: opts.assistant,
+      episodeId: opts.episodeId,
+      source: opts.source,
+    });
+
+    outputJson(result);
+  } catch (err) {
+    outputError('Failed to buffer turn', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+/**
+ * claudia memory session context
+ * Return getActiveReflections + getRecentMemories.
+ */
+export async function sessionContextCommand(opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    const reflections = getActiveReflections(db, config, {
+      limit: 5,
+      minImportance: 0.6,
+    });
+    const recentMemories = getRecentMemories(db, config, {
+      limit: 10,
+      hours: 24,
+    });
+
+    outputJson({
+      active_reflections: reflections,
+      recent_memories: recentMemories,
+    });
+  } catch (err) {
+    outputError('Failed to get session context', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+/**
+ * claudia memory session unsummarized
+ * Call getUnsummarizedTurns.
+ */
+export async function sessionUnsummarizedCommand(opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    const result = getUnsummarizedTurns(db);
+
+    outputJson(result);
+  } catch (err) {
+    outputError('Failed to get unsummarized turns', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Document Commands
+// ---------------------------------------------------------------------------
+
+/**
+ * claudia memory document store <file>
+ * Call fileDocument.
+ */
+export async function documentStoreCommand(file, opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    const filePath = resolve(file);
+    const result = fileDocument(db, {
+      filePath,
+      sourceType: opts.sourceType,
+      sourceRef: opts.sourceRef,
+      summary: opts.summary,
+      entityNames: opts.entityNames,
+    });
+
+    outputJson(result);
+  } catch (err) {
+    outputError('Failed to store document', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+/**
+ * claudia memory document search <query>
+ * Call searchDocuments.
+ */
+export async function documentSearchCommand(query, opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    const result = searchDocuments(db, {
+      query,
+      sourceType: opts.sourceType,
+      entityName: opts.entityName,
+      lifecycle: opts.lifecycle,
+      limit: opts.limit,
+    });
+
+    outputJson(result);
+  } catch (err) {
+    outputError('Failed to search documents', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Provenance Commands
+// ---------------------------------------------------------------------------
+
+/**
+ * claudia memory provenance trace <id>
+ * Call traceMemory.
+ */
+export async function provenanceTraceCommand(id, opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    const result = traceMemory(db, config, id);
+
+    outputJson(result);
+  } catch (err) {
+    outputError('Failed to trace memory', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+/**
+ * claudia memory provenance audit --entity-id <id> | --memory-id <id>
+ * Dispatch based on --entity-id or --memory-id.
+ */
+export async function provenanceAuditCommand(opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    if (opts.entityId) {
+      const result = getEntityAuditHistory(db, opts.entityId);
+      outputJson(result);
+      return;
+    }
+
+    if (opts.memoryId) {
+      const result = getMemoryAuditHistory(db, opts.memoryId);
+      outputJson(result);
+      return;
+    }
+
+    // Default: recent audit entries
+    const result = getAuditRecent(db, {
+      limit: opts.limit || 50,
+    });
+
+    outputJson(result);
+  } catch (err) {
+    outputError('Failed to get audit history', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+/**
+ * claudia memory provenance verify-chain
+ * Verify memory chain hash integrity by recomputing SHA-256 hashes.
+ */
+export async function provenanceVerifyChainCommand(opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    const memories = db.query(
+      'SELECT id, content, chain_hash, created_at FROM memories WHERE invalidated_at IS NULL ORDER BY id ASC',
+    );
+
+    if (!memories || memories.length === 0) {
+      outputJson({
+        verified: true,
+        total: 0,
+        valid: 0,
+        broken: 0,
+        broken_ids: [],
+        message: 'No active memories to verify.',
+      });
+      return;
+    }
+
+    let previousHash = null;
+    let valid = 0;
+    const brokenIds = [];
+
+    for (const memory of memories) {
+      // Recompute: SHA-256(content + previous_chain_hash)
+      const payload = memory.content + (previousHash || '');
+      const expectedHash = createHash('sha256').update(payload).digest('hex');
+
+      if (memory.chain_hash === expectedHash) {
+        valid++;
+      } else if (memory.chain_hash === null) {
+        // Memories without chain_hash are considered valid (pre-chain era)
+        valid++;
+      } else {
+        brokenIds.push({
+          id: memory.id,
+          expected: expectedHash,
+          actual: memory.chain_hash,
+          created_at: memory.created_at,
+        });
+      }
+
+      // Use the stored chain_hash as previous for the next iteration
+      // (even if broken, to detect where the break started)
+      previousHash = memory.chain_hash || expectedHash;
+    }
+
+    outputJson({
+      verified: brokenIds.length === 0,
+      total: memories.length,
+      valid,
+      broken: brokenIds.length,
+      broken_ids: brokenIds,
+      message: brokenIds.length === 0
+        ? `All ${memories.length} memories have valid chain hashes.`
+        : `${brokenIds.length} of ${memories.length} memories have broken chain hashes.`,
+    });
+  } catch (err) {
+    outputError('Failed to verify chain', { error: err.message });
+    process.exitCode = 1;
+  }
+}

--- a/cli/commands/setup.js
+++ b/cli/commands/setup.js
@@ -1,0 +1,144 @@
+/**
+ * Setup/onboarding wizard for Claudia CLI.
+ * Creates directories, verifies Ollama, pulls models, runs health check.
+ *
+ * Usage: claudia setup [--skip-ollama]
+ */
+
+import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  getClaudiaHome,
+  getMemoryDir,
+  getVaultDir,
+  getConfigPath,
+  ensureDir,
+} from '../core/paths.js';
+import { getConfig, saveConfig } from '../core/config.js';
+import { getEmbeddingService } from '../core/embeddings.js';
+import { getLanguageModelService } from '../core/language-model.js';
+import { getDatabase } from '../core/database.js';
+import { outputJson, outputError } from '../core/output.js';
+
+/**
+ * claudia setup
+ * Interactive onboarding wizard.
+ */
+export async function setupCommand(opts, globalOpts) {
+  const steps = [];
+  let hasError = false;
+
+  // Step 1: Create directory structure
+  try {
+    const home = getClaudiaHome();
+    ensureDir(home);
+    ensureDir(getMemoryDir());
+    ensureDir(getVaultDir());
+    ensureDir(join(home, 'backups'));
+
+    steps.push({ step: 'directories', status: 'ok', path: home });
+  } catch (err) {
+    steps.push({ step: 'directories', status: 'error', error: err.message });
+    hasError = true;
+  }
+
+  // Step 2: Ensure config.json exists
+  try {
+    const configPath = getConfigPath();
+    if (!existsSync(configPath)) {
+      // Write default config
+      const defaultConfig = getConfig();
+      saveConfig(defaultConfig);
+      steps.push({ step: 'config', status: 'created', path: configPath });
+    } else {
+      steps.push({ step: 'config', status: 'exists', path: configPath });
+    }
+  } catch (err) {
+    steps.push({ step: 'config', status: 'error', error: err.message });
+    hasError = true;
+  }
+
+  // Step 3: Verify database can be opened
+  try {
+    const projectDir = globalOpts.projectDir || process.cwd();
+    const db = getDatabase(projectDir);
+    const memCount = db.queryOne('SELECT COUNT(*) as count FROM memories');
+    steps.push({
+      step: 'database',
+      status: 'ok',
+      path: db.dbPath,
+      memories: memCount?.count || 0,
+      vec_available: db.vecAvailable,
+    });
+  } catch (err) {
+    steps.push({ step: 'database', status: 'error', error: err.message });
+    hasError = true;
+  }
+
+  // Step 4: Check Ollama and embedding model
+  if (!opts.skipOllama) {
+    try {
+      const embedService = getEmbeddingService();
+      const available = await embedService.isAvailable();
+
+      if (available) {
+        steps.push({
+          step: 'embedding_model',
+          status: 'ok',
+          model: embedService.model,
+          dimensions: embedService.dimensions,
+          host: embedService.host,
+        });
+      } else {
+        steps.push({
+          step: 'embedding_model',
+          status: 'unavailable',
+          model: embedService.model,
+          host: embedService.host,
+          message: `Model not available. Run: ollama pull ${embedService.model}`,
+        });
+      }
+    } catch (err) {
+      steps.push({ step: 'embedding_model', status: 'error', error: err.message });
+    }
+
+    // Step 5: Check language model (optional, for cognitive.ingest)
+    try {
+      const lmService = getLanguageModelService();
+      const available = await lmService.isAvailable();
+
+      if (available) {
+        steps.push({
+          step: 'language_model',
+          status: 'ok',
+          model: lmService.model,
+          host: lmService.host,
+        });
+      } else {
+        steps.push({
+          step: 'language_model',
+          status: 'unavailable',
+          model: lmService.model,
+          message: `Optional. Run: ollama pull ${lmService.model}`,
+        });
+      }
+    } catch (err) {
+      steps.push({ step: 'language_model', status: 'skipped', error: err.message });
+    }
+  } else {
+    steps.push({ step: 'embedding_model', status: 'skipped', reason: '--skip-ollama' });
+    steps.push({ step: 'language_model', status: 'skipped', reason: '--skip-ollama' });
+  }
+
+  const report = {
+    status: hasError ? 'incomplete' : 'ready',
+    claudia_home: getClaudiaHome(),
+    steps,
+  };
+
+  outputJson(report);
+
+  if (hasError) {
+    process.exitCode = 1;
+  }
+}

--- a/cli/commands/system.js
+++ b/cli/commands/system.js
@@ -1,0 +1,118 @@
+/**
+ * System commands for Claudia CLI.
+ * Implements: claudia system-health
+ */
+
+import { getDatabase } from '../core/database.js';
+import { getConfig } from '../core/config.js';
+import { getEmbeddingService } from '../core/embeddings.js';
+import { getLanguageModelService } from '../core/language-model.js';
+import { resolveProjectDir } from '../core/paths.js';
+import { outputJson, outputError } from '../core/output.js';
+
+/**
+ * claudia system-health
+ * Reports database stats, embedding model status, config summary.
+ */
+export async function systemHealthCommand(options) {
+  const projectDir = resolveProjectDir(options.projectDir);
+
+  let dbStats = null;
+  let dbError = null;
+  try {
+    const db = getDatabase(projectDir);
+    const memories = db.queryOne('SELECT COUNT(*) as count FROM memories WHERE invalidated_at IS NULL');
+    const entities = db.queryOne('SELECT COUNT(*) as count FROM entities WHERE deleted_at IS NULL');
+    const relationships = db.queryOne('SELECT COUNT(*) as count FROM relationships WHERE invalid_at IS NULL');
+    const episodes = db.queryOne('SELECT COUNT(*) as count FROM episodes');
+    const reflections = db.queryOne('SELECT COUNT(*) as count FROM reflections');
+
+    // Get last consolidation time from _meta
+    let lastConsolidation = null;
+    try {
+      const meta = db.queryOne("SELECT value FROM _meta WHERE key = 'last_consolidation'");
+      if (meta) lastConsolidation = meta.value;
+    } catch {
+      // _meta table might not exist in older DBs
+    }
+
+    // DB file size
+    let dbSizeBytes = 0;
+    try {
+      const { statSync } = await import('node:fs');
+      dbSizeBytes = statSync(db.dbPath).size;
+    } catch {
+      // ignore
+    }
+
+    dbStats = {
+      path: db.dbPath,
+      size_bytes: dbSizeBytes,
+      size_mb: Math.round(dbSizeBytes / 1024 / 1024 * 100) / 100,
+      vec_available: db.vecAvailable,
+      memories: memories?.count || 0,
+      entities: entities?.count || 0,
+      relationships: relationships?.count || 0,
+      episodes: episodes?.count || 0,
+      reflections: reflections?.count || 0,
+      last_consolidation: lastConsolidation,
+    };
+  } catch (err) {
+    dbError = err.message;
+  }
+
+  // Check embedding service
+  let embeddingStatus = null;
+  try {
+    const embedService = getEmbeddingService();
+    const available = await embedService.isAvailable();
+    embeddingStatus = {
+      available,
+      model: embedService.model,
+      dimensions: embedService.dimensions,
+      host: embedService.host,
+      cache: embedService.cacheStats(),
+    };
+  } catch (err) {
+    embeddingStatus = { available: false, error: err.message };
+  }
+
+  // Check language model service
+  let lmStatus = null;
+  try {
+    const lmService = getLanguageModelService();
+    const available = await lmService.isAvailable();
+    lmStatus = {
+      available,
+      model: lmService.model,
+      host: lmService.host,
+    };
+  } catch (err) {
+    lmStatus = { available: false, error: err.message };
+  }
+
+  // Config summary
+  const config = getConfig(projectDir);
+  const configSummary = {
+    ollama_host: config.ollama_host,
+    embedding_model: config.embedding_model,
+    embedding_dimensions: config.embedding_dimensions,
+    language_model: config.language_model,
+    decay_rate_daily: config.decay_rate_daily,
+    vault_sync_enabled: config.vault_sync_enabled,
+    enable_auto_dedupe: config.enable_auto_dedupe,
+    enable_memory_merging: config.enable_memory_merging,
+  };
+
+  const report = {
+    status: dbError ? 'degraded' : 'healthy',
+    version: '2.0.0',
+    project_dir: projectDir,
+    database: dbStats || { error: dbError },
+    embedding: embeddingStatus,
+    language_model: lmStatus,
+    config: configSummary,
+  };
+
+  outputJson(report);
+}

--- a/cli/commands/vault.js
+++ b/cli/commands/vault.js
@@ -1,0 +1,103 @@
+/**
+ * Vault commands for Claudia CLI.
+ * Implements: claudia vault sync|status|canvas|import
+ */
+
+import { resolveProjectDir } from '../core/paths.js';
+import { getDatabase } from '../core/database.js';
+import { getConfig } from '../core/config.js';
+import { outputJson, outputError, outputSuccess } from '../core/output.js';
+
+/**
+ * claudia vault sync
+ * Export memory data to Obsidian vault in PARA structure.
+ */
+export async function vaultSyncCommand(opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    if (!config.vault_sync_enabled) {
+      outputError('Vault sync is disabled. Enable it in config: vault_sync_enabled = true');
+      process.exitCode = 1;
+      return;
+    }
+
+    const { syncVault } = await import('../services/vault-sync.js');
+    const result = syncVault(db, config);
+    outputJson(result);
+  } catch (err) {
+    outputError('Vault sync failed', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+/**
+ * claudia vault status
+ * Report vault sync status and last sync metadata.
+ */
+export async function vaultStatusCommand(opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    const { getVaultStatus } = await import('../services/vault-sync.js');
+    const status = getVaultStatus(db, config);
+    outputJson(status);
+  } catch (err) {
+    outputError('Vault status check failed', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+/**
+ * claudia vault canvas
+ * Generate .canvas files for Obsidian's canvas view.
+ */
+export async function vaultCanvasCommand(opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    if (!config.vault_sync_enabled) {
+      outputError('Vault sync is disabled. Enable it in config: vault_sync_enabled = true');
+      process.exitCode = 1;
+      return;
+    }
+
+    const { generateCanvasFiles } = await import('../services/vault-sync.js');
+    const result = generateCanvasFiles(db, config);
+    outputJson(result);
+  } catch (err) {
+    outputError('Canvas generation failed', { error: err.message });
+    process.exitCode = 1;
+  }
+}
+
+/**
+ * claudia vault import
+ * Import user edits from vault markdown files back to memory DB.
+ */
+export async function vaultImportCommand(opts, globalOpts) {
+  try {
+    const projectDir = resolveProjectDir(globalOpts.projectDir);
+    const db = getDatabase(projectDir);
+    const config = getConfig(projectDir);
+
+    if (!config.vault_sync_enabled) {
+      outputError('Vault sync is disabled. Enable it in config: vault_sync_enabled = true');
+      process.exitCode = 1;
+      return;
+    }
+
+    const { importVaultEdits } = await import('../services/vault-sync.js');
+    const result = importVaultEdits(db, config);
+    outputJson(result);
+  } catch (err) {
+    outputError('Vault import failed', { error: err.message });
+    process.exitCode = 1;
+  }
+}

--- a/cli/core/config.js
+++ b/cli/core/config.js
@@ -1,0 +1,252 @@
+/**
+ * Configuration management for Claudia CLI.
+ * Port of memory-daemon/claudia_memory/config.py.
+ *
+ * Loads settings from ~/.claudia/config.json with sensible defaults.
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { getConfigPath, getClaudiaHome, getDbPath, getLogPath } from './paths.js';
+
+/** Default configuration values (mirrors Python MemoryConfig dataclass) */
+const DEFAULTS = {
+  // Embedding settings
+  ollama_host: 'http://localhost:11434',
+  embedding_model: 'all-minilm:l6-v2',
+  embedding_dimensions: 384,
+
+  // Language model (for cognitive tools)
+  language_model: 'qwen3:4b',
+
+  // Decay and consolidation
+  decay_rate_daily: 0.995,
+  min_importance_threshold: 0.1,
+  consolidation_interval_hours: 6,
+  pattern_detection_interval_hours: 24,
+
+  // Search/ranking weights (sum to ~1.0)
+  vector_weight: 0.50,
+  importance_weight: 0.25,
+  recency_weight: 0.10,
+  fts_weight: 0.15,
+  recency_half_life_days: 30,
+  max_recall_results: 50,
+
+  // Memory merging
+  similarity_merge_threshold: 0.92,
+  enable_memory_merging: true,
+
+  // RRF scoring
+  rrf_k: 60,
+  enable_rrf: true,
+  graph_proximity_enabled: true,
+  graph_proximity_weight: 0.15,
+
+  // Entity summaries
+  enable_entity_summaries: true,
+  entity_summary_min_memories: 5,
+  entity_summary_max_age_days: 7,
+
+  // Auto-deduplication
+  enable_auto_dedupe: true,
+  auto_dedupe_threshold: 0.90,
+
+  // Document storage
+  document_dormant_days: 90,
+  document_archive_days: 180,
+
+  // Backup settings
+  backup_retention_count: 3,
+  enable_pre_consolidation_backup: true,
+  backup_daily_retention: 7,
+  backup_weekly_retention: 4,
+
+  // Retention (data cleanup during consolidation)
+  audit_log_retention_days: 90,
+  prediction_retention_days: 30,
+  turn_buffer_retention_days: 60,
+  metrics_retention_days: 90,
+
+  // Vault sync (Obsidian integration)
+  vault_sync_enabled: true,
+  vault_name: 'claudia-vault',
+  vault_layout: 'para',
+  obsidian_rest_api_port: 27124,
+  obsidian_rest_api_enabled: false,
+
+  // Lifecycle & sacred memory
+  cooling_threshold_days: 60,
+  archive_threshold_days: 180,
+  enable_auto_sacred: true,
+  close_circle_keywords: [
+    'close friend', 'bestie', 'family', 'inner circle', 'best friend',
+    'spouse', 'partner', 'sibling', 'parent', 'child',
+  ],
+  sacred_core_keywords: [
+    'birthday', 'allergy', 'family', 'boundary', 'health',
+    'never forget', 'anniversary', 'preference', 'medical',
+    'dietary', 'phobia', 'trigger',
+  ],
+  enable_chain_verification: true,
+  context_builder_token_budget: 8000,
+  context_builder_max_facts: 30,
+};
+
+/** All config keys that can be loaded from config.json */
+const CONFIG_KEYS = Object.keys(DEFAULTS);
+
+/**
+ * Validate config values. Warns and auto-corrects out-of-range values.
+ * Matches Python _validate() logic exactly.
+ */
+function validate(config) {
+  const warnings = [];
+
+  if (!(config.decay_rate_daily > 0 && config.decay_rate_daily <= 1.0)) {
+    warnings.push(`decay_rate_daily=${config.decay_rate_daily} out of range (0,1], using default 0.995`);
+    config.decay_rate_daily = 0.995;
+  }
+  if (config.max_recall_results < 1 || config.max_recall_results > 200) {
+    warnings.push(`max_recall_results=${config.max_recall_results} out of range [1,200], using default 50`);
+    config.max_recall_results = 50;
+  }
+  if (config.min_importance_threshold < 0 || config.min_importance_threshold > 1.0) {
+    warnings.push(`min_importance_threshold=${config.min_importance_threshold} out of range [0,1], using default 0.1`);
+    config.min_importance_threshold = 0.1;
+  }
+
+  const weights = config.vector_weight + config.importance_weight + config.recency_weight + config.fts_weight;
+  if (Math.abs(weights - 1.0) > 0.01) {
+    warnings.push(`Ranking weights sum to ${weights.toFixed(3)}, not 1.0. Results may be skewed.`);
+  }
+
+  if (config.backup_retention_count < 1) {
+    warnings.push(`backup_retention_count=${config.backup_retention_count} below minimum, using 1`);
+    config.backup_retention_count = 1;
+  }
+  if (config.backup_daily_retention < 1) {
+    config.backup_daily_retention = 1;
+  }
+  if (config.backup_weekly_retention < 1) {
+    config.backup_weekly_retention = 1;
+  }
+
+  for (const attr of ['audit_log_retention_days', 'prediction_retention_days', 'turn_buffer_retention_days', 'metrics_retention_days']) {
+    if (config[attr] < 1) {
+      warnings.push(`${attr}=${config[attr]} below minimum, using 1`);
+      config[attr] = 1;
+    }
+  }
+
+  const commonDims = new Set([384, 512, 768, 1024, 1536]);
+  if (!commonDims.has(config.embedding_dimensions)) {
+    warnings.push(`embedding_dimensions=${config.embedding_dimensions} is not a common value. Verify this matches your embedding model.`);
+  }
+
+  if (!(config.auto_dedupe_threshold >= 0.0 && config.auto_dedupe_threshold <= 1.0)) {
+    config.auto_dedupe_threshold = 0.90;
+  }
+  if (config.entity_summary_min_memories < 1) {
+    config.entity_summary_min_memories = 1;
+  }
+  if (config.entity_summary_max_age_days < 1) {
+    config.entity_summary_max_age_days = 1;
+  }
+  if (!(config.graph_proximity_weight >= 0.0 && config.graph_proximity_weight <= 1.0)) {
+    config.graph_proximity_weight = 0.15;
+  }
+  if (config.cooling_threshold_days < 1) {
+    config.cooling_threshold_days = 60;
+  }
+  if (config.archive_threshold_days < config.cooling_threshold_days) {
+    config.archive_threshold_days = config.cooling_threshold_days * 3;
+  }
+  if (config.context_builder_token_budget < 500) {
+    config.context_builder_token_budget = 2000;
+  }
+  if (config.context_builder_max_facts < 5) {
+    config.context_builder_max_facts = 10;
+  }
+
+  return warnings;
+}
+
+/**
+ * Load configuration from ~/.claudia/config.json with defaults.
+ * @param {string|null} projectDir - Project directory for DB path resolution
+ * @returns {{ config: object, warnings: string[] }}
+ */
+export function loadConfig(projectDir = null) {
+  const config = { ...DEFAULTS };
+  const configPath = getConfigPath();
+
+  if (existsSync(configPath)) {
+    try {
+      const data = JSON.parse(readFileSync(configPath, 'utf-8'));
+      for (const key of CONFIG_KEYS) {
+        if (key in data) {
+          config[key] = data[key];
+        }
+      }
+    } catch (e) {
+      // Warn but continue with defaults
+    }
+  }
+
+  // Resolve database path via paths.js (handles env overrides, demo mode, project isolation)
+  config.db_path = getDbPath(projectDir);
+
+  // Resolve derived paths
+  config.log_path = getLogPath();
+  config.vault_base_dir = getClaudiaHome() + '/vault';
+  config.files_base_dir = getClaudiaHome() + '/files';
+
+  const warnings = validate(config);
+  return { config, warnings };
+}
+
+/**
+ * Save configuration to ~/.claudia/config.json.
+ * Only saves user-configurable keys (not derived paths).
+ */
+export function saveConfig(config) {
+  const configPath = getConfigPath();
+  mkdirSync(dirname(configPath), { recursive: true });
+
+  const data = {};
+  for (const key of CONFIG_KEYS) {
+    if (key in config) {
+      data[key] = config[key];
+    }
+  }
+
+  writeFileSync(configPath, JSON.stringify(data, null, 2) + '\n');
+}
+
+// Module-level cache
+let _cachedConfig = null;
+let _cachedProjectDir = null;
+
+/**
+ * Get the global config (cached, lazy-loaded).
+ * @param {string|null} projectDir
+ */
+export function getConfig(projectDir = null) {
+  if (_cachedConfig === null || projectDir !== _cachedProjectDir) {
+    const { config, warnings } = loadConfig(projectDir);
+    _cachedConfig = config;
+    _cachedProjectDir = projectDir;
+    // Log warnings to stderr
+    for (const w of warnings) {
+      process.stderr.write(`[config] ${w}\n`);
+    }
+  }
+  return _cachedConfig;
+}
+
+/** Reset cached config (for testing). */
+export function resetConfig() {
+  _cachedConfig = null;
+  _cachedProjectDir = null;
+}

--- a/cli/core/database.js
+++ b/cli/core/database.js
@@ -1,0 +1,1367 @@
+/**
+ * Database management for Claudia CLI (Node.js port).
+ *
+ * Handles SQLite connection with:
+ * - WAL mode for crash safety
+ * - sqlite-vec extension for vector similarity search
+ * - Schema migration system (v1-v20)
+ * - Query helpers and backup
+ *
+ * Uses better-sqlite3 (synchronous API) instead of Python's sqlite3.
+ */
+
+import { createHash, randomUUID } from 'node:crypto';
+import {
+  existsSync, mkdirSync, readFileSync, writeFileSync,
+  readdirSync, statSync, unlinkSync,
+} from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { getConfig } from './config.js';
+import { getRegistryPath } from './paths.js';
+
+// createRequire for loading native addons in ESM context
+const require = createRequire(import.meta.url);
+
+// better-sqlite3 is a native addon; use require for reliable loading
+const BetterSqlite3 = require('better-sqlite3');
+
+// ---------------------------------------------------------------------------
+// Schema path resolution
+// ---------------------------------------------------------------------------
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCHEMA_PATH = join(__dirname, '..', '..', 'memory-daemon', 'claudia_memory', 'schema.sql');
+
+// ---------------------------------------------------------------------------
+// Vec0 table definitions
+// ---------------------------------------------------------------------------
+
+const VEC0_TABLES = [
+  ['entity_embeddings', 'entity_id'],
+  ['memory_embeddings', 'memory_id'],
+  ['message_embeddings', 'message_id'],
+  ['episode_embeddings', 'episode_id'],
+  ['reflection_embeddings', 'reflection_id'],
+];
+
+// ---------------------------------------------------------------------------
+// Database wrapper class
+// ---------------------------------------------------------------------------
+
+class ClaudiaDatabase {
+  /**
+   * @param {string} dbPath - Absolute path to the SQLite database file
+   * @param {object|null} config - Config object (from getConfig). If null, loaded automatically.
+   */
+  constructor(dbPath, config = null) {
+    this.dbPath = dbPath;
+    this.config = config;
+    this.db = null;
+    this.vecAvailable = false;
+    this._initialized = false;
+  }
+
+  // -------------------------------------------------------------------------
+  // Initialization
+  // -------------------------------------------------------------------------
+
+  /** Open the database, load extensions, run schema + migrations. */
+  initialize() {
+    if (this._initialized) return;
+
+    // Ensure parent directory exists
+    const dir = dirname(this.dbPath);
+    mkdirSync(dir, { recursive: true });
+
+    // Open database
+    this.db = new BetterSqlite3(this.dbPath);
+
+    // PRAGMAs
+    this.db.pragma('journal_mode = WAL');
+    this.db.pragma('foreign_keys = ON');
+    this.db.pragma('synchronous = NORMAL');
+
+    // Recover any uncommitted WAL writes from a previous crash
+    try {
+      this.db.pragma('wal_checkpoint(TRUNCATE)');
+    } catch (_) {
+      // Non-fatal
+    }
+
+    // Load sqlite-vec
+    this._loadVec();
+
+    // Execute schema.sql
+    this._executeSchema();
+
+    // Create vec0 virtual tables
+    this._createVec0Tables();
+
+    // Run migrations
+    this._runMigrations();
+
+    // Store workspace path in _meta
+    this._storeWorkspacePath();
+
+    // Register in central registry
+    this._registerDatabase();
+
+    this._initialized = true;
+  }
+
+  // -------------------------------------------------------------------------
+  // Extension loading
+  // -------------------------------------------------------------------------
+
+  /** Attempt to load sqlite-vec extension. Sets this.vecAvailable. */
+  _loadVec() {
+    try {
+      const sqliteVec = require('sqlite-vec');
+      if (typeof sqliteVec.load === 'function') {
+        sqliteVec.load(this.db);
+        this.vecAvailable = true;
+        return;
+      }
+    } catch (_) {
+      // Not available
+    }
+
+    process.stderr.write(
+      '[database] sqlite-vec not available. Vector search will be disabled. ' +
+      'Install with: npm install sqlite-vec\n'
+    );
+    this.vecAvailable = false;
+  }
+
+  // -------------------------------------------------------------------------
+  // Schema execution
+  // -------------------------------------------------------------------------
+
+  /** Read and execute schema.sql, splitting on ; at end of line. */
+  _executeSchema() {
+    if (!existsSync(SCHEMA_PATH)) {
+      process.stderr.write(`[database] Schema file not found at ${SCHEMA_PATH}\n`);
+      return;
+    }
+
+    const schemaSql = readFileSync(SCHEMA_PATH, 'utf-8');
+    const statements = [];
+    let current = [];
+
+    for (const line of schemaSql.split('\n')) {
+      const stripped = line.trim();
+      // Skip comment-only lines
+      if (stripped.startsWith('--')) continue;
+      current.push(line);
+      if (stripped.endsWith(';')) {
+        const stmt = current.join('\n').trim();
+        if (stmt) statements.push(stmt);
+        current = [];
+      }
+    }
+
+    for (const stmt of statements) {
+      if (!stmt.trim()) continue;
+      try {
+        this.db.exec(stmt);
+      } catch (e) {
+        const msg = e.message || '';
+        // Virtual tables may fail if sqlite-vec not loaded
+        if (msg.includes('no such module: vec0')) {
+          // Expected when vec not available; skip silently
+        } else if (msg.includes('no such column')) {
+          // Indexes on columns added by migrations; _runMigrations will handle
+        } else {
+          throw e;
+        }
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Vec0 virtual tables
+  // -------------------------------------------------------------------------
+
+  /** Create vec0 virtual tables with configurable embedding dimensions. */
+  _createVec0Tables() {
+    const config = this.config || getConfig();
+    const dim = config.embedding_dimensions || 384;
+
+    for (const [table, pk] of VEC0_TABLES) {
+      try {
+        this.db.exec(`
+          CREATE VIRTUAL TABLE IF NOT EXISTS ${table} USING vec0(
+            ${pk} INTEGER PRIMARY KEY,
+            embedding FLOAT[${dim}]
+          )
+        `);
+      } catch (e) {
+        const msg = e.message || '';
+        if (msg.includes('no such module: vec0')) {
+          // Expected when vec not available
+        } else {
+          process.stderr.write(`[database] Could not create ${table}: ${msg}\n`);
+        }
+      }
+    }
+
+    // Store dimensions in _meta for migration detection
+    try {
+      const check = this.db.prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='_meta'"
+      ).get();
+      if (check) {
+        const existing = this.db.prepare(
+          "SELECT value FROM _meta WHERE key = 'embedding_dimensions'"
+        ).get();
+        if (!existing) {
+          this.db.prepare(
+            "INSERT OR REPLACE INTO _meta (key, value) VALUES ('embedding_dimensions', ?)"
+          ).run(String(dim));
+        } else if (Number(existing.value) !== dim) {
+          process.stderr.write(
+            `[database] Embedding dimensions mismatch: config=${dim}, ` +
+            `database=${existing.value}. Run --migrate-embeddings to fix.\n`
+          );
+        }
+      }
+    } catch (_) {
+      // _meta table may not exist yet on very first run
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Migration integrity check
+  // -------------------------------------------------------------------------
+
+  /** Get column names for a table. */
+  _getTableColumns(table) {
+    const rows = this.db.prepare(`PRAGMA table_info(${table})`).all();
+    return new Set(rows.map(r => r.name));
+  }
+
+  /** Get set of table names from sqlite_master. */
+  _getTableNames() {
+    const rows = this.db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table'"
+    ).all();
+    return new Set(rows.map(r => r.name));
+  }
+
+  /**
+   * Check if migrations completed properly by verifying expected columns exist.
+   * Returns the effective schema version based on what actually exists,
+   * which may be lower than what schema_migrations claims.
+   * Returns null if all migrations completed properly.
+   */
+  _checkMigrationIntegrity() {
+    const memoryCols = this._getTableColumns('memories');
+    const relCols = this._getTableColumns('relationships');
+    const entityCols = this._getTableColumns('entities');
+    const tables = this._getTableNames();
+
+    // Migration 5: verification_status, verified_at on memories
+    if (!memoryCols.has('verification_status') || !memoryCols.has('verified_at')) {
+      return 4;
+    }
+    // Migration 8: valid_at, invalid_at on relationships
+    if (!relCols.has('invalid_at') || !relCols.has('valid_at')) {
+      return 7;
+    }
+    // Migration 10: reflections table
+    if (!tables.has('reflections')) {
+      return 9;
+    }
+    // Migration 12: audit_log, metrics, soft-delete/correction columns
+    if (!tables.has('audit_log') || !tables.has('metrics')) {
+      return 11;
+    }
+    if (!entityCols.has('deleted_at')) {
+      return 11;
+    }
+    if (!memoryCols.has('invalidated_at') || !memoryCols.has('corrected_at')) {
+      return 11;
+    }
+    // Migration 13: origin_type on memories, agent_dispatches table
+    if (!memoryCols.has('origin_type')) {
+      return 12;
+    }
+    if (!tables.has('agent_dispatches')) {
+      return 12;
+    }
+    // Migration 14: dispatch_tier on agent_dispatches
+    if (tables.has('agent_dispatches')) {
+      const dispatchCols = this._getTableColumns('agent_dispatches');
+      if (!dispatchCols.has('dispatch_tier')) {
+        return 13;
+      }
+    }
+    // Migration 15: origin_type on relationships
+    if (!relCols.has('origin_type')) {
+      return 14;
+    }
+    // Migration 16: source_channel on memories
+    if (!memoryCols.has('source_channel')) {
+      return 15;
+    }
+    // Migration 17: deadline_at, temporal_markers on memories
+    if (!memoryCols.has('deadline_at') || !memoryCols.has('temporal_markers')) {
+      return 16;
+    }
+    // Migration 18: contact velocity + attention tier on entities
+    if (!entityCols.has('last_contact_at') || !entityCols.has('attention_tier')) {
+      return 17;
+    }
+    // Migration 19: entity_summaries table
+    if (!tables.has('entity_summaries')) {
+      return 18;
+    }
+    // Migration 20: lifecycle_tier, fact_id on memories; close_circle on entities
+    if (!memoryCols.has('lifecycle_tier') || !memoryCols.has('fact_id')) {
+      return 19;
+    }
+    if (!entityCols.has('close_circle')) {
+      return 19;
+    }
+
+    return null; // All good
+  }
+
+  // -------------------------------------------------------------------------
+  // Migrations v1-v20
+  // -------------------------------------------------------------------------
+
+  _runMigrations() {
+    let currentVersion;
+    try {
+      const row = this.db.prepare(
+        'SELECT MAX(version) as v FROM schema_migrations'
+      ).get();
+      currentVersion = (row && row.v) ? row.v : 0;
+    } catch (_) {
+      // schema_migrations table does not exist yet
+      return;
+    }
+
+    // Integrity check: verify migrations actually completed
+    const effectiveVersion = this._checkMigrationIntegrity();
+    if (effectiveVersion !== null) {
+      process.stderr.write(
+        `[database] Migration integrity check: effective version is ${effectiveVersion}, not ${currentVersion}\n`
+      );
+      currentVersion = effectiveVersion;
+    }
+
+    // --- Migration 2: turn_buffer, episode narrative columns ---
+    if (currentVersion < 2) {
+      const stmts = [
+        'ALTER TABLE episodes ADD COLUMN narrative TEXT',
+        'ALTER TABLE episodes ADD COLUMN turn_count INTEGER DEFAULT 0',
+        'ALTER TABLE episodes ADD COLUMN is_summarized INTEGER DEFAULT 0',
+        `CREATE TABLE IF NOT EXISTS turn_buffer (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          episode_id INTEGER NOT NULL REFERENCES episodes(id) ON DELETE CASCADE,
+          turn_number INTEGER NOT NULL,
+          user_content TEXT,
+          assistant_content TEXT,
+          created_at TEXT DEFAULT (datetime('now'))
+        )`,
+        'CREATE INDEX IF NOT EXISTS idx_turn_buffer_episode ON turn_buffer(episode_id)',
+      ];
+      for (const stmt of stmts) {
+        try { this.db.exec(stmt); } catch (e) {
+          if (!_isDuplicateOrExists(e)) {
+            process.stderr.write(`[database] Migration 2 failed: ${e.message}\n`);
+          }
+        }
+      }
+      // Mark existing episodes as summarized if they have a summary
+      try {
+        this.db.exec(
+          "UPDATE episodes SET is_summarized = 1 WHERE summary IS NOT NULL AND summary != ''"
+        );
+      } catch (_) { /* ignore */ }
+
+      this.db.exec(
+        "INSERT OR IGNORE INTO schema_migrations (version, description) VALUES (2, 'Add turn_buffer table, episode narrative/summary columns, episode_embeddings')"
+      );
+    }
+
+    // --- Migration 3: source_context on memories, is_archived on turn_buffer ---
+    if (currentVersion < 3) {
+      for (const stmt of [
+        'ALTER TABLE memories ADD COLUMN source_context TEXT',
+        'ALTER TABLE turn_buffer ADD COLUMN is_archived INTEGER DEFAULT 0',
+      ]) {
+        try { this.db.exec(stmt); } catch (e) {
+          if (!_isDuplicateOrExists(e)) {
+            process.stderr.write(`[database] Migration 3 failed: ${e.message}\n`);
+          }
+        }
+      }
+      this.db.exec(
+        "INSERT OR IGNORE INTO schema_migrations (version, description) VALUES (3, 'Add source_context to memories, is_archived to turn_buffer for episodic provenance')"
+      );
+    }
+
+    // --- Migration 4: FTS5 full-text search ---
+    if (currentVersion < 4) {
+      try {
+        this.db.exec(`
+          CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
+            content,
+            content=memories,
+            content_rowid=id,
+            tokenize='porter unicode61'
+          )
+        `);
+        this.db.exec(`
+          CREATE TRIGGER IF NOT EXISTS memories_ai AFTER INSERT ON memories BEGIN
+            INSERT INTO memories_fts(rowid, content) VALUES (new.id, new.content);
+          END
+        `);
+        this.db.exec(`
+          CREATE TRIGGER IF NOT EXISTS memories_ad AFTER DELETE ON memories BEGIN
+            INSERT INTO memories_fts(memories_fts, rowid, content) VALUES ('delete', old.id, old.content);
+          END
+        `);
+        this.db.exec(`
+          CREATE TRIGGER IF NOT EXISTS memories_au AFTER UPDATE ON memories BEGIN
+            INSERT INTO memories_fts(memories_fts, rowid, content) VALUES ('delete', old.id, old.content);
+            INSERT INTO memories_fts(rowid, content) VALUES (new.id, new.content);
+          END
+        `);
+        // Backfill existing memories into FTS5
+        this.db.exec(
+          'INSERT INTO memories_fts(rowid, content) SELECT id, content FROM memories'
+        );
+        this.db.exec(
+          "INSERT OR IGNORE INTO schema_migrations (version, description) VALUES (4, 'Add FTS5 full-text search table and auto-sync triggers for hybrid search')"
+        );
+      } catch (e) {
+        process.stderr.write(`[database] Migration 4 (FTS5) failed: ${e.message}. FTS5 may not be available.\n`);
+      }
+    }
+
+    // --- Migration 5: Verification columns on memories ---
+    if (currentVersion < 5) {
+      for (const stmt of [
+        'ALTER TABLE memories ADD COLUMN verified_at TEXT',
+        "ALTER TABLE memories ADD COLUMN verification_status TEXT DEFAULT 'pending'",
+        'ALTER TABLE predictions ADD COLUMN prediction_pattern_name TEXT',
+      ]) {
+        try { this.db.exec(stmt); } catch (e) {
+          if (!_isDuplicateOrExists(e)) {
+            process.stderr.write(`[database] Migration 5 failed: ${e.message}\n`);
+          }
+        }
+      }
+      try {
+        this.db.exec(
+          'CREATE INDEX IF NOT EXISTS idx_memories_verification ON memories(verification_status)'
+        );
+      } catch (_) { /* ignore */ }
+      // Grandfather existing memories as verified
+      try {
+        this.db.exec(
+          "UPDATE memories SET verification_status = 'verified', verified_at = datetime('now') WHERE verification_status = 'pending' OR verification_status IS NULL"
+        );
+      } catch (_) { /* ignore */ }
+
+      this.db.exec(
+        "INSERT OR IGNORE INTO schema_migrations (version, description) VALUES (5, 'Add verification columns to memories, prediction_pattern_name to predictions')"
+      );
+    }
+
+    // --- Migration 6: Source tracking on episodes ---
+    if (currentVersion < 6) {
+      for (const stmt of [
+        'ALTER TABLE episodes ADD COLUMN source TEXT',
+        'ALTER TABLE episodes ADD COLUMN ingested_at TEXT',
+        'ALTER TABLE turn_buffer ADD COLUMN source TEXT',
+      ]) {
+        try { this.db.exec(stmt); } catch (e) {
+          if (!_isDuplicateOrExists(e)) {
+            process.stderr.write(`[database] Migration 6 failed: ${e.message}\n`);
+          }
+        }
+      }
+      try {
+        this.db.exec(
+          'CREATE INDEX IF NOT EXISTS idx_episodes_source_ingested ON episodes(source, ingested_at)'
+        );
+      } catch (_) { /* ignore */ }
+
+      this.db.exec(
+        "INSERT OR IGNORE INTO schema_migrations (version, description) VALUES (6, 'Add source and ingested_at to episodes, source to turn_buffer for gateway integration')"
+      );
+    }
+
+    // --- Migration 7: Document storage and provenance ---
+    if (currentVersion < 7) {
+      const stmts = [
+        `CREATE TABLE IF NOT EXISTS documents (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          file_hash TEXT,
+          filename TEXT NOT NULL,
+          mime_type TEXT,
+          file_size INTEGER,
+          storage_provider TEXT DEFAULT 'local',
+          storage_path TEXT,
+          source_type TEXT,
+          source_ref TEXT,
+          summary TEXT,
+          lifecycle TEXT DEFAULT 'active',
+          last_accessed_at TEXT,
+          created_at TEXT DEFAULT (datetime('now')),
+          updated_at TEXT DEFAULT (datetime('now')),
+          workspace_id TEXT,
+          metadata TEXT
+        )`,
+        'CREATE INDEX IF NOT EXISTS idx_documents_hash ON documents(file_hash)',
+        'CREATE INDEX IF NOT EXISTS idx_documents_lifecycle ON documents(lifecycle)',
+        'CREATE INDEX IF NOT EXISTS idx_documents_source_type ON documents(source_type)',
+        'CREATE INDEX IF NOT EXISTS idx_documents_workspace ON documents(workspace_id)',
+        `CREATE TABLE IF NOT EXISTS entity_documents (
+          entity_id INTEGER NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+          document_id INTEGER NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+          relationship TEXT DEFAULT 'about',
+          created_at TEXT DEFAULT (datetime('now')),
+          PRIMARY KEY (entity_id, document_id, relationship)
+        )`,
+        'CREATE INDEX IF NOT EXISTS idx_entity_documents_doc ON entity_documents(document_id)',
+        `CREATE TABLE IF NOT EXISTS memory_sources (
+          memory_id INTEGER NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+          document_id INTEGER NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+          excerpt TEXT,
+          created_at TEXT DEFAULT (datetime('now')),
+          PRIMARY KEY (memory_id, document_id)
+        )`,
+        'CREATE INDEX IF NOT EXISTS idx_memory_sources_doc ON memory_sources(document_id)',
+      ];
+      for (const stmt of stmts) {
+        try { this.db.exec(stmt); } catch (e) {
+          if (!_isDuplicateOrExists(e)) {
+            process.stderr.write(`[database] Migration 7 failed: ${e.message}\n`);
+          }
+        }
+      }
+      this.db.exec(
+        "INSERT OR IGNORE INTO schema_migrations (version, description) VALUES (7, 'Add documents, entity_documents, memory_sources tables for provenance tracking')"
+      );
+    }
+
+    // --- Migration 8: Bi-temporal relationship tracking ---
+    if (currentVersion < 8) {
+      for (const stmt of [
+        'ALTER TABLE relationships ADD COLUMN valid_at TEXT',
+        'ALTER TABLE relationships ADD COLUMN invalid_at TEXT',
+      ]) {
+        try { this.db.exec(stmt); } catch (e) {
+          if (!_isDuplicateOrExists(e)) {
+            process.stderr.write(`[database] Migration 8 failed: ${e.message}\n`);
+          }
+        }
+      }
+      try {
+        this.db.exec(
+          'CREATE INDEX IF NOT EXISTS idx_relationships_temporal ON relationships(invalid_at, valid_at)'
+        );
+      } catch (_) { /* ignore */ }
+      // Grandfather existing relationships
+      try {
+        this.db.exec(
+          'UPDATE relationships SET valid_at = created_at WHERE valid_at IS NULL'
+        );
+      } catch (_) { /* ignore */ }
+
+      this.db.exec(
+        "INSERT OR IGNORE INTO schema_migrations (version, description) VALUES (8, 'Add valid_at, invalid_at to relationships for bi-temporal tracking')"
+      );
+    }
+
+    // --- Migration 9: _meta table ---
+    if (currentVersion < 9) {
+      try {
+        this.db.exec(`
+          CREATE TABLE IF NOT EXISTS _meta (
+            key TEXT PRIMARY KEY,
+            value TEXT,
+            updated_at TEXT DEFAULT (datetime('now'))
+          )
+        `);
+      } catch (e) {
+        if (!_isDuplicateOrExists(e)) {
+          process.stderr.write(`[database] Migration 9 failed: ${e.message}\n`);
+        }
+      }
+      this.db.exec(
+        "INSERT OR IGNORE INTO schema_migrations (version, description) VALUES (9, 'Add _meta table for database identification and workspace path tracking')"
+      );
+    }
+
+    // --- Migration 10: Reflections table ---
+    if (currentVersion < 10) {
+      const stmts = [
+        `CREATE TABLE IF NOT EXISTS reflections (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          episode_id INTEGER REFERENCES episodes(id),
+          reflection_type TEXT NOT NULL,
+          content TEXT NOT NULL,
+          content_hash TEXT,
+          about_entity_id INTEGER REFERENCES entities(id),
+          importance REAL DEFAULT 0.7,
+          confidence REAL DEFAULT 0.8,
+          decay_rate REAL DEFAULT 0.999,
+          aggregated_from TEXT,
+          aggregation_count INTEGER DEFAULT 1,
+          first_observed_at TEXT DEFAULT (datetime('now')),
+          last_confirmed_at TEXT DEFAULT (datetime('now')),
+          embedding BLOB,
+          created_at TEXT DEFAULT (datetime('now')),
+          updated_at TEXT,
+          surfaced_count INTEGER DEFAULT 0,
+          last_surfaced_at TEXT
+        )`,
+        'CREATE INDEX IF NOT EXISTS idx_reflections_type ON reflections(reflection_type)',
+        'CREATE INDEX IF NOT EXISTS idx_reflections_importance ON reflections(importance DESC)',
+        'CREATE INDEX IF NOT EXISTS idx_reflections_entity ON reflections(about_entity_id)',
+        'CREATE INDEX IF NOT EXISTS idx_reflections_episode ON reflections(episode_id)',
+      ];
+      for (const stmt of stmts) {
+        try { this.db.exec(stmt); } catch (e) {
+          if (!_isDuplicateOrExists(e)) {
+            process.stderr.write(`[database] Migration 10 failed: ${e.message}\n`);
+          }
+        }
+      }
+      this.db.exec(
+        "INSERT OR IGNORE INTO schema_migrations (version, description) VALUES (10, 'Add reflections table and reflection_embeddings for /meditate skill')"
+      );
+    }
+
+    // --- Migration 11: Source lookup index on documents ---
+    if (currentVersion < 11) {
+      try {
+        this.db.exec(
+          'CREATE INDEX IF NOT EXISTS idx_documents_source_lookup ON documents(source_type, source_ref)'
+        );
+      } catch (e) {
+        if (!_isDuplicateOrExists(e)) {
+          process.stderr.write(`[database] Migration 11 failed: ${e.message}\n`);
+        }
+      }
+      this.db.exec(
+        "INSERT OR IGNORE INTO schema_migrations (version, description) VALUES (11, 'Add compound index for fast source lookup on documents')"
+      );
+    }
+
+    // --- Migration 12: Audit log, metrics, soft-delete/correction ---
+    if (currentVersion < 12) {
+      const stmts = [
+        `CREATE TABLE IF NOT EXISTS audit_log (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          timestamp TEXT DEFAULT (datetime('now')),
+          operation TEXT NOT NULL,
+          details TEXT,
+          session_id TEXT,
+          user_initiated INTEGER DEFAULT 0,
+          entity_id INTEGER,
+          memory_id INTEGER
+        )`,
+        'CREATE INDEX IF NOT EXISTS idx_audit_log_timestamp ON audit_log(timestamp DESC)',
+        'CREATE INDEX IF NOT EXISTS idx_audit_log_operation ON audit_log(operation)',
+        'CREATE INDEX IF NOT EXISTS idx_audit_log_entity ON audit_log(entity_id)',
+        'CREATE INDEX IF NOT EXISTS idx_audit_log_memory ON audit_log(memory_id)',
+        `CREATE TABLE IF NOT EXISTS metrics (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          timestamp TEXT DEFAULT (datetime('now')),
+          metric_name TEXT NOT NULL,
+          metric_value REAL NOT NULL,
+          dimensions TEXT
+        )`,
+        'CREATE INDEX IF NOT EXISTS idx_metrics_name_timestamp ON metrics(metric_name, timestamp DESC)',
+        'ALTER TABLE entities ADD COLUMN deleted_at TEXT',
+        'ALTER TABLE entities ADD COLUMN deleted_reason TEXT',
+        'ALTER TABLE memories ADD COLUMN corrected_at TEXT',
+        'ALTER TABLE memories ADD COLUMN corrected_from TEXT',
+        'ALTER TABLE memories ADD COLUMN invalidated_at TEXT',
+        'ALTER TABLE memories ADD COLUMN invalidated_reason TEXT',
+      ];
+      for (const stmt of stmts) {
+        try { this.db.exec(stmt); } catch (e) {
+          if (!_isDuplicateOrExists(e)) {
+            process.stderr.write(`[database] Migration 12 failed: ${e.message}\n`);
+          }
+        }
+      }
+      try {
+        this.db.exec(
+          'CREATE INDEX IF NOT EXISTS idx_memories_invalidated ON memories(invalidated_at)'
+        );
+        this.db.exec(
+          'CREATE INDEX IF NOT EXISTS idx_entities_deleted ON entities(deleted_at)'
+        );
+      } catch (_) { /* ignore */ }
+
+      this.db.exec(
+        "INSERT OR IGNORE INTO schema_migrations (version, description) VALUES (12, 'Add audit_log, metrics tables, soft-delete on entities, correction/invalidation on memories')"
+      );
+    }
+
+    // --- Migration 13: Trust North Star - origin_type, agent_dispatches ---
+    if (currentVersion < 13) {
+      const stmts = [
+        "ALTER TABLE memories ADD COLUMN origin_type TEXT DEFAULT 'inferred'",
+        `CREATE TABLE IF NOT EXISTS agent_dispatches (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          agent_name TEXT NOT NULL,
+          dispatch_category TEXT NOT NULL,
+          task_summary TEXT,
+          started_at TEXT DEFAULT (datetime('now')),
+          completed_at TEXT,
+          duration_ms INTEGER,
+          success INTEGER DEFAULT 1,
+          required_claudia_judgment INTEGER DEFAULT 0,
+          judgment_reason TEXT,
+          episode_id INTEGER REFERENCES episodes(id),
+          user_approved INTEGER DEFAULT 1,
+          metadata TEXT
+        )`,
+        'CREATE INDEX IF NOT EXISTS idx_agent_dispatches_agent ON agent_dispatches(agent_name)',
+        'CREATE INDEX IF NOT EXISTS idx_agent_dispatches_category ON agent_dispatches(dispatch_category)',
+        'CREATE INDEX IF NOT EXISTS idx_agent_dispatches_started ON agent_dispatches(started_at DESC)',
+      ];
+      for (const stmt of stmts) {
+        try { this.db.exec(stmt); } catch (e) {
+          if (!_isDuplicateOrExists(e)) {
+            process.stderr.write(`[database] Migration 13 failed: ${e.message}\n`);
+          }
+        }
+      }
+      // Grandfather: high-importance conversation memories = user_stated
+      try {
+        this.db.exec(
+          "UPDATE memories SET origin_type = 'user_stated' WHERE origin_type IS NULL AND source = 'conversation' AND importance >= 0.9"
+        );
+        this.db.exec(
+          "UPDATE memories SET origin_type = 'inferred' WHERE origin_type IS NULL"
+        );
+      } catch (_) { /* ignore */ }
+
+      this.db.exec(
+        "INSERT OR IGNORE INTO schema_migrations (version, description) VALUES (13, 'Add origin_type to memories, agent_dispatches table for Trust North Star')"
+      );
+    }
+
+    // --- Migration 14: dispatch_tier on agent_dispatches ---
+    if (currentVersion < 14) {
+      try {
+        this.db.exec(
+          "ALTER TABLE agent_dispatches ADD COLUMN dispatch_tier TEXT DEFAULT 'task'"
+        );
+      } catch (e) {
+        if (!_isDuplicateOrExists(e)) {
+          process.stderr.write(`[database] Migration 14 failed: ${e.message}\n`);
+        }
+      }
+      this.db.exec(
+        "INSERT OR IGNORE INTO schema_migrations (version, description) VALUES (14, 'Add dispatch_tier to agent_dispatches for native agent team support')"
+      );
+    }
+
+    // --- Migration 15: origin_type on relationships ---
+    if (currentVersion < 15) {
+      try {
+        this.db.exec(
+          "ALTER TABLE relationships ADD COLUMN origin_type TEXT DEFAULT 'extracted'"
+        );
+      } catch (e) {
+        if (!_isDuplicateOrExists(e)) {
+          process.stderr.write(`[database] Migration 15 failed: ${e.message}\n`);
+        }
+      }
+      // Grandfather existing relationships
+      try {
+        this.db.exec(
+          "UPDATE relationships SET origin_type = 'extracted' WHERE origin_type IS NULL"
+        );
+      } catch (_) { /* ignore */ }
+
+      this.db.exec(
+        "INSERT OR IGNORE INTO schema_migrations (version, description) VALUES (15, 'Add origin_type to relationships for organic trust model')"
+      );
+    }
+
+    // --- Migration 16: source_channel on memories ---
+    if (currentVersion < 16) {
+      try {
+        this.db.exec(
+          "ALTER TABLE memories ADD COLUMN source_channel TEXT DEFAULT 'claude_code'"
+        );
+      } catch (e) {
+        if (!_isDuplicateOrExists(e)) {
+          process.stderr.write(`[database] Migration 16 failed: ${e.message}\n`);
+        }
+      }
+      this.db.exec(
+        "INSERT OR IGNORE INTO schema_migrations (version, description) VALUES (16, 'Add source_channel to memories for channel-aware memory')"
+      );
+    }
+
+    // --- Migration 17: Temporal intelligence ---
+    if (currentVersion < 17) {
+      for (const stmt of [
+        'ALTER TABLE memories ADD COLUMN deadline_at TEXT',
+        'ALTER TABLE memories ADD COLUMN temporal_markers TEXT',
+      ]) {
+        try { this.db.exec(stmt); } catch (e) {
+          if (!_isDuplicateOrExists(e)) {
+            process.stderr.write(`[database] Migration 17 failed: ${e.message}\n`);
+          }
+        }
+      }
+      try {
+        this.db.exec(
+          'CREATE INDEX IF NOT EXISTS idx_memories_deadline ON memories(deadline_at)'
+        );
+      } catch (_) { /* ignore */ }
+
+      this.db.exec(
+        "INSERT OR IGNORE INTO schema_migrations (version, description) VALUES (17, 'Add deadline_at and temporal_markers to memories for temporal intelligence')"
+      );
+    }
+
+    // --- Migration 18: Contact velocity + attention tiers ---
+    if (currentVersion < 18) {
+      for (const stmt of [
+        'ALTER TABLE entities ADD COLUMN last_contact_at TEXT',
+        'ALTER TABLE entities ADD COLUMN contact_frequency_days REAL',
+        'ALTER TABLE entities ADD COLUMN contact_trend TEXT',
+        "ALTER TABLE entities ADD COLUMN attention_tier TEXT DEFAULT 'standard'",
+      ]) {
+        try { this.db.exec(stmt); } catch (e) {
+          if (!_isDuplicateOrExists(e)) {
+            process.stderr.write(`[database] Migration 18 failed: ${e.message}\n`);
+          }
+        }
+      }
+      try {
+        this.db.exec(
+          'CREATE INDEX IF NOT EXISTS idx_entities_last_contact ON entities(last_contact_at)'
+        );
+        this.db.exec(
+          'CREATE INDEX IF NOT EXISTS idx_entities_trend ON entities(contact_trend)'
+        );
+        this.db.exec(
+          'CREATE INDEX IF NOT EXISTS idx_entities_attention_tier ON entities(attention_tier)'
+        );
+      } catch (_) { /* ignore */ }
+
+      this.db.exec(
+        "INSERT OR IGNORE INTO schema_migrations (version, description) VALUES (18, 'Add contact velocity and attention tier to entities for proactive relationship intelligence')"
+      );
+    }
+
+    // --- Migration 19: Entity summaries ---
+    if (currentVersion < 19) {
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS entity_summaries (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          entity_id INTEGER NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+          summary TEXT NOT NULL,
+          summary_type TEXT DEFAULT 'overview',
+          memory_count INTEGER DEFAULT 0,
+          relationship_count INTEGER DEFAULT 0,
+          generated_at TEXT DEFAULT (datetime('now')),
+          expires_at TEXT,
+          metadata TEXT,
+          UNIQUE(entity_id, summary_type)
+        )
+      `);
+      try {
+        this.db.exec(
+          'CREATE INDEX IF NOT EXISTS idx_entity_summaries_entity ON entity_summaries(entity_id)'
+        );
+        this.db.exec(
+          'CREATE INDEX IF NOT EXISTS idx_entity_summaries_expires ON entity_summaries(expires_at)'
+        );
+      } catch (_) { /* ignore */ }
+
+      this.db.exec(
+        "INSERT OR IGNORE INTO schema_migrations (version, description) VALUES (19, 'Add entity_summaries table for hierarchical graph-aware retrieval')"
+      );
+    }
+
+    // --- Migration 20: Lifecycle tiers, sacred, close-circle, fact_id, chain ---
+    if (currentVersion < 20) {
+      const stmts = [
+        "ALTER TABLE memories ADD COLUMN lifecycle_tier TEXT DEFAULT 'active'",
+        'ALTER TABLE memories ADD COLUMN sacred_reason TEXT',
+        'ALTER TABLE memories ADD COLUMN archived_at TEXT',
+        'ALTER TABLE memories ADD COLUMN fact_id TEXT UNIQUE',
+        'ALTER TABLE memories ADD COLUMN hash TEXT',
+        'ALTER TABLE memories ADD COLUMN prev_hash TEXT',
+        'ALTER TABLE entities ADD COLUMN close_circle BOOLEAN DEFAULT FALSE',
+        'ALTER TABLE entities ADD COLUMN close_circle_reason TEXT',
+        "ALTER TABLE relationships ADD COLUMN lifecycle_tier TEXT DEFAULT 'active'",
+      ];
+      for (const stmt of stmts) {
+        try { this.db.exec(stmt); } catch (e) {
+          if (!_isDuplicateOrExists(e)) {
+            process.stderr.write(`[database] Migration 20 failed: ${e.message}\n`);
+          }
+        }
+      }
+      try {
+        this.db.exec(
+          'CREATE INDEX IF NOT EXISTS idx_memories_lifecycle ON memories(lifecycle_tier)'
+        );
+        this.db.exec(
+          'CREATE INDEX IF NOT EXISTS idx_memories_fact_id ON memories(fact_id)'
+        );
+        this.db.exec(
+          'CREATE INDEX IF NOT EXISTS idx_entities_close_circle ON entities(close_circle) WHERE close_circle = 1'
+        );
+      } catch (_) { /* ignore */ }
+
+      // Backfill: generate fact_id for existing memories
+      try {
+        const rows = this.db.prepare(
+          'SELECT id FROM memories WHERE fact_id IS NULL'
+        ).all();
+        const updateStmt = this.db.prepare(
+          'UPDATE memories SET fact_id = ? WHERE id = ?'
+        );
+        const batchUpdate = this.db.transaction((batch) => {
+          for (const row of batch) {
+            updateStmt.run(randomUUID(), row.id);
+          }
+        });
+        // Process in batches of 1000
+        for (let i = 0; i < rows.length; i += 1000) {
+          batchUpdate(rows.slice(i, i + 1000));
+        }
+      } catch (e) {
+        process.stderr.write(`[database] Migration 20 fact_id backfill failed: ${e.message}\n`);
+      }
+
+      // Initialize chain_head and view_as_of in _meta
+      try {
+        this.db.exec(
+          "INSERT OR IGNORE INTO _meta (key, value, updated_at) VALUES ('chain_head', NULL, datetime('now'))"
+        );
+        this.db.exec(
+          "INSERT OR IGNORE INTO _meta (key, value, updated_at) VALUES ('view_as_of', NULL, datetime('now'))"
+        );
+      } catch (_) { /* ignore */ }
+
+      this.db.exec(
+        "INSERT OR IGNORE INTO schema_migrations (version, description) VALUES (20, 'Add lifecycle tiers, sacred memories, close-circle entities, fact_id, SHA-256 chain')"
+      );
+    }
+
+    // -----------------------------------------------------------------------
+    // Post-migration: Ensure FTS5 table + triggers exist
+    // -----------------------------------------------------------------------
+    try {
+      const ftsCheck = this.db.prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='memories_fts'"
+      ).get();
+      if (!ftsCheck) {
+        this.db.exec(`
+          CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
+            content,
+            content='memories',
+            content_rowid='id',
+            tokenize='porter unicode61'
+          )
+        `);
+        this.db.exec(`
+          CREATE TRIGGER IF NOT EXISTS memories_fts_insert AFTER INSERT ON memories BEGIN
+            INSERT INTO memories_fts(rowid, content) VALUES (new.id, new.content);
+          END
+        `);
+        this.db.exec(`
+          CREATE TRIGGER IF NOT EXISTS memories_fts_delete AFTER DELETE ON memories BEGIN
+            INSERT INTO memories_fts(memories_fts, rowid, content) VALUES ('delete', old.id, old.content);
+          END
+        `);
+        this.db.exec(`
+          CREATE TRIGGER IF NOT EXISTS memories_fts_update AFTER UPDATE OF content ON memories BEGIN
+            INSERT INTO memories_fts(memories_fts, rowid, content) VALUES ('delete', old.id, old.content);
+            INSERT INTO memories_fts(rowid, content) VALUES (new.id, new.content);
+          END
+        `);
+        // Backfill existing memories
+        this.db.exec(
+          'INSERT INTO memories_fts(rowid, content) SELECT id, content FROM memories'
+        );
+        this.db.exec(
+          "INSERT OR IGNORE INTO schema_migrations (version, description) VALUES (4, 'FTS5 full-text search with auto-sync triggers')"
+        );
+      }
+    } catch (e) {
+      const msg = e.message || '';
+      if (msg.toLowerCase().includes('fts5')) {
+        process.stderr.write(`[database] FTS5 not available in this SQLite build: ${msg}\n`);
+      } else {
+        process.stderr.write(`[database] FTS5 setup failed: ${msg}\n`);
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    // Post-migration: Ensure dispatch_tier validation trigger exists
+    // -----------------------------------------------------------------------
+    try {
+      const triggerCheck = this.db.prepare(
+        "SELECT name FROM sqlite_master WHERE type='trigger' AND name='validate_dispatch_tier'"
+      ).get();
+      if (!triggerCheck) {
+        this.db.exec(`
+          CREATE TRIGGER IF NOT EXISTS validate_dispatch_tier
+          BEFORE INSERT ON agent_dispatches
+          WHEN NEW.dispatch_tier NOT IN ('task', 'native_team')
+          BEGIN
+            SELECT RAISE(ABORT, 'dispatch_tier must be task or native_team');
+          END
+        `);
+      }
+    } catch (_) {
+      // Non-fatal; dispatch_tier trigger is a safety guard, not required
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Workspace path and registry
+  // -------------------------------------------------------------------------
+
+  /** Store workspace path in _meta table for database identification. */
+  _storeWorkspacePath() {
+    try {
+      const check = this.db.prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='_meta'"
+      ).get();
+      if (!check) return;
+    } catch (_) {
+      return;
+    }
+
+    const workspacePath = process.env.CLAUDIA_WORKSPACE_PATH;
+    if (!workspacePath) return;
+
+    this.db.prepare(
+      `INSERT INTO _meta (key, value, updated_at)
+       VALUES ('workspace_path', ?, datetime('now'))
+       ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = datetime('now')`
+    ).run(workspacePath);
+
+    this.db.prepare(
+      `INSERT OR IGNORE INTO _meta (key, value, updated_at)
+       VALUES ('created_at', ?, datetime('now'))`
+    ).run(new Date().toISOString());
+  }
+
+  /** Register this database in the central registry. */
+  _registerDatabase() {
+    const registryPath = getRegistryPath();
+
+    try {
+      let registry;
+      if (existsSync(registryPath)) {
+        registry = JSON.parse(readFileSync(registryPath, 'utf-8'));
+      } else {
+        registry = { databases: [] };
+      }
+
+      const dbStr = this.dbPath;
+      let entry = registry.databases.find(d => d.path === dbStr);
+
+      const workspace = process.env.CLAUDIA_WORKSPACE_PATH || '';
+      // Extract bare filename without extension as the name
+      const name = this.dbPath.split('/').pop().replace(/\.db$/, '');
+
+      if (entry) {
+        entry.workspace = workspace || entry.workspace || '';
+        entry.last_seen = new Date().toISOString();
+      } else {
+        registry.databases.push({
+          path: dbStr,
+          workspace,
+          name,
+          registered_at: new Date().toISOString(),
+          last_seen: new Date().toISOString(),
+        });
+      }
+
+      mkdirSync(dirname(registryPath), { recursive: true });
+      writeFileSync(registryPath, JSON.stringify(registry, null, 2));
+    } catch (_) {
+      // Non-fatal
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Query helpers
+  // -------------------------------------------------------------------------
+
+  /**
+   * Execute SQL and return { changes, lastInsertRowid }.
+   * @param {string} sql
+   * @param {Array} [params=[]]
+   * @returns {{ changes: number, lastInsertRowid: number }}
+   */
+  run(sql, params = []) {
+    const info = this.db.prepare(sql).run(...params);
+    return { changes: info.changes, lastInsertRowid: Number(info.lastInsertRowid) };
+  }
+
+  /**
+   * Execute SQL and return info (alias matching Python execute()).
+   * @param {string} sql
+   * @param {Array} [params=[]]
+   * @returns {{ changes: number, lastInsertRowid: number }}
+   */
+  execute(sql, params = []) {
+    return this.run(sql, params);
+  }
+
+  /**
+   * Execute SQL and return all rows as plain objects.
+   * @param {string} sql
+   * @param {Array} [params=[]]
+   * @returns {object[]}
+   */
+  query(sql, params = []) {
+    return this.db.prepare(sql).all(...params);
+  }
+
+  /**
+   * Execute SQL and return first row or null.
+   * @param {string} sql
+   * @param {Array} [params=[]]
+   * @returns {object|null}
+   */
+  queryOne(sql, params = []) {
+    return this.db.prepare(sql).get(...params) || null;
+  }
+
+  /**
+   * INSERT a row and return lastInsertRowid.
+   * @param {string} table
+   * @param {object} data - Column-value pairs
+   * @returns {number}
+   */
+  insert(table, data) {
+    const keys = Object.keys(data);
+    const columns = keys.join(', ');
+    const placeholders = keys.map(() => '?').join(', ');
+    const sql = `INSERT INTO ${table} (${columns}) VALUES (${placeholders})`;
+    const info = this.db.prepare(sql).run(...Object.values(data));
+    return Number(info.lastInsertRowid);
+  }
+
+  /**
+   * UPDATE rows and return changes count.
+   * @param {string} table
+   * @param {object} data - Column-value pairs to SET
+   * @param {string} where - WHERE clause (without "WHERE" keyword)
+   * @param {Array} [whereParams=[]]
+   * @returns {number}
+   */
+  update(table, data, where, whereParams = []) {
+    const setClause = Object.keys(data).map(k => `${k} = ?`).join(', ');
+    const sql = `UPDATE ${table} SET ${setClause} WHERE ${where}`;
+    const info = this.db.prepare(sql).run(...Object.values(data), ...whereParams);
+    return info.changes;
+  }
+
+  /**
+   * Execute raw SQL (multi-statement). No return value.
+   * Use this for DDL or multi-statement scripts.
+   * @param {string} sql
+   */
+  rawExec(sql) {
+    this.db.exec(sql);
+  }
+
+  /**
+   * Create a transaction wrapper.
+   * Usage: const txn = db.transaction((args) => { ... }); txn(args);
+   * @param {Function} fn - Function to execute within transaction
+   * @returns {Function} - Transaction-wrapped function
+   */
+  createTransaction(fn) {
+    return this.db.transaction(fn);
+  }
+
+  // -------------------------------------------------------------------------
+  // Backup
+  // -------------------------------------------------------------------------
+
+  /**
+   * Create a backup of the database using better-sqlite3's backup() API.
+   * @param {string} [label] - Optional label (e.g., "daily", "weekly", "pre-migration")
+   * @returns {Promise<string>} Path to backup file
+   */
+  async backup(label = null) {
+    const config = this.config || getConfig();
+    const timestamp = _formatTimestamp();
+    const suffix = label ? `backup-${label}-${timestamp}` : `backup-${timestamp}`;
+    const backupPath = `${this.dbPath}.${suffix}.db`;
+
+    // better-sqlite3 backup() returns a promise
+    await this.db.backup(backupPath);
+
+    // Verify backup integrity
+    try {
+      const verifyDb = new BetterSqlite3(backupPath, { readonly: true });
+      const result = verifyDb.pragma('integrity_check');
+      verifyDb.close();
+      if (result && result[0] && result[0].integrity_check !== 'ok') {
+        try { unlinkSync(backupPath); } catch (_) { /* ignore */ }
+        throw new Error(`Backup integrity check failed: ${JSON.stringify(result)}`);
+      }
+    } catch (e) {
+      if (e.message && e.message.includes('integrity check failed')) throw e;
+      // Verification could not run, non-fatal
+    }
+
+    // Rolling retention
+    const retention = label
+      ? _getLabelRetention(label, config)
+      : config.backup_retention_count;
+
+    _cleanOldBackups(this.dbPath, label, retention);
+
+    return backupPath;
+  }
+
+  // -------------------------------------------------------------------------
+  // Lifecycle
+  // -------------------------------------------------------------------------
+
+  /** Close the database connection. */
+  close() {
+    if (this.db) {
+      this.db.close();
+      this.db = null;
+    }
+    this._initialized = false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Utility helpers (module-private)
+// ---------------------------------------------------------------------------
+
+/** Check if an error is "duplicate column" or "already exists". */
+function _isDuplicateOrExists(e) {
+  const msg = (e.message || '').toLowerCase();
+  return msg.includes('duplicate column') || msg.includes('already exists');
+}
+
+/** Format current timestamp as YYYY-MM-DD-HHmmss. */
+function _formatTimestamp() {
+  const d = new Date();
+  const pad = (n) => String(n).padStart(2, '0');
+  return [
+    d.getFullYear(),
+    '-', pad(d.getMonth() + 1),
+    '-', pad(d.getDate()),
+    '-', pad(d.getHours()),
+    pad(d.getMinutes()),
+    pad(d.getSeconds()),
+  ].join('');
+}
+
+/** Get retention count for a labeled backup category. */
+function _getLabelRetention(label, config) {
+  const map = {
+    daily: config.backup_daily_retention,
+    weekly: config.backup_weekly_retention,
+  };
+  return map[label] || config.backup_retention_count;
+}
+
+/** Clean old backups, keeping only `retention` most recent. */
+function _cleanOldBackups(dbPath, label, retention) {
+  try {
+    const dir = dirname(dbPath);
+    const dbFilename = dbPath.split('/').pop();
+    const prefix = label
+      ? `${dbFilename}.backup-${label}-`
+      : `${dbFilename}.backup-`;
+
+    const files = readdirSync(dir)
+      .filter(f => f.startsWith(prefix) && f.endsWith('.db'))
+      .map(f => ({
+        name: f,
+        path: join(dir, f),
+        mtime: statSync(join(dir, f)).mtimeMs,
+      }))
+      .sort((a, b) => a.mtime - b.mtime);
+
+    while (files.length > retention) {
+      const oldest = files.shift();
+      try { unlinkSync(oldest.path); } catch (_) { /* ignore */ }
+    }
+  } catch (_) {
+    // Non-fatal
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Content hash utility
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate SHA-256 hex hash of content for deduplication.
+ * @param {string} content
+ * @returns {string}
+ */
+export function contentHash(content) {
+  return createHash('sha256').update(content, 'utf-8').digest('hex');
+}
+
+// ---------------------------------------------------------------------------
+// Singleton pattern
+// ---------------------------------------------------------------------------
+
+/** @type {ClaudiaDatabase|null} */
+let _instance = null;
+let _instanceProjectDir = undefined;
+
+/**
+ * Get or create the global database instance (lazy-initialized singleton).
+ * @param {string|null} [projectDir=null] - Project directory for DB path resolution
+ * @returns {ClaudiaDatabase}
+ */
+export function getDatabase(projectDir = null) {
+  if (_instance !== null && projectDir === _instanceProjectDir) {
+    return _instance;
+  }
+
+  const config = getConfig(projectDir);
+  const db = new ClaudiaDatabase(config.db_path, config);
+  db.initialize();
+
+  _instance = db;
+  _instanceProjectDir = projectDir;
+  return _instance;
+}
+
+/**
+ * Reset the global database instance (for testing).
+ */
+export function resetDatabase() {
+  if (_instance) {
+    _instance.close();
+  }
+  _instance = null;
+  _instanceProjectDir = undefined;
+}
+
+export { ClaudiaDatabase };

--- a/cli/core/embeddings.js
+++ b/cli/core/embeddings.js
@@ -1,0 +1,224 @@
+/**
+ * Embedding service for Claudia CLI.
+ * Port of memory-daemon/claudia_memory/embeddings.py.
+ *
+ * Uses Ollama HTTP API for local embeddings (default: all-minilm:l6-v2, 384D).
+ * All methods are async since Ollama calls are network I/O.
+ */
+
+import { createHash } from 'node:crypto';
+import { getConfig } from './config.js';
+
+// ----- LRU Cache -----
+
+class EmbeddingCache {
+  constructor(maxsize = 256) {
+    this._cache = new Map();
+    this._maxsize = maxsize;
+    this.hits = 0;
+    this.misses = 0;
+  }
+
+  _key(text) {
+    return createHash('sha256').update(text).digest('hex');
+  }
+
+  get(text) {
+    const key = this._key(text);
+    const val = this._cache.get(key);
+    if (val !== undefined) {
+      this._cache.delete(key);
+      this._cache.set(key, val);
+      this.hits++;
+      return val;
+    }
+    this.misses++;
+    return null;
+  }
+
+  put(text, embedding) {
+    const key = this._key(text);
+    this._cache.delete(key);
+    this._cache.set(key, embedding);
+    if (this._cache.size > this._maxsize) {
+      const oldest = this._cache.keys().next().value;
+      this._cache.delete(oldest);
+    }
+  }
+
+  clear() {
+    this._cache.clear();
+    this.hits = 0;
+    this.misses = 0;
+  }
+
+  stats() {
+    return {
+      hits: this.hits,
+      misses: this.misses,
+      size: this._cache.size,
+      maxsize: this._maxsize,
+    };
+  }
+}
+
+// ----- Constants -----
+
+const RETRY_ATTEMPTS = 5;
+const RETRY_DELAY_MS = 2000;
+const REQUEST_TIMEOUT_MS = 30000;
+
+/**
+ * fetch with AbortController timeout (Node 18+).
+ */
+async function fetchWithTimeout(url, options = {}, timeoutMs = REQUEST_TIMEOUT_MS) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...options, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ----- EmbeddingService -----
+
+class EmbeddingService {
+  constructor() {
+    const config = getConfig();
+    this.host = config.ollama_host;
+    this.model = config.embedding_model;
+    this.dimensions = config.embedding_dimensions;
+    this._cache = new EmbeddingCache(256);
+    this._available = null;
+  }
+
+  /**
+   * Wait for Ollama to become available (with retries).
+   */
+  async _waitForOllama(maxRetries = RETRY_ATTEMPTS, delayMs = RETRY_DELAY_MS) {
+    for (let i = 0; i < maxRetries; i++) {
+      try {
+        const res = await fetchWithTimeout(`${this.host}/api/tags`, {}, 5000);
+        if (res.ok) return true;
+      } catch {
+        // Retry
+      }
+      if (i < maxRetries - 1) {
+        await new Promise(r => setTimeout(r, delayMs));
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Check if Ollama is running and the embedding model is available.
+   */
+  async isAvailable() {
+    if (this._available !== null) return this._available;
+
+    const ollamaUp = await this._waitForOllama();
+    if (!ollamaUp) {
+      this._available = false;
+      return false;
+    }
+
+    try {
+      const res = await fetchWithTimeout(`${this.host}/api/tags`);
+      if (!res.ok) {
+        this._available = false;
+        return false;
+      }
+      const data = await res.json();
+      const models = (data.models || []).map(m => m.name);
+      const hasModel = models.some(m =>
+        m === this.model || m === `${this.model}:latest` || m.startsWith(`${this.model}:`)
+      );
+      this._available = hasModel;
+      return hasModel;
+    } catch {
+      this._available = false;
+      return false;
+    }
+  }
+
+  /**
+   * Generate embedding for text.
+   * @param {string} text
+   * @returns {Promise<number[]|null>} Float array or null if unavailable
+   */
+  async embed(text) {
+    const cached = this._cache.get(text);
+    if (cached) return cached;
+
+    if (!(await this.isAvailable())) return null;
+
+    try {
+      const res = await fetchWithTimeout(`${this.host}/api/embeddings`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: this.model, prompt: text }),
+      });
+
+      if (!res.ok) return null;
+      const data = await res.json();
+      const embedding = data.embedding;
+
+      if (!embedding || embedding.length !== this.dimensions) {
+        process.stderr.write(
+          `[embeddings] Dimension mismatch: got ${embedding?.length}, expected ${this.dimensions}\n`
+        );
+        return null;
+      }
+
+      this._cache.put(text, embedding);
+      return embedding;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Generate embeddings for multiple texts in parallel.
+   * @param {string[]} texts
+   * @returns {Promise<(number[]|null)[]>}
+   */
+  async embedBatch(texts) {
+    return Promise.all(texts.map(t => this.embed(t)));
+  }
+
+  /** Cache statistics. */
+  cacheStats() {
+    return this._cache.stats();
+  }
+
+  /** Clear cache (used after model migration). */
+  clearCache() {
+    this._cache.clear();
+  }
+}
+
+// ----- Module Singleton -----
+
+let _service = null;
+
+export function getEmbeddingService() {
+  if (!_service) {
+    _service = new EmbeddingService();
+  }
+  return _service;
+}
+
+export function resetEmbeddingService() {
+  _service = null;
+}
+
+/** Convenience: embed single text. */
+export async function embed(text) {
+  return getEmbeddingService().embed(text);
+}
+
+/** Convenience: batch embed. */
+export async function embedBatch(texts) {
+  return getEmbeddingService().embedBatch(texts);
+}

--- a/cli/core/guards.js
+++ b/cli/core/guards.js
@@ -1,0 +1,192 @@
+/**
+ * Input validation for Claudia CLI.
+ * Port of memory-daemon/claudia_memory/guards.py.
+ *
+ * Deterministic validation: no LLM calls, just regex + clamping.
+ */
+
+// ----- Deadline Detection Patterns -----
+
+const DEADLINE_PATTERNS = [
+  /\b(by|before|due|until|deadline)\s+\w+/i,
+  /\b\d{1,2}[/-]\d{1,2}([/-]\d{2,4})?\b/,
+  /\b(january|february|march|april|may|june|july|august|september|october|november|december)\s+\d{1,2}\b/i,
+  /\b(monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b/i,
+  /\b(tomorrow|tonight|next week|next month|end of (week|month|day|year))\b/i,
+  /\bEOD\b|\bEOW\b|\bEOM\b/,
+];
+
+// ----- Origin Strength Ceilings -----
+
+export const ORIGIN_STRENGTH_CEILING = {
+  user_stated: 1.0,
+  extracted: 0.8,
+  inferred: 0.5,
+  corrected: 1.0,
+};
+
+export const REINFORCEMENT_BY_ORIGIN = {
+  user_stated: 0.2,
+  extracted: 0.1,
+  inferred: 0.05,
+  corrected: 0.2,
+};
+
+// ----- Validation Results -----
+
+/**
+ * @typedef {Object} ValidationResult
+ * @property {boolean} isValid
+ * @property {string[]} warnings
+ * @property {Object} adjustments - Key-value pairs of adjusted values
+ */
+
+/**
+ * Validate a memory before saving.
+ * @param {string} content
+ * @param {string} memoryType - fact, preference, observation, learning, commitment, pattern
+ * @param {number} importance - 0.0-1.0
+ * @returns {ValidationResult}
+ */
+export function validateMemory(content, memoryType = 'fact', importance = 1.0) {
+  const warnings = [];
+  const adjustments = {};
+
+  // Content length check
+  if (content.length > 1000) {
+    warnings.push('Content exceeds 1000 characters. Truncating.');
+    adjustments.content = content.slice(0, 1000);
+  } else if (content.length > 500) {
+    warnings.push('Content is long (>500 chars). Consider breaking into multiple memories.');
+  }
+
+  // Importance clamping
+  if (importance < 0) {
+    adjustments.importance = 0;
+    warnings.push(`Importance ${importance} below 0, clamped to 0.`);
+  } else if (importance > 1.0) {
+    adjustments.importance = 1.0;
+    warnings.push(`Importance ${importance} above 1.0, clamped to 1.0.`);
+  }
+
+  // Commitment deadline detection
+  if (memoryType === 'commitment') {
+    const hasDeadline = DEADLINE_PATTERNS.some(p => p.test(content));
+    if (!hasDeadline) {
+      warnings.push('Commitment without a detected deadline. Consider adding a date or timeframe.');
+    }
+  }
+
+  return { isValid: true, warnings, adjustments };
+}
+
+/**
+ * Validate an entity before creating.
+ * @param {string} name
+ * @param {string} entityType - person, organization, project, concept, location
+ * @param {string[]|null} existingCanonicalNames - For near-duplicate detection
+ * @returns {ValidationResult}
+ */
+export function validateEntity(name, entityType = '', existingCanonicalNames = null) {
+  const warnings = [];
+  const adjustments = {};
+
+  if (!name || !name.trim()) {
+    return { isValid: false, warnings: ['Entity name cannot be empty.'], adjustments };
+  }
+
+  if (!entityType) {
+    warnings.push("Entity type not specified. Defaulting to 'person'.");
+    adjustments.type = 'person';
+  }
+
+  // Near-duplicate detection (simple ratio check)
+  if (existingCanonicalNames && existingCanonicalNames.length > 0) {
+    const canonical = canonicalName(name);
+    for (const existing of existingCanonicalNames) {
+      const ratio = similarityRatio(canonical, existing);
+      if (ratio > 0.85 && canonical !== existing) {
+        warnings.push(`Near-duplicate detected: "${name}" is ${(ratio * 100).toFixed(0)}% similar to existing entity "${existing}".`);
+      }
+    }
+  }
+
+  return { isValid: true, warnings, adjustments };
+}
+
+/**
+ * Validate a relationship.
+ * @param {number} strength - 0.0-1.0
+ * @param {string} originType - user_stated, extracted, inferred, corrected
+ * @returns {ValidationResult}
+ */
+export function validateRelationship(strength = 1.0, originType = 'extracted') {
+  const warnings = [];
+  const adjustments = {};
+
+  // Clamp strength to [0, 1]
+  let clamped = Math.max(0, Math.min(1.0, strength));
+
+  // Cap by origin authority ceiling
+  const ceiling = ORIGIN_STRENGTH_CEILING[originType] ?? 0.5;
+  if (clamped > ceiling) {
+    warnings.push(`Strength ${clamped} exceeds ceiling ${ceiling} for origin '${originType}'. Capping.`);
+    clamped = ceiling;
+  }
+
+  if (clamped !== strength) {
+    adjustments.strength = clamped;
+  }
+
+  return { isValid: true, warnings, adjustments };
+}
+
+// ----- Utility Functions -----
+
+/**
+ * Normalize entity name to canonical form.
+ * Lowercase, strip special characters, trim whitespace.
+ */
+export function canonicalName(name) {
+  return name
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Simple string similarity ratio (Dice coefficient).
+ * Good enough for near-duplicate detection.
+ */
+function similarityRatio(a, b) {
+  if (a === b) return 1.0;
+  if (a.length < 2 || b.length < 2) return 0.0;
+
+  const bigrams = new Map();
+  for (let i = 0; i < a.length - 1; i++) {
+    const bigram = a.slice(i, i + 2);
+    bigrams.set(bigram, (bigrams.get(bigram) || 0) + 1);
+  }
+
+  let matches = 0;
+  for (let i = 0; i < b.length - 1; i++) {
+    const bigram = b.slice(i, i + 2);
+    const count = bigrams.get(bigram) || 0;
+    if (count > 0) {
+      bigrams.set(bigram, count - 1);
+      matches++;
+    }
+  }
+
+  return (2.0 * matches) / (a.length + b.length - 2);
+}
+
+/**
+ * Check if content contains deadline patterns.
+ * @param {string} content
+ * @returns {boolean}
+ */
+export function hasDeadlinePattern(content) {
+  return DEADLINE_PATTERNS.some(p => p.test(content));
+}

--- a/cli/core/language-model.js
+++ b/cli/core/language-model.js
@@ -1,0 +1,168 @@
+/**
+ * Language model service for Claudia CLI.
+ * Port of memory-daemon/claudia_memory/language_model.py.
+ *
+ * Uses Ollama HTTP API for local text generation (default: qwen3:4b).
+ * Used by cognitive.ingest for entity/memory extraction from raw text.
+ *
+ * When no language model is available, returns null so Claude handles
+ * the work directly (current fallback behavior).
+ */
+
+import { getConfig } from './config.js';
+
+// ----- Constants -----
+
+const RETRY_ATTEMPTS = 3;
+const RETRY_DELAY_MS = 2000;
+const DEFAULT_TIMEOUT_MS = 120_000; // Longer timeout for generation vs embeddings
+const DEFAULT_TEMPERATURE = 0.1; // Low temp for deterministic extraction
+
+/**
+ * fetch with AbortController timeout.
+ */
+async function fetchWithTimeout(url, options = {}, timeoutMs = DEFAULT_TIMEOUT_MS) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...options, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ----- LanguageModelService -----
+
+class LanguageModelService {
+  constructor() {
+    const config = getConfig();
+    this.host = config.ollama_host;
+    this.model = config.language_model;
+    this._available = null;
+  }
+
+  /**
+   * Check if Ollama is running and the language model is pulled.
+   */
+  async isAvailable() {
+    if (this._available !== null) return this._available;
+
+    // No model configured means the user opted out
+    if (!this.model) {
+      this._available = false;
+      return false;
+    }
+
+    // Check Ollama is reachable
+    let reachable = false;
+    for (let i = 0; i < RETRY_ATTEMPTS; i++) {
+      try {
+        const res = await fetchWithTimeout(`${this.host}/api/tags`, {}, 5000);
+        if (res.ok) {
+          reachable = true;
+          break;
+        }
+      } catch {
+        // Retry
+      }
+      if (i < RETRY_ATTEMPTS - 1) {
+        await new Promise(r => setTimeout(r, RETRY_DELAY_MS));
+      }
+    }
+
+    if (!reachable) {
+      this._available = false;
+      return false;
+    }
+
+    // Check the model is pulled
+    try {
+      const res = await fetchWithTimeout(`${this.host}/api/tags`);
+      if (!res.ok) {
+        this._available = false;
+        return false;
+      }
+      const data = await res.json();
+      const models = (data.models || []).map(m => m.name);
+      const hasModel = models.some(m =>
+        m === this.model || m === `${this.model}:latest` || m.startsWith(`${this.model}:`)
+      );
+
+      if (!hasModel) {
+        process.stderr.write(
+          `[language-model] Model '${this.model}' not found. ` +
+          `Available: ${models.join(', ')}. Pull with: ollama pull ${this.model}\n`
+        );
+      }
+
+      this._available = hasModel;
+      return hasModel;
+    } catch {
+      this._available = false;
+      return false;
+    }
+  }
+
+  /**
+   * Generate text using the local language model.
+   * @param {string} prompt - The user prompt to send
+   * @param {object} options
+   * @param {string} [options.system] - System prompt for task framing
+   * @param {number} [options.temperature] - Sampling temperature (low = deterministic)
+   * @param {boolean} [options.formatJson] - If true, request JSON output from Ollama
+   * @returns {Promise<string|null>} Generated text, or null if unavailable/failed
+   */
+  async generate(prompt, { system, temperature = DEFAULT_TEMPERATURE, formatJson = false } = {}) {
+    if (!(await this.isAvailable())) return null;
+
+    try {
+      const payload = {
+        model: this.model,
+        prompt,
+        stream: false,
+        options: { temperature },
+      };
+      if (system) payload.system = system;
+      if (formatJson) payload.format = 'json';
+
+      const res = await fetchWithTimeout(`${this.host}/api/generate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        process.stderr.write(`[language-model] Generation failed: HTTP ${res.status}\n`);
+        return null;
+      }
+
+      const data = await res.json();
+      return data.response || null;
+    } catch (err) {
+      if (err.name === 'AbortError') {
+        process.stderr.write(`[language-model] Generation timed out (model=${this.model})\n`);
+      }
+      return null;
+    }
+  }
+}
+
+// ----- Module Singleton -----
+
+let _service = null;
+
+export function getLanguageModelService() {
+  if (!_service) {
+    _service = new LanguageModelService();
+  }
+  return _service;
+}
+
+export function resetLanguageModelService() {
+  _service = null;
+}
+
+/** Convenience: generate text. */
+export async function generate(prompt, options) {
+  return getLanguageModelService().generate(prompt, options);
+}

--- a/cli/core/output.js
+++ b/cli/core/output.js
@@ -1,0 +1,93 @@
+/**
+ * Output formatting for Claudia CLI.
+ * JSON by default (for Claude to parse), --pretty for human-readable.
+ */
+
+/**
+ * Output a JSON result to stdout.
+ * This is the primary output method — Claude parses this.
+ */
+export function outputJson(data) {
+  process.stdout.write(JSON.stringify(data, null, 2) + '\n');
+}
+
+/**
+ * Output an error as JSON to stderr and exit with code 1.
+ */
+export function outputError(message, details = {}) {
+  const error = { error: true, message, ...details };
+  process.stderr.write(JSON.stringify(error, null, 2) + '\n');
+  process.exit(1);
+}
+
+/**
+ * Output a warning to stderr (does not exit).
+ */
+export function outputWarning(message) {
+  process.stderr.write(JSON.stringify({ warning: true, message }) + '\n');
+}
+
+/**
+ * Output a success result.
+ */
+export function outputSuccess(message, data = {}) {
+  outputJson({ success: true, message, ...data });
+}
+
+/**
+ * Format a RecallResult for output.
+ */
+export function formatRecallResult(result) {
+  return {
+    id: result.id,
+    content: result.content,
+    type: result.type,
+    score: result.score != null ? Math.round(result.score * 1000) / 1000 : undefined,
+    importance: result.importance,
+    confidence: result.confidence,
+    created_at: result.created_at,
+    entities: result.entities || [],
+    source: result.source,
+    source_context: result.source_context,
+    origin_type: result.origin_type,
+    verification_status: result.verification_status,
+    source_channel: result.source_channel,
+    lifecycle_tier: result.lifecycle_tier,
+    fact_id: result.fact_id,
+  };
+}
+
+/**
+ * Format entity for output.
+ */
+export function formatEntity(entity) {
+  return {
+    id: entity.id,
+    name: entity.name,
+    type: entity.type,
+    canonical_name: entity.canonical_name,
+    description: entity.description,
+    importance: entity.importance,
+    attention_tier: entity.attention_tier,
+    contact_trend: entity.contact_trend,
+    close_circle: Boolean(entity.close_circle),
+    created_at: entity.created_at,
+  };
+}
+
+/**
+ * Format relationship for output.
+ */
+export function formatRelationship(rel) {
+  return {
+    id: rel.id,
+    source_name: rel.source_name,
+    target_name: rel.target_name,
+    relationship_type: rel.relationship_type,
+    strength: rel.strength,
+    origin_type: rel.origin_type,
+    direction: rel.direction,
+    valid_at: rel.valid_at,
+    invalid_at: rel.invalid_at,
+  };
+}

--- a/cli/core/paths.js
+++ b/cli/core/paths.js
@@ -1,0 +1,153 @@
+/**
+ * Path resolution for Claudia CLI.
+ * Handles ~/.claudia/ directory structure and workspace detection.
+ */
+
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { basename, join, resolve } from 'node:path';
+
+/** Base Claudia home directory */
+export function getClaudiaHome() {
+  return process.env.CLAUDIA_HOME || join(homedir(), '.claudia');
+}
+
+/** Memory database directory */
+export function getMemoryDir() {
+  return join(getClaudiaHome(), 'memory');
+}
+
+/** Config file path */
+export function getConfigPath() {
+  return join(getClaudiaHome(), 'config.json');
+}
+
+/** Vault base directory */
+export function getVaultDir() {
+  return join(getClaudiaHome(), 'vault');
+}
+
+/** Files storage directory */
+export function getFilesDir() {
+  return join(getClaudiaHome(), 'files');
+}
+
+/** Log file path */
+export function getLogPath() {
+  return join(getClaudiaHome(), 'daemon.log');
+}
+
+/** Backup directory for a database */
+export function getBackupDir(dbPath) {
+  const dir = join(getClaudiaHome(), 'backups');
+  ensureDir(dir);
+  return dir;
+}
+
+/**
+ * Compute workspace hash for per-project database isolation.
+ * SHA-256[:12] of the absolute workspace path.
+ */
+export function workspaceHash(projectDir) {
+  const absPath = resolve(projectDir);
+  return createHash('sha256').update(absPath).digest('hex').slice(0, 12);
+}
+
+/**
+ * Get database path for a project directory.
+ *
+ * Priority:
+ * 1. CLAUDIA_DB_OVERRIDE env var
+ * 2. CLAUDIA_DEMO_MODE=1 → demo database
+ * 3. projectDir → per-project database
+ * 4. Default → claudia.db
+ */
+export function getDbPath(projectDir) {
+  // Override
+  if (process.env.CLAUDIA_DB_OVERRIDE) {
+    return process.env.CLAUDIA_DB_OVERRIDE;
+  }
+
+  const memDir = getMemoryDir();
+  ensureDir(memDir);
+
+  // Demo mode
+  if (process.env.CLAUDIA_DEMO_MODE === '1') {
+    const demoDir = join(getClaudiaHome(), 'demo');
+    ensureDir(demoDir);
+    if (projectDir) {
+      return join(demoDir, `${workspaceHash(projectDir)}.db`);
+    }
+    return join(demoDir, 'claudia-demo.db');
+  }
+
+  // Per-project isolation
+  if (projectDir) {
+    return join(memDir, `${workspaceHash(projectDir)}.db`);
+  }
+
+  // Default
+  return join(memDir, 'claudia.db');
+}
+
+/**
+ * Detect workspace directory by walking up from cwd.
+ * Looks for CLAUDE.md + .claude/ directory as markers.
+ */
+export function detectWorkspace(startDir) {
+  let dir = resolve(startDir || process.cwd());
+  const root = resolve('/');
+
+  while (dir !== root) {
+    const hasClaudeMd = existsSync(join(dir, 'CLAUDE.md'));
+    const hasClaudeDir = existsSync(join(dir, '.claude'));
+    if (hasClaudeMd && hasClaudeDir) {
+      return dir;
+    }
+    const parent = resolve(dir, '..');
+    if (parent === dir) break;
+    dir = parent;
+  }
+
+  return null;
+}
+
+/**
+ * Resolve the project directory from various sources.
+ *
+ * Priority:
+ * 1. Explicit --project-dir flag
+ * 2. CLAUDIA_PROJECT_DIR env var
+ * 3. Auto-detect from cwd
+ * 4. Fall back to cwd
+ */
+export function resolveProjectDir(explicitDir) {
+  if (explicitDir) {
+    return resolve(explicitDir);
+  }
+
+  if (process.env.CLAUDIA_PROJECT_DIR) {
+    return resolve(process.env.CLAUDIA_PROJECT_DIR);
+  }
+
+  const detected = detectWorkspace(process.cwd());
+  if (detected) {
+    return detected;
+  }
+
+  return process.cwd();
+}
+
+/** Ensure a directory exists, creating it recursively if needed. */
+export function ensureDir(dir) {
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  return dir;
+}
+
+/** Database registry path */
+export function getRegistryPath() {
+  return join(getMemoryDir(), 'registry.json');
+}

--- a/cli/index.js
+++ b/cli/index.js
@@ -1,0 +1,523 @@
+#!/usr/bin/env node
+
+/**
+ * Claudia CLI - Pure Node.js memory system.
+ * Replaces the Python MCP daemon with CLI subcommands.
+ *
+ * Usage:
+ *   claudia memory save "fact" --person Kamil
+ *   claudia memory recall "query"
+ *   claudia system-health
+ */
+
+import { Command } from 'commander';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'));
+
+const program = new Command();
+
+program
+  .name('claudia')
+  .description('Claudia CLI - An AI assistant who learns how you work')
+  .version(pkg.version)
+  .option('--project-dir <dir>', 'Workspace directory (auto-detected if omitted)');
+
+// Register subcommands (lazy-loaded)
+
+program
+  .command('system-health')
+  .description('Check system health and diagnostics')
+  .action(async (opts) => {
+    const { systemHealthCommand } = await import('./commands/system.js');
+    await systemHealthCommand(program.opts());
+  });
+
+// Memory subcommand group
+const memory = program
+  .command('memory')
+  .description('Memory operations (save, recall, about, etc.)');
+
+memory
+  .command('save')
+  .description('Save a memory')
+  .argument('<content>', 'Memory content to save')
+  .option('--type <type>', 'Memory type: fact, preference, observation, learning, commitment, pattern', 'fact')
+  .option('--person <name>', 'Person this memory is about')
+  .option('--entity <names...>', 'Entity names this memory is about')
+  .option('--importance <n>', 'Importance 0.0-1.0', parseFloat, 1.0)
+  .option('--source <source>', 'Where this came from', 'conversation')
+  .option('--source-context <ctx>', 'One-line breadcrumb')
+  .option('--source-channel <ch>', 'Origin channel', 'claude_code')
+  .option('--critical', 'Mark as sacred (immune to decay)')
+  .action(async (content, opts) => {
+    const { memorySaveCommand } = await import('./commands/memory.js');
+    await memorySaveCommand(content, opts, program.opts());
+  });
+
+memory
+  .command('recall')
+  .description('Search memories')
+  .argument('<query>', 'Search query')
+  .option('--limit <n>', 'Max results', parseInt, 20)
+  .option('--type <types...>', 'Filter by memory type')
+  .option('--entity <name>', 'Filter to memories about entity')
+  .option('--since <date>', 'Only memories after this date')
+  .option('--before <date>', 'Only memories before this date')
+  .option('--include-archived', 'Include archived memories')
+  .action(async (query, opts) => {
+    const { memoryRecallCommand } = await import('./commands/memory.js');
+    await memoryRecallCommand(query, opts, program.opts());
+  });
+
+memory
+  .command('about')
+  .description('Get full context about an entity')
+  .argument('<entity>', 'Entity name')
+  .option('--limit <n>', 'Max memories to return', parseInt, 20)
+  .option('--include-historical', 'Include invalidated relationships')
+  .action(async (entity, opts) => {
+    const { memoryAboutCommand } = await import('./commands/memory.js');
+    await memoryAboutCommand(entity, opts, program.opts());
+  });
+
+memory
+  .command('relate')
+  .description('Create or strengthen a relationship')
+  .option('--source <name>', 'Source entity name')
+  .option('--target <name>', 'Target entity name')
+  .option('--type <type>', 'Relationship type (works_with, manages, etc.)')
+  .option('--strength <n>', 'Relationship strength 0.0-1.0', parseFloat, 1.0)
+  .option('--origin <type>', 'Origin type', 'extracted')
+  .action(async (opts) => {
+    const { memoryRelateCommand } = await import('./commands/memory.js');
+    await memoryRelateCommand(opts, program.opts());
+  });
+
+memory
+  .command('batch')
+  .description('Run batch memory operations (reads JSON from stdin or --file)')
+  .option('--file <path>', 'JSON file with operations')
+  .action(async (opts) => {
+    const { memoryBatchCommand } = await import('./commands/memory.js');
+    await memoryBatchCommand(opts, program.opts());
+  });
+
+memory
+  .command('end-session')
+  .description('End a session with narrative and extractions')
+  .option('--episode-id <id>', 'Episode ID', parseInt)
+  .option('--narrative <text>', 'Session narrative')
+  .option('--file <path>', 'JSON file with session data')
+  .action(async (opts) => {
+    const { memoryEndSessionCommand } = await import('./commands/memory.js');
+    await memoryEndSessionCommand(opts, program.opts());
+  });
+
+memory
+  .command('consolidate')
+  .description('Run memory consolidation (decay, patterns, merge)')
+  .option('--lightweight', 'Only run decay (faster)')
+  .action(async (opts) => {
+    const { memoryConsolidateCommand } = await import('./commands/memory.js');
+    await memoryConsolidateCommand(opts, program.opts());
+  });
+
+memory
+  .command('briefing')
+  .description('Get compact session-start briefing')
+  .action(async (opts) => {
+    const { memoryBriefingCommand } = await import('./commands/memory.js');
+    await memoryBriefingCommand(opts, program.opts());
+  });
+
+memory
+  .command('summary')
+  .description('Get lightweight entity summary')
+  .option('--entity <name>', 'Entity name')
+  .action(async (opts) => {
+    const { memorySummaryCommand } = await import('./commands/memory.js');
+    await memorySummaryCommand(opts, program.opts());
+  });
+
+memory
+  .command('reflections')
+  .description('Query or manage reflections')
+  .option('--query <text>', 'Search reflections')
+  .option('--save <content>', 'Store a new reflection')
+  .option('--type <type>', 'Reflection type: observation, pattern, learning, question')
+  .option('--update <id>', 'Update reflection by ID', parseInt)
+  .option('--delete <id>', 'Delete reflection by ID', parseInt)
+  .action(async (opts) => {
+    const { memoryReflectionsCommand } = await import('./commands/memory.js');
+    await memoryReflectionsCommand(opts, program.opts());
+  });
+
+memory
+  .command('project-health')
+  .description('Relationship velocity projection')
+  .option('--entity <name>', 'Project or person name')
+  .action(async (opts) => {
+    const { memoryProjectHealthCommand } = await import('./commands/memory.js');
+    await memoryProjectHealthCommand(opts, program.opts());
+  });
+
+// Temporal subcommands
+const temporal = memory
+  .command('temporal')
+  .description('Time-based memory queries');
+
+temporal
+  .command('upcoming')
+  .description('Upcoming deadlines')
+  .option('--days <n>', 'Days ahead to look', parseInt, 14)
+  .option('--include-overdue', 'Include overdue items')
+  .action(async (opts) => {
+    const { temporalUpcomingCommand } = await import('./commands/memory.js');
+    await temporalUpcomingCommand(opts, program.opts());
+  });
+
+temporal
+  .command('since')
+  .description('Changes since a date')
+  .argument('<date>', 'ISO date string')
+  .option('--entity <name>', 'Filter to entity')
+  .option('--limit <n>', 'Max results', parseInt, 50)
+  .action(async (date, opts) => {
+    const { temporalSinceCommand } = await import('./commands/memory.js');
+    await temporalSinceCommand(date, opts, program.opts());
+  });
+
+temporal
+  .command('timeline')
+  .description('Entity history timeline')
+  .argument('<entity>', 'Entity name')
+  .option('--limit <n>', 'Max results', parseInt, 50)
+  .action(async (entity, opts) => {
+    const { temporalTimelineCommand } = await import('./commands/memory.js');
+    await temporalTimelineCommand(entity, opts, program.opts());
+  });
+
+temporal
+  .command('morning')
+  .description('Morning context digest')
+  .action(async (opts) => {
+    const { temporalMorningCommand } = await import('./commands/memory.js');
+    await temporalMorningCommand(opts, program.opts());
+  });
+
+// Graph subcommands
+const graph = memory
+  .command('graph')
+  .description('Relationship graph operations');
+
+graph
+  .command('network')
+  .description('Project collaborator network')
+  .argument('<entity>', 'Project name')
+  .action(async (entity, opts) => {
+    const { graphNetworkCommand } = await import('./commands/memory.js');
+    await graphNetworkCommand(entity, opts, program.opts());
+  });
+
+graph
+  .command('path')
+  .description('Find connection path between entities')
+  .argument('<entityA>', 'Start entity')
+  .argument('<entityB>', 'End entity')
+  .option('--max-depth <n>', 'Max path depth', parseInt, 4)
+  .action(async (entityA, entityB, opts) => {
+    const { graphPathCommand } = await import('./commands/memory.js');
+    await graphPathCommand(entityA, entityB, opts, program.opts());
+  });
+
+graph
+  .command('hubs')
+  .description('Hub entities with many connections')
+  .option('--min-connections <n>', 'Minimum connections', parseInt, 5)
+  .option('--type <type>', 'Entity type filter')
+  .option('--limit <n>', 'Max results', parseInt, 20)
+  .action(async (opts) => {
+    const { graphHubsCommand } = await import('./commands/memory.js');
+    await graphHubsCommand(opts, program.opts());
+  });
+
+graph
+  .command('dormant')
+  .description('Dormant relationships')
+  .option('--days <n>', 'Days without activity', parseInt, 60)
+  .option('--min-strength <n>', 'Min relationship strength', parseFloat, 0.3)
+  .option('--limit <n>', 'Max results', parseInt, 20)
+  .action(async (opts) => {
+    const { graphDormantCommand } = await import('./commands/memory.js');
+    await graphDormantCommand(opts, program.opts());
+  });
+
+graph
+  .command('reconnect')
+  .description('Reconnection suggestions')
+  .option('--limit <n>', 'Max results', parseInt, 10)
+  .action(async (opts) => {
+    const { graphReconnectCommand } = await import('./commands/memory.js');
+    await graphReconnectCommand(opts, program.opts());
+  });
+
+// Entities subcommands
+const entities = memory
+  .command('entities')
+  .description('Entity management');
+
+entities
+  .command('create')
+  .description('Create a new entity')
+  .argument('<name>', 'Entity name')
+  .option('--type <type>', 'Entity type', 'person')
+  .option('--description <desc>', 'Entity description')
+  .option('--aliases <names...>', 'Alias names')
+  .action(async (name, opts) => {
+    const { entitiesCreateCommand } = await import('./commands/memory.js');
+    await entitiesCreateCommand(name, opts, program.opts());
+  });
+
+entities
+  .command('search')
+  .description('Search entities')
+  .argument('<query>', 'Search query')
+  .option('--type <types...>', 'Filter by entity type')
+  .option('--limit <n>', 'Max results', parseInt, 10)
+  .action(async (query, opts) => {
+    const { entitiesSearchCommand } = await import('./commands/memory.js');
+    await entitiesSearchCommand(query, opts, program.opts());
+  });
+
+entities
+  .command('merge')
+  .description('Merge duplicate entities')
+  .option('--source <id>', 'Source entity ID (to merge FROM)', parseInt)
+  .option('--target <id>', 'Target entity ID (to merge INTO)', parseInt)
+  .option('--reason <text>', 'Reason for merge')
+  .action(async (opts) => {
+    const { entitiesMergeCommand } = await import('./commands/memory.js');
+    await entitiesMergeCommand(opts, program.opts());
+  });
+
+entities
+  .command('delete')
+  .description('Soft-delete an entity')
+  .argument('<id>', 'Entity ID', parseInt)
+  .option('--reason <text>', 'Reason for deletion')
+  .action(async (id, opts) => {
+    const { entitiesDeleteCommand } = await import('./commands/memory.js');
+    await entitiesDeleteCommand(id, opts, program.opts());
+  });
+
+entities
+  .command('overview')
+  .description('Entity overview with network')
+  .argument('<names...>', 'Entity names')
+  .action(async (names, opts) => {
+    const { entitiesOverviewCommand } = await import('./commands/memory.js');
+    await entitiesOverviewCommand(names, opts, program.opts());
+  });
+
+// Modify subcommands
+const modify = memory
+  .command('modify')
+  .description('Correct or invalidate memories');
+
+modify
+  .command('correct')
+  .description('Correct a memory')
+  .argument('<id>', 'Memory ID', parseInt)
+  .argument('<correction>', 'Corrected content')
+  .option('--reason <text>', 'Reason for correction')
+  .action(async (id, correction, opts) => {
+    const { modifyCorrectCommand } = await import('./commands/memory.js');
+    await modifyCorrectCommand(id, correction, opts, program.opts());
+  });
+
+modify
+  .command('invalidate')
+  .description('Mark a memory as no longer true')
+  .argument('<id>', 'Memory ID', parseInt)
+  .option('--reason <text>', 'Reason for invalidation')
+  .action(async (id, opts) => {
+    const { modifyInvalidateCommand } = await import('./commands/memory.js');
+    await modifyInvalidateCommand(id, opts, program.opts());
+  });
+
+modify
+  .command('invalidate-relationship')
+  .description('Invalidate a relationship')
+  .option('--source <name>', 'Source entity name')
+  .option('--target <name>', 'Target entity name')
+  .option('--type <type>', 'Relationship type')
+  .option('--reason <text>', 'Reason for invalidation')
+  .action(async (opts) => {
+    const { modifyInvalidateRelationshipCommand } = await import('./commands/memory.js');
+    await modifyInvalidateRelationshipCommand(opts, program.opts());
+  });
+
+// Session subcommands
+const session = memory
+  .command('session')
+  .description('Session lifecycle');
+
+session
+  .command('buffer')
+  .description('Buffer a conversation turn')
+  .option('--user <content>', 'User message content')
+  .option('--assistant <content>', 'Assistant message content')
+  .option('--episode-id <id>', 'Episode ID', parseInt)
+  .option('--source <channel>', 'Source channel', 'claude_code')
+  .action(async (opts) => {
+    const { sessionBufferCommand } = await import('./commands/memory.js');
+    await sessionBufferCommand(opts, program.opts());
+  });
+
+session
+  .command('context')
+  .description('Get session context summary')
+  .option('--episode-id <id>', 'Episode ID', parseInt)
+  .action(async (opts) => {
+    const { sessionContextCommand } = await import('./commands/memory.js');
+    await sessionContextCommand(opts, program.opts());
+  });
+
+session
+  .command('unsummarized')
+  .description('List unsummarized sessions')
+  .action(async (opts) => {
+    const { sessionUnsummarizedCommand } = await import('./commands/memory.js');
+    await sessionUnsummarizedCommand(opts, program.opts());
+  });
+
+// Document subcommands
+const document = memory
+  .command('document')
+  .description('Document storage and search');
+
+document
+  .command('store')
+  .description('Store a document')
+  .argument('<file>', 'File path')
+  .option('--source-type <type>', 'Source type: gmail, transcript, upload, capture, session')
+  .option('--source-ref <ref>', 'External reference')
+  .option('--summary <text>', 'Document summary')
+  .action(async (file, opts) => {
+    const { documentStoreCommand } = await import('./commands/memory.js');
+    await documentStoreCommand(file, opts, program.opts());
+  });
+
+document
+  .command('search')
+  .description('Search documents')
+  .argument('<query>', 'Search query')
+  .option('--source-type <type>', 'Filter by source type')
+  .option('--limit <n>', 'Max results', parseInt, 10)
+  .action(async (query, opts) => {
+    const { documentSearchCommand } = await import('./commands/memory.js');
+    await documentSearchCommand(query, opts, program.opts());
+  });
+
+// Provenance subcommands
+const provenance = memory
+  .command('provenance')
+  .description('Audit trail and provenance');
+
+provenance
+  .command('trace')
+  .description('Trace memory provenance chain')
+  .argument('<id>', 'Memory ID', parseInt)
+  .action(async (id, opts) => {
+    const { provenanceTraceCommand } = await import('./commands/memory.js');
+    await provenanceTraceCommand(id, opts, program.opts());
+  });
+
+provenance
+  .command('audit')
+  .description('Entity or memory audit history')
+  .option('--entity-id <id>', 'Entity ID', parseInt)
+  .option('--memory-id <id>', 'Memory ID', parseInt)
+  .action(async (opts) => {
+    const { provenanceAuditCommand } = await import('./commands/memory.js');
+    await provenanceAuditCommand(opts, program.opts());
+  });
+
+provenance
+  .command('verify-chain')
+  .description('Verify memory hash chain integrity')
+  .action(async (opts) => {
+    const { provenanceVerifyChainCommand } = await import('./commands/memory.js');
+    await provenanceVerifyChainCommand(opts, program.opts());
+  });
+
+// Vault subcommand group (top-level, not under memory)
+const vault = program
+  .command('vault')
+  .description('Obsidian vault operations');
+
+vault
+  .command('sync')
+  .description('Export to Obsidian vault (PARA structure)')
+  .action(async (opts) => {
+    const { vaultSyncCommand } = await import('./commands/vault.js');
+    await vaultSyncCommand(opts, program.opts());
+  });
+
+vault
+  .command('status')
+  .description('Vault sync status')
+  .action(async (opts) => {
+    const { vaultStatusCommand } = await import('./commands/vault.js');
+    await vaultStatusCommand(opts, program.opts());
+  });
+
+vault
+  .command('canvas')
+  .description('Generate Obsidian .canvas files')
+  .action(async (opts) => {
+    const { vaultCanvasCommand } = await import('./commands/vault.js');
+    await vaultCanvasCommand(opts, program.opts());
+  });
+
+vault
+  .command('import')
+  .description('Import vault edits back to memory')
+  .action(async (opts) => {
+    const { vaultImportCommand } = await import('./commands/vault.js');
+    await vaultImportCommand(opts, program.opts());
+  });
+
+// Cognitive subcommand group
+const cognitive = program
+  .command('cognitive')
+  .description('Cognitive operations (LLM-powered)');
+
+cognitive
+  .command('ingest')
+  .description('Extract entities and memories from text')
+  .option('--text <text>', 'Text to ingest')
+  .option('--file <path>', 'File to ingest')
+  .option('--type <type>', 'Source type: meeting, email, document, general')
+  .option('--context <ctx>', 'Extra context for extraction')
+  .action(async (opts) => {
+    const { cognitiveIngestCommand } = await import('./commands/cognitive.js');
+    await cognitiveIngestCommand(opts, program.opts());
+  });
+
+// Setup command
+program
+  .command('setup')
+  .description('Onboarding wizard — create dirs, verify Ollama, run health check')
+  .option('--skip-ollama', 'Skip Ollama model checks')
+  .action(async (opts) => {
+    const { setupCommand } = await import('./commands/setup.js');
+    await setupCommand(opts, program.opts());
+  });
+
+// Parse and execute
+program.parseAsync(process.argv);

--- a/cli/services/audit.js
+++ b/cli/services/audit.js
@@ -1,0 +1,107 @@
+/**
+ * Audit service for Claudia CLI.
+ * Port of memory-daemon/claudia_memory/services/audit.py.
+ *
+ * Tracks all memory system operations for debugging and accountability.
+ */
+
+/**
+ * Log an operation to the audit trail.
+ * @param {object} db - ClaudiaDatabase instance
+ * @param {string} operation - Operation type (e.g., 'entity_merge', 'memory_correct')
+ * @param {object} [options]
+ * @param {object} [options.details] - JSON-serializable details
+ * @param {string} [options.sessionId] - Session identifier
+ * @param {boolean} [options.userInitiated] - Whether triggered by user
+ * @param {number} [options.entityId] - Entity ID this affects
+ * @param {number} [options.memoryId] - Memory ID this affects
+ * @returns {number} Audit log entry ID
+ */
+export function auditLog(db, operation, { details, sessionId, userInitiated, entityId, memoryId } = {}) {
+  try {
+    return db.insert('audit_log', {
+      timestamp: new Date().toISOString(),
+      operation,
+      details: details ? JSON.stringify(details) : null,
+      session_id: sessionId || null,
+      user_initiated: userInitiated ? 1 : 0,
+      entity_id: entityId || null,
+      memory_id: memoryId || null,
+    });
+  } catch {
+    // Audit logging should never crash the caller
+    return -1;
+  }
+}
+
+/**
+ * Get recent audit entries.
+ * @param {object} db
+ * @param {object} [options]
+ * @param {number} [options.limit=50]
+ * @param {string} [options.operation]
+ * @param {number} [options.entityId]
+ * @param {number} [options.memoryId]
+ * @returns {object[]}
+ */
+export function getAuditRecent(db, { limit = 50, operation, entityId, memoryId } = {}) {
+  let sql = 'SELECT * FROM audit_log WHERE 1=1';
+  const params = [];
+
+  if (operation) {
+    sql += ' AND operation = ?';
+    params.push(operation);
+  }
+  if (entityId) {
+    sql += ' AND entity_id = ?';
+    params.push(entityId);
+  }
+  if (memoryId) {
+    sql += ' AND memory_id = ?';
+    params.push(memoryId);
+  }
+
+  sql += ' ORDER BY timestamp DESC LIMIT ?';
+  params.push(limit);
+
+  return (db.query(sql, params) || []).map(formatAuditEntry);
+}
+
+/**
+ * Get all audit entries affecting an entity.
+ * @param {object} db
+ * @param {number} entityId
+ * @returns {object[]}
+ */
+export function getEntityAuditHistory(db, entityId) {
+  return (db.query(
+    'SELECT * FROM audit_log WHERE entity_id = ? ORDER BY timestamp ASC',
+    [entityId],
+  ) || []).map(formatAuditEntry);
+}
+
+/**
+ * Get all audit entries affecting a memory.
+ * @param {object} db
+ * @param {number} memoryId
+ * @returns {object[]}
+ */
+export function getMemoryAuditHistory(db, memoryId) {
+  return (db.query(
+    'SELECT * FROM audit_log WHERE memory_id = ? ORDER BY timestamp ASC',
+    [memoryId],
+  ) || []).map(formatAuditEntry);
+}
+
+function formatAuditEntry(row) {
+  return {
+    id: row.id,
+    timestamp: row.timestamp,
+    operation: row.operation,
+    details: row.details ? JSON.parse(row.details) : null,
+    session_id: row.session_id,
+    user_initiated: Boolean(row.user_initiated),
+    entity_id: row.entity_id,
+    memory_id: row.memory_id,
+  };
+}

--- a/cli/services/consolidate.js
+++ b/cli/services/consolidate.js
@@ -1,0 +1,2416 @@
+/**
+ * Consolidation Service for Claudia CLI (Node.js port).
+ * Port of memory-daemon/claudia_memory/services/consolidate.py.
+ *
+ * Handles memory decay, pattern detection, near-duplicate merging,
+ * lifecycle transitions, entity summaries, and retention cleanup.
+ * Runs on a schedule (typically overnight) to maintain memory health.
+ *
+ * All functions are synchronous (better-sqlite3 is sync, no Ollama calls).
+ */
+
+// ---------------------------------------------------------------------------
+// Cosine similarity (pure JS, no external dependencies)
+// ---------------------------------------------------------------------------
+
+function cosineSimilarity(a, b) {
+  if (a.length !== b.length || a.length === 0) return 0;
+  let dot = 0, normA = 0, normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  normA = Math.sqrt(normA);
+  normB = Math.sqrt(normB);
+  if (normA === 0 || normB === 0) return 0;
+  return dot / (normA * normB);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function nowISO() {
+  return new Date().toISOString().replace('T', ' ').slice(0, 19);
+}
+
+function nowISOFull() {
+  return new Date().toISOString();
+}
+
+function daysAgo(days) {
+  const d = new Date();
+  d.setDate(d.getDate() - days);
+  return d.toISOString();
+}
+
+function daysAhead(days) {
+  const d = new Date();
+  d.setDate(d.getDate() + days);
+  return d.toISOString().replace('T', ' ').slice(0, 19);
+}
+
+function hoursAgo(hours) {
+  const d = new Date();
+  d.setTime(d.getTime() - hours * 3600 * 1000);
+  return d.toISOString();
+}
+
+function daysBetween(isoA, isoB) {
+  const a = new Date(isoA);
+  const b = new Date(isoB);
+  return (b.getTime() - a.getTime()) / (86400 * 1000);
+}
+
+function safeJsonParse(str, fallback) {
+  if (!str) return fallback;
+  try {
+    return JSON.parse(str);
+  } catch {
+    return fallback;
+  }
+}
+
+function log(msg) {
+  process.stderr.write(`[consolidate] ${msg}\n`);
+}
+
+// ---------------------------------------------------------------------------
+// Phase 0 support: Deadline surge
+// ---------------------------------------------------------------------------
+
+/**
+ * Boost importance of memories with approaching deadlines.
+ * Runs BEFORE decay so that deadline-driven items resist decay.
+ * Tiered surge:
+ *  - Overdue: surge to 1.0
+ *  - Due within 48 hours: surge to 0.95
+ *  - Due within 7 days: surge to 0.85
+ *
+ * @param {object} db - ClaudiaDatabase instance
+ * @returns {{ overdue_surged: number, near_surged: number, week_surged: number }}
+ */
+function surgeApproachingDeadlines(db) {
+  const now = nowISO();
+  const twoDays = daysAhead(2);
+  const oneWeek = daysAhead(7);
+
+  // Overdue: surge to 1.0
+  const overdueResult = db.run(
+    `UPDATE memories SET importance = 1.0, updated_at = datetime('now')
+     WHERE deadline_at IS NOT NULL
+       AND deadline_at < ?
+       AND invalidated_at IS NULL
+       AND importance < 1.0`,
+    [now],
+  );
+  const overdue = overdueResult.changes;
+
+  // Due within 48 hours: surge to 0.95
+  const nearResult = db.run(
+    `UPDATE memories SET importance = MAX(importance, 0.95), updated_at = datetime('now')
+     WHERE deadline_at IS NOT NULL
+       AND deadline_at BETWEEN ? AND ?
+       AND invalidated_at IS NULL`,
+    [now, twoDays],
+  );
+  const near = nearResult.changes;
+
+  // Due within 7 days: surge to 0.85
+  const weekResult = db.run(
+    `UPDATE memories SET importance = MAX(importance, 0.85), updated_at = datetime('now')
+     WHERE deadline_at IS NOT NULL
+       AND deadline_at BETWEEN ? AND ?
+       AND invalidated_at IS NULL`,
+    [twoDays, oneWeek],
+  );
+  const week = weekResult.changes;
+
+  const total = overdue + near + week;
+  if (total > 0) {
+    log(`Deadline surge: ${overdue} overdue, ${near} within 48h, ${week} within 7d`);
+  }
+
+  return { overdue_surged: overdue, near_surged: near, week_surged: week };
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1: Decay
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply tiered importance decay to memories, entities, relationships, and reflections.
+ *
+ * Tier 1 (high-value): importance > 0.7 -> decay at half standard rate
+ * Tier 2 (standard): everything else -> decay at config rate (0.995)
+ *
+ * All decays have a floor at min_importance_threshold to prevent memories
+ * from becoming permanently invisible.
+ *
+ * Sacred memories (lifecycle_tier='sacred') and close-circle entities are exempt.
+ *
+ * @param {object} db - ClaudiaDatabase instance
+ * @param {object} config - Configuration object
+ * @returns {object} Counts of decayed items
+ */
+export function runDecay(db, config) {
+  // Surge approaching deadlines BEFORE decay (so they resist decay)
+  let surgeResults = {};
+  try {
+    surgeResults = surgeApproachingDeadlines(db);
+  } catch (e) {
+    // Column may not exist on older schemas
+    surgeResults = {};
+  }
+
+  const decayRate = config.decay_rate_daily;
+  const slowDecayRate = (1.0 + decayRate) / 2; // Midpoint between 1.0 and standard rate
+  const floor = config.min_importance_threshold;
+  const ts = nowISOFull();
+
+  // Tier 1: High-value memories decay slower
+  const tier1 = db.run(
+    `UPDATE memories
+     SET importance = MAX(?, importance * ?),
+         updated_at = ?
+     WHERE importance > 0.7
+       AND importance > ?
+       AND (lifecycle_tier IS NULL OR lifecycle_tier != 'sacred')`,
+    [floor, slowDecayRate, ts, floor],
+  );
+  const tier1Count = tier1.changes;
+
+  // Tier 2: Standard memories decay normally
+  const tier2 = db.run(
+    `UPDATE memories
+     SET importance = MAX(?, importance * ?),
+         updated_at = ?
+     WHERE importance <= 0.7
+       AND importance > ?
+       AND (lifecycle_tier IS NULL OR lifecycle_tier != 'sacred')`,
+    [floor, decayRate, ts, floor],
+  );
+  const tier2Count = tier2.changes;
+
+  const memoriesDecayed = tier1Count + tier2Count;
+
+  // Entities: same tiered approach (close-circle entities are protected from decay)
+  db.run(
+    `UPDATE entities
+     SET importance = MAX(?, importance * ?),
+         updated_at = ?
+     WHERE importance > 0.7
+       AND importance > ?
+       AND (close_circle IS NULL OR close_circle = 0)`,
+    [floor, slowDecayRate, ts, floor],
+  );
+  db.run(
+    `UPDATE entities
+     SET importance = MAX(?, importance * ?),
+         updated_at = ?
+     WHERE importance <= 0.7
+       AND importance > ?
+       AND (close_circle IS NULL OR close_circle = 0)`,
+    [floor, decayRate, ts, floor],
+  );
+
+  // Relationships: tiered by strength
+  db.run(
+    `UPDATE relationships
+     SET strength = MAX(0.01, strength * ?),
+         updated_at = ?
+     WHERE strength > 0.7
+       AND strength > 0.01
+       AND (lifecycle_tier IS NULL OR lifecycle_tier != 'sacred')`,
+    [slowDecayRate, ts],
+  );
+  db.run(
+    `UPDATE relationships
+     SET strength = MAX(0.01, strength * ?),
+         updated_at = ?
+     WHERE strength <= 0.7
+       AND strength > 0.01
+       AND (lifecycle_tier IS NULL OR lifecycle_tier != 'sacred')`,
+    [decayRate, ts],
+  );
+
+  // Reflections: keep using per-row decay_rate (unchanged)
+  let reflectionsDecayed = 0;
+  try {
+    const refResult = db.run(
+      `UPDATE reflections
+       SET importance = MAX(0.01, importance * decay_rate),
+           updated_at = ?
+       WHERE importance > 0.01`,
+      [ts],
+    );
+    reflectionsDecayed = refResult.changes;
+  } catch {
+    // Reflection table may not exist
+  }
+
+  log(`Decay applied: standard_rate=${decayRate}, slow_rate=${slowDecayRate.toFixed(4)}, floor=${floor}`);
+
+  return {
+    memories_decayed: memoriesDecayed,
+    reflections_decayed: reflectionsDecayed,
+    ...surgeResults,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1: Boost
+// ---------------------------------------------------------------------------
+
+/**
+ * Boost importance of recently accessed memories (rehearsal effect).
+ * Memories accessed in the last 24 hours get a 5% importance boost.
+ *
+ * @param {object} db - ClaudiaDatabase instance
+ * @returns {number} Count of boosted memories
+ */
+export function boostAccessedMemories(db) {
+  const cutoff = hoursAgo(24);
+  const boostFactor = 1.05;
+
+  const result = db.run(
+    `UPDATE memories
+     SET importance = MIN(1.0, importance * ?),
+         updated_at = ?
+     WHERE last_accessed_at >= ?`,
+    [boostFactor, nowISOFull(), cutoff],
+  );
+
+  const count = result.changes;
+  if (count > 0) {
+    log(`Boosted ${count} recently accessed memories`);
+  }
+  return count;
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1b: Lifecycle transitions
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply lifecycle tier transitions based on access patterns.
+ *
+ * Cooling: memory not accessed for cooling_threshold_days AND not sacred
+ * Archive: in cooling for archive_threshold_days AND importance < 0.3
+ *
+ * @param {object} db
+ * @param {object} config
+ * @returns {{ cooled: number, archived: number }}
+ */
+export function runLifecycleTransitions(db, config) {
+  const coolingCutoff = daysAgo(config.cooling_threshold_days);
+  const archiveCutoff = daysAgo(config.archive_threshold_days);
+
+  // Active -> Cooling: not accessed recently, not sacred
+  let cooled = 0;
+  try {
+    const result = db.run(
+      `UPDATE memories
+       SET lifecycle_tier = 'cooling', updated_at = datetime('now')
+       WHERE (lifecycle_tier = 'active' OR lifecycle_tier IS NULL)
+         AND invalidated_at IS NULL
+         AND (lifecycle_tier IS NULL OR lifecycle_tier != 'sacred')
+         AND (last_accessed_at IS NULL OR last_accessed_at < ?)
+         AND created_at < ?`,
+      [coolingCutoff, coolingCutoff],
+    );
+    cooled = result.changes;
+  } catch (e) {
+    // lifecycle_tier column may not exist on older schemas
+  }
+
+  // Cooling -> Archived: been cooling long enough AND low importance
+  let archived = 0;
+  try {
+    const result = db.run(
+      `UPDATE memories
+       SET lifecycle_tier = 'archived',
+           archived_at = datetime('now'),
+           updated_at = datetime('now')
+       WHERE lifecycle_tier = 'cooling'
+         AND invalidated_at IS NULL
+         AND importance < 0.3
+         AND (last_accessed_at IS NULL OR last_accessed_at < ?)
+         AND created_at < ?`,
+      [archiveCutoff, archiveCutoff],
+    );
+    archived = result.changes;
+  } catch (e) {
+    // lifecycle_tier column may not exist
+  }
+
+  if (cooled > 0 || archived > 0) {
+    log(`Lifecycle transitions: ${cooled} cooled, ${archived} archived`);
+  }
+
+  return { cooled, archived };
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1b: Auto-sacred detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Auto-promote memories about close-circle entities that match sacred keywords.
+ *
+ * @param {object} db
+ * @param {object} config
+ * @returns {number} Count of promoted memories
+ */
+export function detectAutoSacred(db, config) {
+  if (!config.enable_auto_sacred) {
+    return 0;
+  }
+
+  let promoted = 0;
+  try {
+    const closeEntities = db.query(
+      "SELECT id FROM entities WHERE close_circle = 1 AND deleted_at IS NULL",
+    );
+
+    for (const entity of closeEntities) {
+      const entityId = entity.id;
+      for (const keyword of config.sacred_core_keywords) {
+        const rows = db.query(
+          `SELECT m.id FROM memories m
+           JOIN memory_entities me ON m.id = me.memory_id
+           WHERE me.entity_id = ?
+             AND m.invalidated_at IS NULL
+             AND (m.lifecycle_tier IS NULL OR m.lifecycle_tier != 'sacred')
+             AND LOWER(m.content) LIKE '%' || LOWER(?) || '%'`,
+          [entityId, keyword],
+        );
+        for (const row of rows) {
+          db.run(
+            `UPDATE memories SET lifecycle_tier = 'sacred',
+                sacred_reason = ?,
+                updated_at = datetime('now')
+                WHERE id = ? AND (lifecycle_tier IS NULL OR lifecycle_tier != 'sacred')`,
+            [`auto: close-circle keyword '${keyword}'`, row.id],
+          );
+          promoted++;
+        }
+      }
+    }
+  } catch (e) {
+    // close_circle or lifecycle_tier column may not exist
+  }
+
+  if (promoted > 0) {
+    log(`Auto-sacred: promoted ${promoted} memories`);
+  }
+  return promoted;
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1b: Close-circle candidate detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect entities that should be close-circle based on contact velocity.
+ *
+ * @param {object} db
+ * @param {object} config
+ * @returns {Array<{ entity_id: number, name: string, reason: string }>}
+ */
+export function detectCloseCircleCandidates(db, config) {
+  const candidates = [];
+
+  try {
+    // High contact velocity detection
+    const rows = db.query(
+      `SELECT id, name, contact_frequency_days, contact_trend, description
+       FROM entities
+       WHERE type = 'person'
+         AND deleted_at IS NULL
+         AND (close_circle IS NULL OR close_circle = 0)
+         AND contact_frequency_days IS NOT NULL
+         AND contact_frequency_days < 7
+         AND contact_trend IN ('accelerating', 'stable')`,
+    );
+
+    for (const row of rows) {
+      candidates.push({
+        entity_id: row.id,
+        name: row.name,
+        reason: `high contact velocity (${row.contact_frequency_days.toFixed(1)}d, ${row.contact_trend})`,
+      });
+    }
+
+    // Keyword-based detection in entity descriptions
+    for (const keyword of config.close_circle_keywords) {
+      const descRows = db.query(
+        `SELECT id, name FROM entities
+         WHERE type = 'person'
+           AND deleted_at IS NULL
+           AND (close_circle IS NULL OR close_circle = 0)
+           AND LOWER(description) LIKE '%' || LOWER(?) || '%'`,
+        [keyword],
+      );
+      for (const row of descRows) {
+        if (!candidates.some(c => c.entity_id === row.id)) {
+          candidates.push({
+            entity_id: row.id,
+            name: row.name,
+            reason: `keyword match: '${keyword}' in description`,
+          });
+        }
+      }
+    }
+  } catch (e) {
+    // close_circle or contact_frequency_days columns may not exist
+  }
+
+  return candidates;
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2: Memory merging
+// ---------------------------------------------------------------------------
+
+/**
+ * Merge a duplicate memory into the primary.
+ * - Transfers entity links from duplicate to primary
+ * - Adds merged_from to primary's metadata
+ * - Sets duplicate importance to 0.001
+ */
+function mergeMemoryPair(db, primaryId, duplicateId) {
+  // Transfer entity links
+  const dupLinks = db.query(
+    "SELECT entity_id, relationship FROM memory_entities WHERE memory_id = ?",
+    [duplicateId],
+  );
+
+  for (const link of dupLinks) {
+    try {
+      db.insert("memory_entities", {
+        memory_id: primaryId,
+        entity_id: link.entity_id,
+        relationship: link.relationship,
+      });
+    } catch {
+      // Duplicate link, ignore
+    }
+  }
+
+  // Update primary's metadata with merge info
+  const primary = db.queryOne("SELECT metadata FROM memories WHERE id = ?", [primaryId]);
+  if (primary) {
+    const meta = safeJsonParse(primary.metadata, {});
+    const mergedFrom = meta.merged_from || [];
+    mergedFrom.push(duplicateId);
+    meta.merged_from = mergedFrom;
+    db.update(
+      "memories",
+      { metadata: JSON.stringify(meta), updated_at: nowISOFull() },
+      "id = ?",
+      [primaryId],
+    );
+  }
+
+  // Suppress duplicate (don't delete, just minimize importance)
+  db.update(
+    "memories",
+    { importance: 0.001, updated_at: nowISOFull() },
+    "id = ?",
+    [duplicateId],
+  );
+}
+
+/**
+ * Merge semantically similar memories during consolidation.
+ * Uses existing stored embeddings (no new Ollama calls).
+ *
+ * Finds entities with 5+ linked memories, loads stored embeddings,
+ * computes pairwise cosine similarity, and merges pairs above threshold (0.92).
+ * Keeps the higher-scoring memory (importance * (1 + access_count)).
+ *
+ * @param {object} db
+ * @param {object} config
+ * @returns {number} Count of merged memory pairs
+ */
+export function mergeSimilarMemories(db, config) {
+  if (!config.enable_memory_merging) {
+    return 0;
+  }
+
+  const threshold = config.similarity_merge_threshold;
+  let mergedCount = 0;
+
+  try {
+    // Find entities with 5+ linked memories (high-memory entities first)
+    const entityRows = db.query(
+      `SELECT me.entity_id, COUNT(DISTINCT me.memory_id) as mem_count
+       FROM memory_entities me
+       GROUP BY me.entity_id
+       HAVING mem_count >= 5
+       ORDER BY mem_count DESC
+       LIMIT 50`,
+    );
+
+    for (const entityRow of entityRows) {
+      const entityId = entityRow.entity_id;
+
+      // Load memory IDs and embeddings for this entity
+      const memRows = db.query(
+        `SELECT me.memory_id, m.importance, m.access_count,
+                emb.embedding
+         FROM memory_entities me
+         JOIN memories m ON me.memory_id = m.id
+         LEFT JOIN memory_embeddings emb ON m.id = emb.memory_id
+         WHERE me.entity_id = ?
+           AND m.importance > 0.01
+         ORDER BY m.importance DESC`,
+        [entityId],
+      );
+
+      // Parse embeddings
+      const memoriesWithEmb = [];
+      for (const row of memRows) {
+        if (row.embedding) {
+          try {
+            const emb = typeof row.embedding === 'string'
+              ? JSON.parse(row.embedding)
+              : row.embedding;
+            memoriesWithEmb.push({
+              id: row.memory_id,
+              importance: row.importance,
+              accessCount: row.access_count || 0,
+              embedding: emb,
+            });
+          } catch {
+            continue;
+          }
+        }
+      }
+
+      if (memoriesWithEmb.length < 2) {
+        continue;
+      }
+
+      // Pairwise cosine similarity
+      const alreadyMerged = new Set();
+      for (let i = 0; i < memoriesWithEmb.length; i++) {
+        if (alreadyMerged.has(memoriesWithEmb[i].id)) continue;
+        for (let j = i + 1; j < memoriesWithEmb.length; j++) {
+          if (alreadyMerged.has(memoriesWithEmb[j].id)) continue;
+
+          const sim = cosineSimilarity(
+            memoriesWithEmb[i].embedding,
+            memoriesWithEmb[j].embedding,
+          );
+          if (sim >= threshold) {
+            // Keep the one with higher importance * (1 + access_count)
+            const scoreI = memoriesWithEmb[i].importance * (1 + memoriesWithEmb[i].accessCount);
+            const scoreJ = memoriesWithEmb[j].importance * (1 + memoriesWithEmb[j].accessCount);
+
+            let primaryId, duplicateId;
+            if (scoreI >= scoreJ) {
+              primaryId = memoriesWithEmb[i].id;
+              duplicateId = memoriesWithEmb[j].id;
+            } else {
+              primaryId = memoriesWithEmb[j].id;
+              duplicateId = memoriesWithEmb[i].id;
+            }
+
+            mergeMemoryPair(db, primaryId, duplicateId);
+            alreadyMerged.add(duplicateId);
+            mergedCount++;
+          }
+        }
+      }
+    }
+  } catch (e) {
+    log(`Memory merging failed: ${e.message || e}`);
+  }
+
+  if (mergedCount > 0) {
+    log(`Merged ${mergedCount} near-duplicate memory pairs`);
+  }
+  return mergedCount;
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2: Reflection aggregation
+// ---------------------------------------------------------------------------
+
+/**
+ * Merge a duplicate reflection into the primary.
+ * Preserves timeline: earliest first_observed_at, latest last_confirmed_at.
+ * Combines aggregation counts. Adjusts decay rate for well-confirmed reflections.
+ */
+function mergeReflectionPair(db, primary, duplicate) {
+  const newAggregationCount = primary.aggregation_count + duplicate.aggregation_count;
+  const newFirstObserved = primary.first_observed_at < duplicate.first_observed_at
+    ? primary.first_observed_at
+    : duplicate.first_observed_at;
+  const newLastConfirmed = primary.last_confirmed_at > duplicate.last_confirmed_at
+    ? primary.last_confirmed_at
+    : duplicate.last_confirmed_at;
+
+  // Slow decay for well-confirmed reflections
+  const newDecayRate = newAggregationCount >= 3 ? 0.9995 : 0.999;
+
+  // Boost importance slightly for confirmed patterns
+  const newImportance = Math.min(1.0, primary.importance + 0.05);
+
+  // Track which reflections were merged
+  const existing = db.queryOne("SELECT aggregated_from FROM reflections WHERE id = ?", [primary.id]);
+  const aggregatedFrom = safeJsonParse(existing ? existing.aggregated_from : null, []);
+  aggregatedFrom.push(duplicate.id);
+
+  // Update primary
+  db.update(
+    "reflections",
+    {
+      aggregation_count: newAggregationCount,
+      first_observed_at: newFirstObserved,
+      last_confirmed_at: newLastConfirmed,
+      decay_rate: newDecayRate,
+      importance: newImportance,
+      aggregated_from: JSON.stringify(aggregatedFrom),
+      updated_at: nowISOFull(),
+    },
+    "id = ?",
+    [primary.id],
+  );
+
+  // Suppress duplicate (don't delete, minimize importance)
+  db.update(
+    "reflections",
+    { importance: 0.001, updated_at: nowISOFull() },
+    "id = ?",
+    [duplicate.id],
+  );
+}
+
+/**
+ * Aggregate semantically similar reflections during consolidation.
+ *
+ * Finds reflection pairs with high cosine similarity (>0.85) of the
+ * same type and merges them while preserving timeline information.
+ *
+ * @param {object} db
+ * @returns {number} Count of reflection pairs merged
+ */
+export function aggregateReflections(db) {
+  const threshold = 0.85;
+  let mergedCount = 0;
+
+  try {
+    // Find reflections with embeddings
+    const rows = db.query(
+      `SELECT r.id, r.content, r.reflection_type, r.importance,
+              r.aggregation_count, r.first_observed_at, r.last_confirmed_at,
+              re.embedding
+       FROM reflections r
+       JOIN reflection_embeddings re ON r.id = re.reflection_id
+       WHERE r.importance > 0.1
+       ORDER BY r.importance DESC`,
+    );
+
+    if (rows.length < 2) {
+      return 0;
+    }
+
+    // Parse embeddings
+    const reflectionsWithEmb = [];
+    for (const row of rows) {
+      if (row.embedding) {
+        try {
+          const emb = typeof row.embedding === 'string'
+            ? JSON.parse(row.embedding)
+            : row.embedding;
+          reflectionsWithEmb.push({
+            id: row.id,
+            content: row.content,
+            type: row.reflection_type,
+            importance: row.importance,
+            aggregation_count: row.aggregation_count,
+            first_observed_at: row.first_observed_at,
+            last_confirmed_at: row.last_confirmed_at,
+            embedding: emb,
+          });
+        } catch {
+          continue;
+        }
+      }
+    }
+
+    // Pairwise similarity, same type only
+    const alreadyMerged = new Set();
+    for (let i = 0; i < reflectionsWithEmb.length; i++) {
+      if (alreadyMerged.has(reflectionsWithEmb[i].id)) continue;
+      for (let j = i + 1; j < reflectionsWithEmb.length; j++) {
+        if (alreadyMerged.has(reflectionsWithEmb[j].id)) continue;
+
+        // Only merge same type
+        if (reflectionsWithEmb[i].type !== reflectionsWithEmb[j].type) continue;
+
+        const sim = cosineSimilarity(
+          reflectionsWithEmb[i].embedding,
+          reflectionsWithEmb[j].embedding,
+        );
+        if (sim >= threshold) {
+          // Keep the one with higher aggregation_count * importance
+          const scoreI = reflectionsWithEmb[i].aggregation_count * reflectionsWithEmb[i].importance;
+          const scoreJ = reflectionsWithEmb[j].aggregation_count * reflectionsWithEmb[j].importance;
+
+          let primary, duplicate;
+          if (scoreI >= scoreJ) {
+            primary = reflectionsWithEmb[i];
+            duplicate = reflectionsWithEmb[j];
+          } else {
+            primary = reflectionsWithEmb[j];
+            duplicate = reflectionsWithEmb[i];
+          }
+
+          mergeReflectionPair(db, primary, duplicate);
+          alreadyMerged.add(duplicate.id);
+          mergedCount++;
+        }
+      }
+    }
+  } catch (e) {
+    // Reflection table may not exist
+  }
+
+  if (mergedCount > 0) {
+    log(`Aggregated ${mergedCount} similar reflection pairs`);
+  }
+  return mergedCount;
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3: Pattern detection - sub-detectors
+// ---------------------------------------------------------------------------
+
+/**
+ * Store or update a detected pattern in the database.
+ * @param {object} db
+ * @param {{ name: string, description: string, pattern_type: string, confidence: number, evidence: string[] }} pattern
+ * @returns {number} Pattern row ID
+ */
+function storePattern(db, pattern) {
+  const existing = db.queryOne(
+    "SELECT id, occurrences, confidence FROM patterns WHERE name = ?",
+    [pattern.name],
+  );
+
+  if (existing) {
+    const newOccurrences = existing.occurrences + 1;
+    const newConfidence = Math.min(1.0, (existing.confidence + pattern.confidence) / 2);
+
+    db.update(
+      "patterns",
+      {
+        occurrences: newOccurrences,
+        confidence: newConfidence,
+        last_observed_at: nowISOFull(),
+        evidence: JSON.stringify(pattern.evidence),
+      },
+      "id = ?",
+      [existing.id],
+    );
+    return existing.id;
+  } else {
+    return db.insert("patterns", {
+      name: pattern.name,
+      description: pattern.description,
+      pattern_type: pattern.pattern_type,
+      occurrences: 1,
+      confidence: pattern.confidence,
+      first_observed_at: nowISOFull(),
+      last_observed_at: nowISOFull(),
+      evidence: JSON.stringify(pattern.evidence),
+      is_active: 1,
+    });
+  }
+}
+
+/**
+ * Detect relationships that haven't been mentioned recently.
+ * @param {object} db
+ * @returns {Array} Detected patterns
+ */
+function detectCoolingRelationships(db) {
+  const patterns = [];
+  const cutoff30 = daysAgo(30);
+
+  const rows = db.query(
+    `SELECT e.id, e.name, e.type, e.importance,
+            MAX(m.created_at) as last_mention
+     FROM entities e
+     LEFT JOIN memory_entities me ON e.id = me.entity_id
+     LEFT JOIN memories m ON me.memory_id = m.id
+     WHERE e.type = 'person'
+       AND e.importance > 0.3
+     GROUP BY e.id
+     HAVING last_mention < ? OR last_mention IS NULL
+     ORDER BY e.importance DESC
+     LIMIT 20`,
+    [cutoff30],
+  );
+
+  for (const row of rows) {
+    let daysSince = null;
+    if (row.last_mention) {
+      daysSince = Math.floor(daysBetween(row.last_mention, new Date().toISOString()));
+    }
+
+    patterns.push({
+      name: `cooling_relationship_${row.id}`,
+      description: `No contact with ${row.name} in ${daysSince || 'many'} days`,
+      pattern_type: "relationship",
+      confidence: Math.min(0.9, 0.5 + (daysSince || 30) / 100),
+      evidence: [`Last mention: ${row.last_mention || 'never'}`],
+    });
+  }
+
+  return patterns;
+}
+
+/**
+ * Detect patterns in commitments (overdue, frequently delayed, etc.)
+ * @param {object} db
+ * @returns {Array} Detected patterns
+ */
+function detectCommitmentPatterns(db) {
+  const patterns = [];
+  const cutoff = daysAgo(7);
+
+  const overdue = db.queryOne(
+    `SELECT COUNT(*) as count FROM memories
+     WHERE type = 'commitment'
+       AND importance > 0.5
+       AND created_at < ?`,
+    [cutoff],
+  );
+
+  if (overdue && overdue.count > 3) {
+    patterns.push({
+      name: "overdue_commitments",
+      description: `${overdue.count} commitments older than 7 days may be overdue`,
+      pattern_type: "behavioral",
+      confidence: 0.7,
+      evidence: ["Multiple old commitments detected"],
+    });
+  }
+
+  return patterns;
+}
+
+/**
+ * Detect communication style patterns.
+ * @param {object} db
+ * @returns {Array} Detected patterns
+ */
+function detectCommunicationPatterns(db) {
+  const patterns = [];
+
+  try {
+    const recentMessages = db.query(
+      `SELECT role, LENGTH(content) as msg_length
+       FROM messages
+       WHERE created_at >= ?
+       ORDER BY created_at DESC
+       LIMIT 100`,
+      [daysAgo(7)],
+    );
+
+    if (recentMessages.length >= 20) {
+      const userMsgs = recentMessages.filter(m => m.role === 'user');
+      if (userMsgs.length > 0) {
+        const avgLength = userMsgs.reduce((sum, m) => sum + m.msg_length, 0) / userMsgs.length;
+
+        if (avgLength < 50) {
+          patterns.push({
+            name: "brief_communication_style",
+            description: "User tends to communicate in brief messages",
+            pattern_type: "communication",
+            confidence: 0.6,
+            evidence: [`Average message length: ${Math.round(avgLength)} characters`],
+          });
+        } else if (avgLength > 200) {
+          patterns.push({
+            name: "detailed_communication_style",
+            description: "User tends to provide detailed context",
+            pattern_type: "communication",
+            confidence: 0.6,
+            evidence: [`Average message length: ${Math.round(avgLength)} characters`],
+          });
+        }
+      }
+    }
+  } catch {
+    // messages table may not exist
+  }
+
+  return patterns;
+}
+
+/**
+ * Detect person entities that co-occur in memories but have no explicit relationship.
+ * @param {object} db
+ * @returns {Array} Detected patterns
+ */
+function detectCrossEntityPatterns(db) {
+  const patterns = [];
+
+  try {
+    // Find pairs of person entities that appear together in 2+ memories
+    const coMentions = db.query(
+      `SELECT
+          e1.id as id1, e1.name as name1,
+          e2.id as id2, e2.name as name2,
+          COUNT(DISTINCT me1.memory_id) as co_count
+       FROM memory_entities me1
+       JOIN memory_entities me2 ON me1.memory_id = me2.memory_id AND me1.entity_id < me2.entity_id
+       JOIN entities e1 ON me1.entity_id = e1.id AND e1.type = 'person'
+       JOIN entities e2 ON me2.entity_id = e2.id AND e2.type = 'person'
+       GROUP BY me1.entity_id, me2.entity_id
+       HAVING co_count >= 2
+       ORDER BY co_count DESC
+       LIMIT 20`,
+    );
+
+    for (const row of coMentions) {
+      // Check if a relationship already exists between them
+      const existing = db.queryOne(
+        `SELECT id FROM relationships
+         WHERE (source_entity_id = ? AND target_entity_id = ?)
+            OR (source_entity_id = ? AND target_entity_id = ?)`,
+        [row.id1, row.id2, row.id2, row.id1],
+      );
+      if (existing) continue;
+
+      const coCount = row.co_count;
+      const confidence = Math.min(0.9, 0.4 + coCount * 0.1);
+
+      patterns.push({
+        name: `cross_entity_${row.id1}_${row.id2}`,
+        description: `${row.name1} and ${row.name2} appear together in ${coCount} memories. Are they connected?`,
+        pattern_type: "relationship",
+        confidence,
+        evidence: [`Co-mentioned in ${coCount} memories`],
+      });
+    }
+  } catch {
+    // database structure issue
+  }
+
+  return patterns;
+}
+
+/**
+ * Infer a likely connection between two entities based on shared attributes.
+ * @param {object} db
+ * @param {number} entityAId
+ * @param {number} entityBId
+ * @returns {[string, number]|null} [relationship_type, confidence] or null
+ */
+function inferConnections(db, entityAId, entityBId) {
+  try {
+    const entityA = db.queryOne("SELECT * FROM entities WHERE id = ?", [entityAId]);
+    const entityB = db.queryOne("SELECT * FROM entities WHERE id = ?", [entityBId]);
+
+    if (!entityA || !entityB) return null;
+
+    const aMeta = safeJsonParse(entityA.metadata, {});
+    const bMeta = safeJsonParse(entityB.metadata, {});
+
+    // Same company = definitely connected (colleagues)
+    const aCompany = aMeta.company;
+    const bCompany = bMeta.company;
+    if (aCompany && bCompany && aCompany.toLowerCase() === bCompany.toLowerCase()) {
+      return ["colleagues", 0.9];
+    }
+
+    // Same community = probably know each other
+    const aCommunities = new Set((aMeta.communities || []).map(c => c.toLowerCase()));
+    const bCommunities = new Set((bMeta.communities || []).map(c => c.toLowerCase()));
+    const sharedCommunities = [...aCommunities].filter(c => bCommunities.has(c));
+    if (sharedCommunities.length > 0) {
+      return ["community_connection", 0.6];
+    }
+
+    // Same city + same industry = might know each other
+    const aGeo = aMeta.geography || {};
+    const bGeo = bMeta.geography || {};
+    const aCity = (aGeo.city || "").toLowerCase();
+    const bCity = (bGeo.city || "").toLowerCase();
+
+    const aIndustries = new Set((aMeta.industries || []).map(i => i.toLowerCase()));
+    const bIndustries = new Set((bMeta.industries || []).map(i => i.toLowerCase()));
+    const sharedIndustries = [...aIndustries].filter(i => bIndustries.has(i));
+
+    if (aCity && aCity === bCity && sharedIndustries.length > 0) {
+      return ["likely_connected", 0.3];
+    }
+
+    // Same industry alone = weak inference
+    if (sharedIndustries.length >= 1) {
+      return ["industry_peers", 0.2];
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Detect potential connections between entities based on shared attributes.
+ * @param {object} db
+ * @returns {Array} Detected patterns
+ */
+function detectInferredConnections(db) {
+  const patterns = [];
+
+  try {
+    const entities = db.query(
+      `SELECT id, name, metadata FROM entities
+       WHERE type = 'person' AND importance > 0.2 AND metadata IS NOT NULL
+       ORDER BY importance DESC
+       LIMIT 100`,
+    );
+
+    for (let i = 0; i < entities.length; i++) {
+      for (let j = i + 1; j < entities.length; j++) {
+        const entityA = entities[i];
+        const entityB = entities[j];
+
+        // Check if relationship already exists
+        const existing = db.queryOne(
+          `SELECT id FROM relationships
+           WHERE (source_entity_id = ? AND target_entity_id = ?)
+              OR (source_entity_id = ? AND target_entity_id = ?)`,
+          [entityA.id, entityB.id, entityB.id, entityA.id],
+        );
+        if (existing) continue;
+
+        const inference = inferConnections(db, entityA.id, entityB.id);
+        if (inference) {
+          const [relType, confidence] = inference;
+          patterns.push({
+            name: `inferred_connection_${entityA.id}_${entityB.id}`,
+            description: `${entityA.name} and ${entityB.name} may be connected (${relType})`,
+            pattern_type: "relationship",
+            confidence,
+            evidence: [`Inferred relationship type: ${relType}`],
+          });
+        }
+      }
+    }
+  } catch {
+    // database structure issue
+  }
+
+  return patterns;
+}
+
+/**
+ * Detect pairs of people who share attributes but aren't directly connected.
+ * Only strong inferences (confidence >= 0.5).
+ * @param {object} db
+ * @returns {Array} Detected patterns (max 10)
+ */
+function detectIntroductionOpportunities(db) {
+  const patterns = [];
+
+  try {
+    const entities = db.query(
+      `SELECT id, name, metadata FROM entities
+       WHERE type = 'person' AND importance > 0.3 AND metadata IS NOT NULL
+       ORDER BY importance DESC
+       LIMIT 50`,
+    );
+
+    for (let i = 0; i < entities.length; i++) {
+      for (let j = i + 1; j < entities.length; j++) {
+        const entityA = entities[i];
+        const entityB = entities[j];
+
+        // Check if relationship already exists
+        const existing = db.queryOne(
+          `SELECT id FROM relationships
+           WHERE (source_entity_id = ? AND target_entity_id = ?)
+              OR (source_entity_id = ? AND target_entity_id = ?)`,
+          [entityA.id, entityB.id, entityB.id, entityA.id],
+        );
+        if (existing) continue;
+
+        const inference = inferConnections(db, entityA.id, entityB.id);
+        if (inference && inference[1] >= 0.5) {
+          const [relType, confidence] = inference;
+          const aMeta = safeJsonParse(entityA.metadata, {});
+          const bMeta = safeJsonParse(entityB.metadata, {});
+
+          // Build reason
+          const reasonParts = [];
+          if (relType === "colleagues") {
+            reasonParts.push(`both at ${aMeta.company || 'same company'}`);
+          } else if (relType === "community_connection") {
+            const sharedCommunities = (aMeta.communities || []).filter(
+              c => (bMeta.communities || []).map(x => x.toLowerCase()).includes(c.toLowerCase()),
+            );
+            if (sharedCommunities.length > 0) {
+              reasonParts.push(`both in ${sharedCommunities[0]}`);
+            }
+          }
+
+          const reason = reasonParts.length > 0 ? reasonParts.join(" and ") : relType;
+
+          patterns.push({
+            name: `intro_opportunity_${entityA.id}_${entityB.id}`,
+            description: `${entityA.name} and ${entityB.name} might benefit from meeting (${reason})`,
+            pattern_type: "relationship",
+            confidence,
+            evidence: [`Shared attributes suggest connection: ${relType}`],
+          });
+        }
+      }
+    }
+  } catch {
+    // database structure issue
+  }
+
+  return patterns.slice(0, 10);
+}
+
+/**
+ * Detect when 3+ people are mentioned together frequently.
+ * @param {object} db
+ * @returns {Array} Detected patterns
+ */
+function detectClusterForming(db) {
+  const patterns = [];
+
+  try {
+    const cutoff = daysAgo(30);
+
+    const clusterRows = db.query(
+      `SELECT
+          m.id as memory_id,
+          GROUP_CONCAT(e.name) as people,
+          COUNT(DISTINCT e.id) as person_count
+       FROM memories m
+       JOIN memory_entities me ON m.id = me.memory_id
+       JOIN entities e ON me.entity_id = e.id AND e.type = 'person'
+       WHERE m.created_at >= ?
+       GROUP BY m.id
+       HAVING person_count >= 3
+       ORDER BY m.created_at DESC
+       LIMIT 50`,
+      [cutoff],
+    );
+
+    // Count co-occurrence frequency
+    const clusterCounts = new Map();
+    for (const row of clusterRows) {
+      const people = row.people.split(",").sort();
+      const key = people.join(",");
+      clusterCounts.set(key, (clusterCounts.get(key) || 0) + 1);
+    }
+
+    // Sort by count descending, take top 5
+    const sorted = [...clusterCounts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5);
+
+    for (const [key, count] of sorted) {
+      if (count >= 2) {
+        const people = key.split(",");
+        let peopleStr = people.slice(0, 3).join(", ");
+        if (people.length > 3) {
+          peopleStr += ` and ${people.length - 3} others`;
+        }
+
+        const nameKey = people.slice(0, 3).map(p => p.split(/\s+/)[0].toLowerCase()).join("_");
+
+        patterns.push({
+          name: `cluster_forming_${nameKey}`,
+          description: `You're frequently mentioning ${peopleStr} together (${count} times recently)`,
+          pattern_type: "behavioral",
+          confidence: Math.min(0.9, 0.5 + count * 0.1),
+          evidence: [`Co-mentioned in ${count} memories in the last 30 days`],
+        });
+      }
+    }
+  } catch {
+    // database structure issue
+  }
+
+  return patterns;
+}
+
+/**
+ * Find people with skills/interests that match projects they're not connected to.
+ * @param {object} db
+ * @param {object} config
+ * @returns {Array} Detected patterns (max 10)
+ */
+function detectSkillProjectMatches(db, config) {
+  const patterns = [];
+
+  try {
+    // Get projects with descriptions
+    const projects = db.query(
+      `SELECT id, name, description, metadata FROM entities
+       WHERE type = 'project' AND importance > 0.2
+       ORDER BY importance DESC
+       LIMIT 20`,
+    );
+
+    // Get people with attributes
+    const people = db.query(
+      `SELECT id, name, metadata FROM entities
+       WHERE type = 'person' AND importance > 0.3 AND metadata IS NOT NULL
+       ORDER BY importance DESC
+       LIMIT 50`,
+    );
+
+    for (const project of projects) {
+      const projDesc = (project.description || "").toLowerCase();
+      const projMeta = safeJsonParse(project.metadata, {});
+      const projIndustries = new Set(projMeta.industries || []);
+
+      for (const person of people) {
+        // Check if person is already connected to project
+        const existing = db.queryOne(
+          `SELECT id FROM relationships
+           WHERE (source_entity_id = ? AND target_entity_id = ?)
+              OR (source_entity_id = ? AND target_entity_id = ?)`,
+          [person.id, project.id, project.id, person.id],
+        );
+        if (existing) continue;
+
+        const personMeta = safeJsonParse(person.metadata, {});
+        const personIndustries = new Set(personMeta.industries || []);
+        const personRole = (personMeta.role || "").toLowerCase();
+
+        // Check for industry match
+        const sharedIndustries = [...projIndustries].filter(i => personIndustries.has(i));
+        if (sharedIndustries.length > 0) {
+          patterns.push({
+            name: `skill_project_match_${person.id}_${project.id}`,
+            description: `${person.name} might be valuable for ${project.name} (shares ${sharedIndustries.join(', ')} expertise)`,
+            pattern_type: "opportunity",
+            confidence: 0.6,
+            evidence: [`Shared industries: ${sharedIndustries.join(', ')}`],
+          });
+          continue;
+        }
+
+        // Check for role match in description
+        if (personRole && projDesc.includes(personRole)) {
+          patterns.push({
+            name: `skill_project_match_${person.id}_${project.id}`,
+            description: `${person.name} (${personRole}) might be valuable for ${project.name}`,
+            pattern_type: "opportunity",
+            confidence: 0.5,
+            evidence: [`Role '${personRole}' mentioned in project description`],
+          });
+        }
+      }
+    }
+  } catch {
+    // database structure issue
+  }
+
+  return patterns.slice(0, 10);
+}
+
+/**
+ * Detect when the user bridges distinct clusters in their network.
+ * @param {object} db
+ * @returns {Array} Detected patterns
+ */
+function detectNetworkBridges(db) {
+  const patterns = [];
+
+  try {
+    // Find people with high connection counts
+    const hubs = db.query(
+      `SELECT e.id, e.name,
+              COUNT(DISTINCT r.id) as connection_count
+       FROM entities e
+       LEFT JOIN relationships r ON (e.id = r.source_entity_id OR e.id = r.target_entity_id)
+           AND r.strength > 0.2 AND r.invalid_at IS NULL
+       WHERE e.type = 'person' AND e.importance > 0.4
+       GROUP BY e.id
+       HAVING connection_count >= 5
+       ORDER BY connection_count DESC
+       LIMIT 10`,
+    );
+
+    for (const hub of hubs) {
+      // Get all neighbors of this hub
+      const neighbors = db.query(
+        `SELECT DISTINCT
+            CASE WHEN r.source_entity_id = ? THEN r.target_entity_id ELSE r.source_entity_id END as neighbor_id,
+            e.name as neighbor_name
+         FROM relationships r
+         JOIN entities e ON e.id = CASE WHEN r.source_entity_id = ? THEN r.target_entity_id ELSE r.source_entity_id END
+         WHERE (r.source_entity_id = ? OR r.target_entity_id = ?)
+           AND r.strength > 0.2 AND r.invalid_at IS NULL
+           AND e.type = 'person'`,
+        [hub.id, hub.id, hub.id, hub.id],
+      );
+
+      if (neighbors.length < 4) continue;
+
+      // Check how many neighbors are connected to each other (not through hub)
+      const neighborIds = neighbors.map(n => n.neighbor_id);
+      const placeholders = neighborIds.map(() => '?').join(',');
+      const interconnections = db.queryOne(
+        `SELECT COUNT(*) as cnt FROM relationships
+         WHERE source_entity_id IN (${placeholders})
+           AND target_entity_id IN (${placeholders})
+           AND strength > 0.2 AND invalid_at IS NULL`,
+        [...neighborIds, ...neighborIds],
+      );
+
+      const interCount = interconnections ? interconnections.cnt : 0;
+      const maxPossible = neighborIds.length * (neighborIds.length - 1) / 2;
+
+      // If few interconnections relative to possible, this is a bridge
+      if (maxPossible > 0 && interCount / maxPossible < 0.2) {
+        const groupA = neighbors.slice(0, Math.floor(neighbors.length / 2));
+        const groupB = neighbors.slice(Math.floor(neighbors.length / 2));
+
+        patterns.push({
+          name: `network_bridge_${hub.id}`,
+          description: `${hub.name} bridges distinct groups (${groupA.length} and ${groupB.length} people who don't know each other)`,
+          pattern_type: "opportunity",
+          confidence: 0.7,
+          evidence: [`Only ${interCount} connections among ${neighborIds.length} neighbors`],
+        });
+      }
+    }
+  } catch {
+    // database structure issue
+  }
+
+  return patterns;
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3: Contact velocity + attention tiers
+// ---------------------------------------------------------------------------
+
+/**
+ * Calculate contact frequency and trend for person entities.
+ * @param {object} db
+ */
+function updateContactVelocity(db) {
+  const entities = db.query(
+    "SELECT id, name FROM entities WHERE type = 'person' AND deleted_at IS NULL",
+  );
+
+  const now = new Date();
+
+  for (const entity of entities) {
+    // Get all memory timestamps for this entity
+    const rows = db.query(
+      `SELECT m.created_at
+       FROM memories m
+       JOIN memory_entities me ON m.id = me.memory_id
+       WHERE me.entity_id = ?
+         AND m.invalidated_at IS NULL
+       ORDER BY m.created_at ASC`,
+      [entity.id],
+    );
+
+    if (rows.length === 0) continue;
+
+    const timestamps = [];
+    for (const r of rows) {
+      try {
+        timestamps.push(new Date(r.created_at));
+      } catch {
+        continue;
+      }
+    }
+
+    if (timestamps.length === 0) continue;
+
+    const lastContact = timestamps[timestamps.length - 1];
+
+    // Calculate intervals between consecutive mentions (in days)
+    const intervals = [];
+    for (let i = 1; i < timestamps.length; i++) {
+      const delta = (timestamps[i].getTime() - timestamps[i - 1].getTime()) / (86400 * 1000);
+      if (delta > 0) {
+        intervals.push(delta);
+      }
+    }
+
+    let avgFreq = null;
+    let trend = "stable";
+
+    // Need at least 2 intervals for trend detection
+    if (intervals.length < 2) {
+      avgFreq = intervals.length > 0 ? intervals[0] : null;
+      trend = "stable";
+    } else {
+      // Rolling average: last 5 intervals vs historical
+      const recent = intervals.length >= 5 ? intervals.slice(-5) : intervals.slice();
+      avgFreq = recent.reduce((s, v) => s + v, 0) / recent.length;
+
+      if (intervals.length >= 4) {
+        const historical = intervals.length > recent.length
+          ? intervals.slice(0, -recent.length)
+          : intervals.slice(0, Math.floor(intervals.length / 2));
+        const histAvg = historical.length > 0
+          ? historical.reduce((s, v) => s + v, 0) / historical.length
+          : avgFreq;
+
+        const ratio = histAvg > 0 ? avgFreq / histAvg : 1.0;
+
+        if (ratio < 0.7) {
+          trend = "accelerating"; // Recent intervals shorter
+        } else if (ratio > 1.5) {
+          trend = "decelerating"; // Recent intervals longer
+        } else {
+          trend = "stable";
+        }
+      } else {
+        trend = "stable";
+      }
+    }
+
+    // Check for dormancy: last contact > 2x average frequency
+    const daysSinceContact = (now.getTime() - lastContact.getTime()) / (86400 * 1000);
+    if (avgFreq && daysSinceContact > avgFreq * 2 && daysSinceContact > 30) {
+      trend = "dormant";
+    }
+
+    // Update entity
+    db.run(
+      `UPDATE entities
+       SET last_contact_at = ?,
+           contact_frequency_days = ?,
+           contact_trend = ?,
+           updated_at = datetime('now')
+       WHERE id = ?`,
+      [
+        lastContact.toISOString(),
+        avgFreq !== null ? Math.round(avgFreq * 10) / 10 : null,
+        trend,
+        entity.id,
+      ],
+    );
+  }
+
+  log(`Updated contact velocity for ${entities.length} entities`);
+}
+
+/**
+ * Assign attention tiers based on recency and deadlines.
+ *
+ * - Active: mentioned in last 7 days OR has deadline within 14 days
+ * - Watchlist: decelerating trend OR has deadline within 30 days
+ * - Standard: default
+ * - Archive: not mentioned in 90+ days AND importance < 0.3
+ *
+ * @param {object} db
+ */
+function updateAttentionTiers(db) {
+  const sevenDays = daysAgo(7);
+  const ninetyDays = daysAgo(90);
+  const fourteenDaysAhead = daysAhead(14);
+  const thirtyDaysAhead = daysAhead(30);
+  const nowStr = nowISO();
+
+  // Reset all to standard first
+  db.run("UPDATE entities SET attention_tier = 'standard' WHERE deleted_at IS NULL");
+
+  // Archive: no contact in 90+ days AND low importance
+  db.run(
+    `UPDATE entities SET attention_tier = 'archive'
+     WHERE deleted_at IS NULL
+       AND type = 'person'
+       AND (last_contact_at IS NULL OR last_contact_at < ?)
+       AND importance < 0.3`,
+    [ninetyDays],
+  );
+
+  // Watchlist: decelerating trend OR deadline within 30 days
+  db.run(
+    `UPDATE entities SET attention_tier = 'watchlist'
+     WHERE deleted_at IS NULL
+       AND type = 'person'
+       AND (
+         contact_trend = 'decelerating'
+         OR id IN (
+             SELECT DISTINCT me.entity_id
+             FROM memory_entities me
+             JOIN memories m ON me.memory_id = m.id
+             WHERE m.deadline_at IS NOT NULL
+               AND m.deadline_at BETWEEN ? AND ?
+               AND m.invalidated_at IS NULL
+         )
+       )`,
+    [nowStr, thirtyDaysAhead],
+  );
+
+  // Active: mentioned in last 7 days OR deadline within 14 days
+  db.run(
+    `UPDATE entities SET attention_tier = 'active'
+     WHERE deleted_at IS NULL
+       AND type = 'person'
+       AND (
+         last_contact_at >= ?
+         OR id IN (
+             SELECT DISTINCT me.entity_id
+             FROM memory_entities me
+             JOIN memories m ON me.memory_id = m.id
+             WHERE m.deadline_at IS NOT NULL
+               AND m.deadline_at BETWEEN ? AND ?
+               AND m.invalidated_at IS NULL
+         )
+       )`,
+    [sevenDays, nowStr, fourteenDaysAhead],
+  );
+
+  log("Updated attention tiers");
+}
+
+/**
+ * Generate actionable reconnection predictions for dormant/decelerating contacts.
+ * @param {object} db
+ */
+function generateReconnectionSuggestions(db) {
+  const entities = db.query(
+    `SELECT id, name, contact_trend, last_contact_at, contact_frequency_days
+     FROM entities
+     WHERE type = 'person'
+       AND deleted_at IS NULL
+       AND contact_trend IN ('decelerating', 'dormant')
+       AND importance > 0.3
+     ORDER BY importance DESC
+     LIMIT 20`,
+  );
+
+  const now = new Date();
+
+  for (const entity of entities) {
+    const entityId = entity.id;
+    const entityName = entity.name;
+    const trend = entity.contact_trend;
+
+    // Calculate days since last contact
+    let daysSince = 0;
+    if (entity.last_contact_at) {
+      try {
+        const lastDt = new Date(entity.last_contact_at);
+        daysSince = Math.floor((now.getTime() - lastDt.getTime()) / (86400 * 1000));
+      } catch {
+        // ignore parse errors
+      }
+    }
+
+    // Get last topic (most recent memory about this entity)
+    const lastMemory = db.queryOne(
+      `SELECT m.content FROM memories m
+       JOIN memory_entities me ON m.id = me.memory_id
+       WHERE me.entity_id = ? AND m.invalidated_at IS NULL
+       ORDER BY m.created_at DESC LIMIT 1`,
+      [entityId],
+    );
+    const lastTopic = lastMemory ? lastMemory.content.slice(0, 100) : "No recent topic";
+
+    // Get open commitments
+    const openCommitments = db.query(
+      `SELECT m.content FROM memories m
+       JOIN memory_entities me ON m.id = me.memory_id
+       WHERE me.entity_id = ?
+         AND m.type = 'commitment'
+         AND m.invalidated_at IS NULL
+       ORDER BY m.importance DESC LIMIT 3`,
+      [entityId],
+    );
+    const commitmentList = openCommitments.map(c => c.content.slice(0, 80));
+
+    // Build suggestion
+    let suggestedAction = "Reach out to reconnect";
+    if (commitmentList.length > 0) {
+      suggestedAction = `Address open commitment: ${commitmentList[0]}`;
+    }
+
+    let priority = 0.7;
+    if (trend === "dormant") {
+      priority = 0.85;
+    }
+    if (commitmentList.length > 0) {
+      priority = Math.min(1.0, priority + 0.1);
+    }
+
+    let content = `Reconnect with ${entityName} (${daysSince} days, ${trend}). Last topic: ${lastTopic}. `;
+    if (commitmentList.length > 0) {
+      content += `Open commitments: ${commitmentList.join('; ')}. `;
+    }
+    content += `Suggested: ${suggestedAction}`;
+
+    const metadata = JSON.stringify({
+      entity_id: entityId,
+      entity_name: entityName,
+      days_since_contact: daysSince,
+      trend,
+      open_commitments: commitmentList,
+      last_topic: lastTopic,
+    });
+
+    const expires = new Date(now.getTime() + 14 * 86400 * 1000).toISOString();
+
+    // Check for existing reconnection prediction for this entity
+    const existing = db.queryOne(
+      `SELECT id FROM predictions
+       WHERE prediction_type = 'reconnection'
+         AND metadata LIKE ?
+         AND expires_at > ?
+       LIMIT 1`,
+      [`%"entity_id": ${entityId}%`, now.toISOString()],
+    );
+
+    if (existing) {
+      db.update(
+        "predictions",
+        {
+          content,
+          priority,
+          metadata,
+          expires_at: expires,
+          updated_at: nowISOFull(),
+        },
+        "id = ?",
+        [existing.id],
+      );
+    } else {
+      db.insert("predictions", {
+        content,
+        prediction_type: "reconnection",
+        priority,
+        expires_at: expires,
+        created_at: now.toISOString(),
+        updated_at: now.toISOString(),
+        metadata,
+      });
+    }
+  }
+
+  if (entities.length > 0) {
+    log(`Generated ${entities.length} reconnection suggestions`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3: Pattern detection (orchestrator)
+// ---------------------------------------------------------------------------
+
+/**
+ * Analyze memories and entities to detect behavioral patterns.
+ *
+ * Detects: cooling relationships, commitment patterns, communication patterns,
+ * cross-entity patterns, inferred connections, introduction opportunities,
+ * cluster forming, opportunities (skill-project matches, network bridges).
+ *
+ * Also updates contact velocity and attention tiers.
+ *
+ * @param {object} db
+ * @param {object} config
+ * @returns {Array} List of detected patterns
+ */
+export function detectPatterns(db, config) {
+  const patterns = [];
+
+  // Detect relationship cooling
+  patterns.push(...detectCoolingRelationships(db));
+
+  // Detect commitment patterns
+  patterns.push(...detectCommitmentPatterns(db));
+
+  // Detect communication patterns
+  patterns.push(...detectCommunicationPatterns(db));
+
+  // Detect cross-entity patterns (co-mentioned people without explicit relationships)
+  patterns.push(...detectCrossEntityPatterns(db));
+
+  // Detect inferred connections (attribute-based: same city, industry, community)
+  patterns.push(...detectInferredConnections(db));
+
+  // Detect introduction opportunities (people who should know each other)
+  patterns.push(...detectIntroductionOpportunities(db));
+
+  // Detect forming clusters (3+ people mentioned together frequently)
+  patterns.push(...detectClusterForming(db));
+
+  // Detect opportunities (skill-project matches, network bridges)
+  patterns.push(...detectSkillProjectMatches(db, config));
+  patterns.push(...detectNetworkBridges(db));
+
+  // Update contact velocity and attention tiers
+  try {
+    updateContactVelocity(db);
+    updateAttentionTiers(db);
+    generateReconnectionSuggestions(db);
+  } catch (e) {
+    // Velocity/tier columns may not exist
+  }
+
+  // Store detected patterns
+  for (const pattern of patterns) {
+    storePattern(db, pattern);
+  }
+
+  log(`Detected ${patterns.length} patterns`);
+  return patterns;
+}
+
+// ---------------------------------------------------------------------------
+// Phase 4: Entity summaries
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a structured summary for a single entity.
+ * @param {object} db
+ * @param {object} entity - Entity row with mem_count
+ * @returns {string|null} Summary text or null if not enough data
+ */
+function buildEntitySummary(db, entity) {
+  const entityId = entity.id;
+  const parts = [];
+
+  // Header
+  const entityType = entity.type;
+  const name = entity.name;
+  const description = entity.description || "";
+  if (description) {
+    parts.push(`${name} (${entityType}): ${description}`);
+  } else {
+    parts.push(`${name} (${entityType})`);
+  }
+
+  // Key facts (top 5 by importance)
+  const facts = db.query(
+    `SELECT m.content, m.type, m.importance
+     FROM memories m
+     JOIN memory_entities me ON m.id = me.memory_id
+     WHERE me.entity_id = ?
+       AND m.invalidated_at IS NULL
+       AND m.importance > 0.2
+     ORDER BY m.importance DESC
+     LIMIT 5`,
+    [entityId],
+  );
+
+  if (facts.length > 0) {
+    const factLines = [];
+    for (const f of facts) {
+      const prefix = f.type !== "fact" ? f.type.toUpperCase() : "";
+      const content = f.content.slice(0, 120);
+      if (prefix) {
+        factLines.push(`  [${prefix}] ${content}`);
+      } else {
+        factLines.push(`  - ${content}`);
+      }
+    }
+    parts.push("Key information:\n" + factLines.join("\n"));
+  }
+
+  // Relationships
+  const relationships = db.query(
+    `SELECT r.relationship_type, r.strength, r.origin_type,
+            e.name as connected_name, e.type as connected_type
+     FROM relationships r
+     JOIN entities e ON e.id = CASE
+         WHEN r.source_entity_id = ? THEN r.target_entity_id
+         ELSE r.source_entity_id END
+     WHERE (r.source_entity_id = ? OR r.target_entity_id = ?)
+       AND r.invalid_at IS NULL
+       AND r.strength > 0.1
+     ORDER BY r.strength DESC
+     LIMIT 10`,
+    [entityId, entityId, entityId],
+  );
+
+  if (relationships.length > 0) {
+    const relLines = [];
+    for (const r of relationships) {
+      relLines.push(
+        `  ${r.relationship_type} -> ${r.connected_name} ` +
+        `(${r.connected_type}, strength: ${r.strength.toFixed(1)})`,
+      );
+    }
+    parts.push("Relationships:\n" + relLines.join("\n"));
+  }
+
+  // Open commitments
+  const commitments = db.query(
+    `SELECT m.content, m.deadline_at
+     FROM memories m
+     JOIN memory_entities me ON m.id = me.memory_id
+     WHERE me.entity_id = ?
+       AND m.type = 'commitment'
+       AND m.invalidated_at IS NULL
+     ORDER BY m.importance DESC
+     LIMIT 3`,
+    [entityId],
+  );
+
+  if (commitments.length > 0) {
+    const commitLines = [];
+    for (const c of commitments) {
+      const deadline = c.deadline_at ? ` (due: ${c.deadline_at})` : "";
+      commitLines.push(`  - ${c.content.slice(0, 100)}${deadline}`);
+    }
+    parts.push("Open commitments:\n" + commitLines.join("\n"));
+  }
+
+  // Contact velocity (for person entities)
+  if (entity.type === "person") {
+    const velocityParts = [];
+    if (entity.contact_trend) {
+      velocityParts.push(`trend: ${entity.contact_trend}`);
+    }
+    if (entity.contact_frequency_days) {
+      velocityParts.push(`avg frequency: ${Math.round(entity.contact_frequency_days)} days`);
+    }
+    if (entity.attention_tier) {
+      velocityParts.push(`tier: ${entity.attention_tier}`);
+    }
+    if (entity.last_contact_at) {
+      try {
+        const lastDt = new Date(entity.last_contact_at);
+        const daysSince = Math.floor((new Date().getTime() - lastDt.getTime()) / (86400 * 1000));
+        velocityParts.push(`last contact: ${daysSince} days ago`);
+      } catch {
+        // ignore parse error
+      }
+    }
+    if (velocityParts.length > 0) {
+      parts.push("Contact velocity: " + velocityParts.join(", "));
+    }
+  }
+
+  if (parts.length <= 1) {
+    return null; // Not enough data for a useful summary
+  }
+
+  return parts.join("\n\n");
+}
+
+/**
+ * Store or update an entity summary.
+ * @param {object} db
+ * @param {number} entityId
+ * @param {string} summary
+ * @param {object} entity
+ * @param {object} config
+ */
+function storeEntitySummary(db, entityId, summary, entity, config) {
+  const now = nowISOFull();
+  const expires = new Date(new Date().getTime() + config.entity_summary_max_age_days * 86400 * 1000).toISOString();
+
+  // Count relationships
+  const relCountRow = db.queryOne(
+    `SELECT COUNT(*) as cnt FROM relationships
+     WHERE (source_entity_id = ? OR target_entity_id = ?)
+       AND invalid_at IS NULL AND strength > 0.1`,
+    [entityId, entityId],
+  );
+  const relCount = relCountRow ? relCountRow.cnt : 0;
+
+  const metadata = JSON.stringify({
+    entity_name: entity.name,
+    entity_type: entity.type,
+    attention_tier: entity.attention_tier,
+    contact_trend: entity.contact_trend,
+  });
+
+  // Upsert: try update first, then insert
+  const existing = db.queryOne(
+    "SELECT id FROM entity_summaries WHERE entity_id = ? AND summary_type = 'overview'",
+    [entityId],
+  );
+
+  if (existing) {
+    db.update(
+      "entity_summaries",
+      {
+        summary,
+        memory_count: entity.mem_count,
+        relationship_count: relCount,
+        generated_at: now,
+        expires_at: expires,
+        metadata,
+      },
+      "id = ?",
+      [existing.id],
+    );
+  } else {
+    db.insert("entity_summaries", {
+      entity_id: entityId,
+      summary,
+      summary_type: "overview",
+      memory_count: entity.mem_count,
+      relationship_count: relCount,
+      generated_at: now,
+      expires_at: expires,
+      metadata,
+    });
+  }
+}
+
+/**
+ * Generate hierarchical summaries for entities with enough memories.
+ *
+ * Creates or updates entity_summaries rows that provide a high-level
+ * overview of each significant entity.
+ *
+ * @param {object} db
+ * @param {object} config
+ * @returns {number} Count of summaries generated or updated
+ */
+export function generateEntitySummaries(db, config) {
+  if (!config.enable_entity_summaries) {
+    return 0;
+  }
+
+  const minMemories = config.entity_summary_min_memories;
+  const maxAgeDays = config.entity_summary_max_age_days;
+  const cutoff = daysAgo(maxAgeDays);
+  let count = 0;
+
+  try {
+    // Find entities that need summaries (enough memories, no recent summary)
+    const entities = db.query(
+      `SELECT e.id, e.name, e.type, e.description, e.importance,
+              e.last_contact_at, e.contact_frequency_days, e.contact_trend,
+              e.attention_tier,
+              COUNT(DISTINCT me.memory_id) as mem_count,
+              es.generated_at as last_summary_at
+       FROM entities e
+       JOIN memory_entities me ON e.id = me.entity_id
+       LEFT JOIN entity_summaries es ON e.id = es.entity_id AND es.summary_type = 'overview'
+       WHERE e.deleted_at IS NULL
+         AND e.importance > 0.1
+       GROUP BY e.id
+       HAVING mem_count >= ?
+         AND (es.generated_at IS NULL OR es.generated_at < ?)
+       ORDER BY e.importance DESC, mem_count DESC
+       LIMIT 50`,
+      [minMemories, cutoff],
+    );
+
+    for (const entity of entities) {
+      const summary = buildEntitySummary(db, entity);
+      if (summary) {
+        storeEntitySummary(db, entity.id, summary, entity, config);
+        count++;
+      }
+    }
+  } catch (e) {
+    log(`Entity summary generation failed: ${e.message || e}`);
+  }
+
+  if (count > 0) {
+    log(`Generated ${count} entity summaries`);
+  }
+  return count;
+}
+
+// ---------------------------------------------------------------------------
+// Phase 5: Auto-dedupe entities
+// ---------------------------------------------------------------------------
+
+/**
+ * Find and flag potential entity duplicates using embedding similarity.
+ *
+ * Uses vec0's native KNN search on entity_embeddings to find entities with
+ * similar embeddings that likely refer to the same real-world entity.
+ * Does NOT auto-merge -- stores suggestions in predictions for user review.
+ *
+ * Also checks alias overlap between entities of the same type.
+ *
+ * @param {object} db
+ * @param {object} config
+ * @returns {Array} List of duplicate candidate pairs with similarity scores
+ */
+export function autoDedupeEntities(db, config) {
+  if (!config.enable_auto_dedupe) {
+    return [];
+  }
+
+  const threshold = config.auto_dedupe_threshold;
+  const candidates = [];
+  const seenPairs = new Set();
+
+  // Method 1: vec0 KNN search on entity embeddings
+  try {
+    const entities = db.query(
+      `SELECT e.id, e.name, e.canonical_name, e.type, e.importance
+       FROM entities e
+       WHERE e.deleted_at IS NULL AND e.importance > 0.05
+       ORDER BY e.importance DESC
+       LIMIT 200`,
+    );
+
+    const entityMap = new Map();
+    for (const e of entities) {
+      entityMap.set(e.id, e);
+    }
+
+    let embRows;
+    try {
+      embRows = db.query("SELECT entity_id FROM entity_embeddings");
+    } catch {
+      embRows = [];
+    }
+    const entityIdsWithEmb = new Set(
+      embRows.filter(r => entityMap.has(r.entity_id)).map(r => r.entity_id),
+    );
+
+    for (const eid of entityIdsWithEmb) {
+      try {
+        const neighbors = db.query(
+          `SELECT ee.entity_id, ee.distance
+           FROM entity_embeddings ee
+           WHERE ee.embedding MATCH (
+               SELECT embedding FROM entity_embeddings WHERE entity_id = ?
+           )
+           AND k = 10`,
+          [eid],
+        );
+
+        const e1 = entityMap.get(eid);
+        if (!e1) continue;
+
+        for (const neighbor of neighbors) {
+          const nid = neighbor.entity_id;
+          if (nid === eid) continue;
+          const e2 = entityMap.get(nid);
+          if (!e2) continue;
+          if (e1.type !== e2.type) continue;
+
+          const dist = neighbor.distance;
+          const sim = 1.0 - dist;
+          if (sim < threshold) continue;
+
+          const pairKey = `${Math.min(eid, nid)}_${Math.max(eid, nid)}`;
+          if (seenPairs.has(pairKey)) continue;
+          seenPairs.add(pairKey);
+
+          candidates.push({
+            entity_1: { id: e1.id, name: e1.name, type: e1.type },
+            entity_2: { id: e2.id, name: e2.name, type: e2.type },
+            similarity: Math.round(sim * 1000) / 1000,
+            method: "embedding",
+          });
+        }
+      } catch {
+        continue;
+      }
+    }
+  } catch {
+    // Embedding-based dedupe unavailable
+  }
+
+  // Method 2: Alias overlap detection
+  try {
+    const aliasRows = db.query(
+      `SELECT a1.entity_id as eid1, a2.entity_id as eid2,
+              a1.canonical_alias as alias
+       FROM entity_aliases a1
+       JOIN entity_aliases a2 ON a1.canonical_alias = a2.canonical_alias
+           AND a1.entity_id < a2.entity_id
+       JOIN entities e1 ON a1.entity_id = e1.id AND e1.deleted_at IS NULL
+       JOIN entities e2 ON a2.entity_id = e2.id AND e2.deleted_at IS NULL
+           AND e1.type = e2.type`,
+    );
+
+    for (const row of aliasRows) {
+      const pairKey = `${row.eid1}_${row.eid2}`;
+      if (seenPairs.has(pairKey)) continue;
+      seenPairs.add(pairKey);
+
+      const e1 = db.queryOne("SELECT id, name, type FROM entities WHERE id = ?", [row.eid1]);
+      const e2 = db.queryOne("SELECT id, name, type FROM entities WHERE id = ?", [row.eid2]);
+      if (e1 && e2) {
+        candidates.push({
+          entity_1: { id: e1.id, name: e1.name, type: e1.type },
+          entity_2: { id: e2.id, name: e2.name, type: e2.type },
+          similarity: 0.95,
+          method: "alias_overlap",
+          shared_alias: row.alias,
+        });
+      }
+    }
+
+    // Store top candidates as predictions for user review
+    const now = new Date();
+    for (const candidate of candidates.slice(0, 10)) {
+      const content =
+        `Possible duplicate entities: '${candidate.entity_1.name}' ` +
+        `and '${candidate.entity_2.name}' ` +
+        `(${Math.round(candidate.similarity * 100)}% similar via ${candidate.method}). ` +
+        `Consider merging with memory.merge_entities.`;
+
+      // Check for existing dedupe prediction
+      const existing = db.queryOne(
+        `SELECT id FROM predictions
+         WHERE prediction_type = 'suggestion'
+           AND metadata LIKE ?
+           AND expires_at > ?
+         LIMIT 1`,
+        [
+          `%"dedupe_pair": [${candidate.entity_1.id}, ${candidate.entity_2.id}]%`,
+          now.toISOString(),
+        ],
+      );
+
+      if (!existing) {
+        db.insert("predictions", {
+          content,
+          prediction_type: "suggestion",
+          priority: 0.6 + 0.3 * candidate.similarity,
+          expires_at: new Date(now.getTime() + 14 * 86400 * 1000).toISOString(),
+          created_at: now.toISOString(),
+          metadata: JSON.stringify({
+            dedupe_pair: [candidate.entity_1.id, candidate.entity_2.id],
+            similarity: candidate.similarity,
+            method: candidate.method,
+          }),
+        });
+      }
+    }
+  } catch (e) {
+    log(`Auto dedupe failed: ${e.message || e}`);
+  }
+
+  if (candidates.length > 0) {
+    log(`Found ${candidates.length} potential entity duplicates`);
+  }
+  return candidates;
+}
+
+// ---------------------------------------------------------------------------
+// Phase 6: Retention cleanup
+// ---------------------------------------------------------------------------
+
+/**
+ * Auto-close orphan episodes that have no end_session call.
+ * After 24 hours these will never be closed naturally.
+ *
+ * @param {object} db
+ * @returns {number} Number of episodes closed
+ */
+export function closeStaleEpisodes(db) {
+  const cutoff = hoursAgo(24);
+  try {
+    const result = db.run(
+      `UPDATE episodes
+       SET
+           ended_at = COALESCE(
+               (
+                   SELECT MAX(created_at) FROM turn_buffer
+                   WHERE turn_buffer.session_id = episodes.session_id
+               ),
+               started_at
+           ),
+           is_summarized = 1,
+           summary = 'Auto-closed: session ended without explicit end_session call'
+       WHERE ended_at IS NULL
+         AND started_at < ?`,
+      [cutoff],
+    );
+    const count = result.changes;
+    if (count > 0) {
+      log(`Auto-closed ${count} stale open episode(s)`);
+    }
+    return count;
+  } catch (e) {
+    log(`close_stale_episodes failed: ${e.message || e}`);
+    return 0;
+  }
+}
+
+/**
+ * Clean up old data per retention policies.
+ *
+ * Removes:
+ * - Old audit_log entries
+ * - Expired predictions past retention window
+ * - Archived turn_buffer from old episodes
+ * - Old metrics rows
+ * - Auto-closes stale open episodes (no end_session after 24h)
+ *
+ * @param {object} db
+ * @param {object} config
+ * @returns {object} Counts of deleted items by category
+ */
+export function runRetentionCleanup(db, config) {
+  const results = {};
+
+  // Audit log cleanup
+  try {
+    const cutoff = daysAgo(config.audit_log_retention_days);
+    const r = db.run("DELETE FROM audit_log WHERE timestamp < ?", [cutoff]);
+    results.audit_log_deleted = r.changes;
+  } catch (e) {
+    log(`Audit log cleanup failed: ${e.message || e}`);
+    results.audit_log_deleted = 0;
+  }
+
+  // Predictions cleanup (expired + past retention window)
+  try {
+    const cutoff = daysAgo(config.prediction_retention_days);
+    const r = db.run(
+      "DELETE FROM predictions WHERE expires_at IS NOT NULL AND expires_at < ?",
+      [cutoff],
+    );
+    results.predictions_deleted = r.changes;
+  } catch (e) {
+    log(`Predictions cleanup failed: ${e.message || e}`);
+    results.predictions_deleted = 0;
+  }
+
+  // Turn buffer cleanup (old archived turns)
+  try {
+    const cutoff = daysAgo(config.turn_buffer_retention_days);
+    const r = db.run("DELETE FROM turn_buffer WHERE created_at < ?", [cutoff]);
+    results.turn_buffer_deleted = r.changes;
+  } catch (e) {
+    log(`Turn buffer cleanup failed: ${e.message || e}`);
+    results.turn_buffer_deleted = 0;
+  }
+
+  // Metrics cleanup
+  try {
+    const cutoff = daysAgo(config.metrics_retention_days);
+    const r = db.run("DELETE FROM metrics WHERE timestamp < ?", [cutoff]);
+    results.metrics_deleted = r.changes;
+  } catch (e) {
+    log(`Metrics cleanup failed: ${e.message || e}`);
+    results.metrics_deleted = 0;
+  }
+
+  // Auto-close orphan episodes (no end_session after 24h)
+  results.stale_episodes_closed = closeStaleEpisodes(db);
+
+  log(`Retention cleanup: ${JSON.stringify(results)}`);
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Full consolidation orchestrator
+// ---------------------------------------------------------------------------
+
+/**
+ * Run complete consolidation: decay, patterns, merging, summaries, cleanup.
+ * Typically called overnight. Each phase is wrapped in try/catch so partial
+ * failures don't prevent later phases from running.
+ *
+ * Phases:
+ *  0. Pre-consolidation backup
+ *  1. Decay + boost + lifecycle transitions + auto-sacred
+ *  2. Memory merging + reflection aggregation
+ *  3. Pattern detection
+ *  4. Entity summaries (if enabled)
+ *  5. Auto-dedupe entities (if enabled)
+ *  6. Retention cleanup
+ *
+ * @param {object} db - ClaudiaDatabase instance
+ * @param {object} config - Configuration object
+ * @returns {object} Results dict with counts from each phase
+ */
+export async function runFullConsolidation(db, config) {
+  log("Starting full consolidation");
+
+  const results = {};
+
+  // Phase 0: Pre-consolidation backup
+  if (config.enable_pre_consolidation_backup) {
+    try {
+      const backupPath = await db.backup();
+      results.backup_path = backupPath;
+    } catch (e) {
+      log(`Pre-consolidation backup failed: ${e.message || e}`);
+      results.backup_error = String(e.message || e);
+    }
+  }
+
+  // Phase 1: Decay + boost (modifies importance scores)
+  try {
+    results.decay = runDecay(db, config);
+    results.boosted = boostAccessedMemories(db);
+  } catch (e) {
+    log(`Decay phase failed: ${e.message || e}`);
+    results.decay = { error: String(e.message || e) };
+    results.boosted = 0;
+  }
+
+  // Phase 1b: Lifecycle transitions + auto-sacred
+  try {
+    results.lifecycle = runLifecycleTransitions(db, config);
+    results.auto_sacred = detectAutoSacred(db, config);
+    results.close_circle_candidates = detectCloseCircleCandidates(db, config).length;
+  } catch (e) {
+    log(`Lifecycle phase failed: ${e.message || e}`);
+    results.lifecycle = { error: String(e.message || e) };
+  }
+
+  // Phase 2: Merging (modifies memory content)
+  try {
+    results.merged = mergeSimilarMemories(db, config);
+    results.reflections_aggregated = aggregateReflections(db);
+  } catch (e) {
+    log(`Merge phase failed: ${e.message || e}`);
+    results.merged = 0;
+    results.reflections_aggregated = 0;
+  }
+
+  // Phase 3: Detection (read-heavy, writes new pattern rows)
+  try {
+    const patterns = detectPatterns(db, config);
+    results.patterns_detected = patterns.length;
+  } catch (e) {
+    log(`Pattern detection failed: ${e.message || e}`);
+    results.patterns_detected = 0;
+  }
+
+  // Phase 4: Entity summaries (hierarchical graph retrieval)
+  try {
+    results.entity_summaries_generated = generateEntitySummaries(db, config);
+  } catch (e) {
+    log(`Entity summary generation failed: ${e.message || e}`);
+    results.entity_summaries_generated = 0;
+  }
+
+  // Phase 5: Auto-dedupe entities
+  try {
+    const dedupeCandidates = autoDedupeEntities(db, config);
+    results.dedupe_candidates_found = dedupeCandidates.length;
+  } catch (e) {
+    log(`Auto dedupe failed: ${e.message || e}`);
+    results.dedupe_candidates_found = 0;
+  }
+
+  // Phase 6: Retention cleanup (removes old data)
+  try {
+    results.retention = runRetentionCleanup(db, config);
+  } catch (e) {
+    log(`Retention cleanup failed: ${e.message || e}`);
+    results.retention = { error: String(e.message || e) };
+  }
+
+  log(`Consolidation complete: ${JSON.stringify(results)}`);
+  return results;
+}

--- a/cli/services/documents.js
+++ b/cli/services/documents.js
@@ -1,0 +1,264 @@
+/**
+ * Document service for Claudia CLI.
+ * Port of memory-daemon/claudia_memory/services/documents.py.
+ *
+ * Manages document storage, entity/memory linking, and lifecycle transitions.
+ * Documents are the physical files (transcripts, emails, uploads) backing memories.
+ */
+
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, mkdirSync, unlinkSync, writeFileSync } from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import { getClaudiaHome } from '../core/paths.js';
+import { canonicalName } from './extraction.js';
+
+// ----- File Storage Helpers -----
+
+function getFilesDir() {
+  return join(getClaudiaHome(), 'files');
+}
+
+function buildRelativePath(sourceType, filename) {
+  const date = new Date().toISOString().slice(0, 10);
+  return join(sourceType, date, filename);
+}
+
+function buildEntityPath(entityType, entityCanonical, sourceType, filename) {
+  return join('entities', entityType, entityCanonical, sourceType, filename);
+}
+
+function storeFile(content, relativePath) {
+  const baseDir = getFilesDir();
+  const fullPath = join(baseDir, relativePath);
+  mkdirSync(dirname(fullPath), { recursive: true });
+  writeFileSync(fullPath, content);
+  return relativePath;
+}
+
+function deleteFile(relativePath) {
+  const fullPath = join(getFilesDir(), relativePath);
+  try {
+    unlinkSync(fullPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ----- Document Operations -----
+
+/**
+ * Store a document and register it in the database.
+ * @param {object} db
+ * @param {object} options
+ * @returns {object}
+ */
+export function fileDocument(db, {
+  filePath, content, sourceType = 'upload', filename, summary,
+  aboutEntities, memoryIds, sourceRef, entityRelationships, metadata,
+}) {
+  // Resolve content
+  let raw;
+  if (filePath) {
+    if (!existsSync(filePath)) return { error: `File not found: ${filePath}` };
+    raw = readFileSync(filePath);
+    if (!filename) filename = basename(filePath);
+  } else if (content != null) {
+    raw = typeof content === 'string' ? Buffer.from(content, 'utf-8') : content;
+    if (!filename) filename = `document-${new Date().toISOString().replace(/[:.]/g, '-')}`;
+  } else {
+    return { error: 'Either filePath or content is required' };
+  }
+
+  // Compute hash for dedup
+  const fileHash = createHash('sha256').update(raw).digest('hex');
+
+  // Check duplicate
+  const existing = db.queryOne('SELECT * FROM documents WHERE file_hash = ?', [fileHash]);
+  if (existing) {
+    _linkEntities(db, existing.id, aboutEntities, entityRelationships);
+    _linkMemories(db, existing.id, memoryIds);
+    return { document_id: existing.id, storage_path: existing.storage_path, deduplicated: true };
+  }
+
+  // Determine storage path
+  let relativePath;
+  if (aboutEntities && aboutEntities.length > 0) {
+    const cn = canonicalName(aboutEntities[0]);
+    const entity = db.queryOne('SELECT * FROM entities WHERE canonical_name = ?', [cn]);
+    if (entity) {
+      relativePath = buildEntityPath(entity.type, entity.canonical_name, sourceType, filename);
+    }
+  }
+  if (!relativePath) {
+    relativePath = buildRelativePath(sourceType, filename);
+  }
+
+  // Store file
+  const storagePath = storeFile(raw, relativePath);
+  const now = new Date().toISOString();
+
+  // Insert DB row
+  const docId = db.insert('documents', {
+    file_hash: fileHash,
+    filename,
+    mime_type: guessMimeType(filename),
+    file_size: raw.length,
+    storage_provider: 'local',
+    storage_path: storagePath,
+    source_type: sourceType,
+    source_ref: sourceRef || null,
+    summary: summary || null,
+    lifecycle: 'active',
+    last_accessed_at: now,
+    created_at: now,
+    updated_at: now,
+    metadata: metadata ? JSON.stringify(metadata) : null,
+  });
+
+  _linkEntities(db, docId, aboutEntities, entityRelationships);
+  _linkMemories(db, docId, memoryIds);
+
+  return { document_id: docId, storage_path: storagePath, deduplicated: false };
+}
+
+/**
+ * Search documents by text, entity, source type, or lifecycle.
+ */
+export function searchDocuments(db, { query, sourceType, entityName, lifecycle, limit = 20 } = {}) {
+  let sql = 'SELECT DISTINCT d.* FROM documents d';
+  const params = [];
+  const joins = [];
+  const wheres = [];
+
+  if (entityName) {
+    const cn = canonicalName(entityName);
+    joins.push('JOIN entity_documents ed ON d.id = ed.document_id');
+    joins.push('JOIN entities e ON ed.entity_id = e.id');
+    wheres.push('e.canonical_name = ?');
+    params.push(cn);
+  }
+
+  if (query) {
+    wheres.push('(d.filename LIKE ? OR d.summary LIKE ?)');
+    params.push(`%${query}%`, `%${query}%`);
+  }
+
+  if (sourceType) {
+    wheres.push('d.source_type = ?');
+    params.push(sourceType);
+  }
+
+  if (lifecycle) {
+    wheres.push('d.lifecycle = ?');
+    params.push(lifecycle);
+  } else {
+    wheres.push("d.lifecycle != 'purged'");
+  }
+
+  for (const j of joins) sql += ` ${j}`;
+  if (wheres.length) sql += ' WHERE ' + wheres.join(' AND ');
+  sql += ' ORDER BY d.created_at DESC LIMIT ?';
+  params.push(limit);
+
+  return (db.query(sql, params) || []).map(r => ({
+    id: r.id,
+    filename: r.filename,
+    mime_type: r.mime_type,
+    file_size: r.file_size,
+    source_type: r.source_type,
+    summary: r.summary,
+    lifecycle: r.lifecycle,
+    created_at: r.created_at,
+  }));
+}
+
+/**
+ * Purge a document: delete file from disk, keep metadata as tombstone.
+ */
+export function purgeDocument(db, documentId) {
+  const doc = db.queryOne('SELECT * FROM documents WHERE id = ?', [documentId]);
+  if (!doc) return { error: 'Document not found' };
+
+  let fileDeleted = false;
+  if (doc.storage_path) {
+    fileDeleted = deleteFile(doc.storage_path);
+  }
+
+  db.update('documents', {
+    lifecycle: 'purged',
+    storage_path: null,
+    updated_at: new Date().toISOString(),
+  }, 'id = ?', [documentId]);
+
+  return { document_id: documentId, file_deleted: fileDeleted, metadata_preserved: true };
+}
+
+/**
+ * Get documents linked to a memory (provenance chain).
+ */
+export function getMemoryDocuments(db, memoryId) {
+  return (db.query(`
+    SELECT d.*, ms.excerpt
+    FROM documents d
+    JOIN memory_sources ms ON d.id = ms.document_id
+    WHERE ms.memory_id = ?
+    ORDER BY d.created_at DESC
+  `, [memoryId]) || []).map(r => ({
+    id: r.id,
+    filename: r.filename,
+    source_type: r.source_type,
+    summary: r.summary,
+    excerpt: r.excerpt,
+    storage_path: r.storage_path,
+    created_at: r.created_at,
+  }));
+}
+
+// ----- Internal Helpers -----
+
+function _linkEntities(db, docId, aboutEntities, entityRelationships) {
+  if (!aboutEntities) return;
+  for (const name of aboutEntities) {
+    const cn = canonicalName(name);
+    const entity = db.queryOne('SELECT id FROM entities WHERE canonical_name = ?', [cn]);
+    if (!entity) continue;
+    const rel = entityRelationships?.[name] || 'about';
+    try {
+      db.insert('entity_documents', {
+        entity_id: entity.id,
+        document_id: docId,
+        relationship: rel,
+        created_at: new Date().toISOString(),
+      });
+    } catch {
+      // Duplicate link — ignore
+    }
+  }
+}
+
+function _linkMemories(db, docId, memoryIds) {
+  if (!memoryIds) return;
+  for (const mid of memoryIds) {
+    try {
+      db.insert('memory_sources', {
+        memory_id: mid,
+        document_id: docId,
+        created_at: new Date().toISOString(),
+      });
+    } catch {
+      // Duplicate link — ignore
+    }
+  }
+}
+
+function guessMimeType(filename) {
+  const ext = (filename || '').split('.').pop()?.toLowerCase();
+  const map = {
+    txt: 'text/plain', md: 'text/markdown', json: 'application/json',
+    pdf: 'application/pdf', html: 'text/html', csv: 'text/csv',
+    jpg: 'image/jpeg', jpeg: 'image/jpeg', png: 'image/png',
+    gif: 'image/gif', mp3: 'audio/mpeg', mp4: 'video/mp4',
+  };
+  return map[ext] || 'application/octet-stream';
+}

--- a/cli/services/extraction.js
+++ b/cli/services/extraction.js
@@ -1,0 +1,324 @@
+/**
+ * Entity extraction for Claudia CLI.
+ * Port of memory-daemon/claudia_memory/extraction/entity_extractor.py.
+ *
+ * Regex-only extraction (no spaCy dependency in Node.js).
+ * Extracts people, organizations, projects, locations, commitments, preferences.
+ */
+
+// ----- Regex Patterns -----
+
+const PERSON_PATTERNS = [
+  /\b(?:Dr\.?|Mr\.?|Mrs\.?|Ms\.?|Prof\.?)?\s*([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\b/g,
+  /\b([A-Z][a-z]+)'s\b/g,
+  /\b(?:with|from|to|about|called|named|meet(?:ing)?)\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)?)\b/g,
+];
+
+const ORGANIZATION_PATTERNS = [
+  /\b([A-Z][A-Za-z]+(?:\s+[A-Z][A-Za-z]+)*\s+(?:Inc\.?|Corp\.?|LLC|Ltd\.?|Co\.?|Company|Group|Partners|Consulting))\b/g,
+  /\b([A-Z]{2,5})\b(?:\s+(?:team|company|client|project))?/g,
+];
+
+const PROJECT_PATTERNS = [
+  /\b(?:the\s+)?([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)\s+(?:project|initiative|proposal|deal)\b/gi,
+  /\b(Q[1-4]\s+[A-Za-z]+)\b/g,
+];
+
+const COMMITMENT_PATTERNS = [
+  /(?:I'll|I will|I'm going to|we'll|we will)\s+(.+?)(?:\.|$)/gi,
+  /(?:by|before|until)\s+(\w+day|\d+[/-]\d+|\w+\s+\d+)/gi,
+  /(?:send|deliver|complete|finish|submit)\s+(?:the\s+)?(.+?)(?:\s+(?:by|to|before)|\.|$)/gi,
+];
+
+const PREFERENCE_PATTERNS = [
+  /(?:I |he |she |they )(?:prefer|like|want|need)\s+(.+?)(?:\.|$)/gi,
+  /(?:better|best|rather)\s+(?:to |if |when )?(.+?)(?:\.|$)/gi,
+];
+
+const GEOGRAPHY_PATTERNS = [
+  /(?:based in|from|lives in|located in|residing in)\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)?)/gi,
+  /\b([A-Z][a-z]+),\s*([A-Z]{2})\b/g,
+  /\b([A-Z][a-z]+),\s*([A-Z][a-z]+(?:\s+[A-Z][a-z]+)?)\b/g,
+];
+
+const ROLE_PATTERNS = [
+  /\b(CEO|CFO|CTO|COO|CMO|CIO|VP|President|Director|Manager|Partner|Founder|Co-founder|Chairman|Board Member|Advisor|Consultant|Principal|Associate|Analyst|Engineer|Developer)\s*(?:of|at|for)?\b/gi,
+  /(?:works as|serves as|role is|position is|title is)\s+(?:a\s+)?([A-Za-z\s]+?)(?:\s+at|\s+for|\.|,|$)/gi,
+];
+
+const COMMUNITY_PATTERNS = [
+  /(?:member of|part of|belongs to|joined|active in)\s+(?:the\s+)?([A-Za-z\s]+?)(?:\s+(?:chapter|group|club|organization|network))?(?:\.|,|$)/gi,
+  /(?:on the board of|board member of|serves on)\s+(?:the\s+)?([A-Za-z\s]+?)(?:\.|,|$)/gi,
+];
+
+// ----- Reference Sets -----
+
+const MAJOR_CITIES = new Set([
+  'new york', 'los angeles', 'chicago', 'houston', 'phoenix',
+  'philadelphia', 'san antonio', 'san diego', 'dallas', 'san jose',
+  'austin', 'jacksonville', 'fort worth', 'columbus', 'charlotte',
+  'san francisco', 'indianapolis', 'seattle', 'denver', 'boston',
+  'el paso', 'nashville', 'detroit', 'portland', 'las vegas',
+  'miami', 'atlanta', 'palm beach', 'west palm beach', 'tampa',
+  'orlando', 'sarasota', 'naples', 'fort lauderdale',
+]);
+
+const US_STATES = new Set([
+  'AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', 'FL', 'GA',
+  'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'ME', 'MD',
+  'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NH', 'NJ',
+  'NM', 'NY', 'NC', 'ND', 'OH', 'OK', 'OR', 'PA', 'RI', 'SC',
+  'SD', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY', 'DC',
+]);
+
+const KNOWN_COMMUNITIES = new Set([
+  'ypo', 'eo', 'entrepreneurs organization', 'vistage',
+  'young presidents organization', 'rotary', 'lions club',
+  'chamber of commerce', 'bni', 'business network international',
+]);
+
+const INDUSTRY_KEYWORDS = {
+  'real estate': ['real estate', 'property', 'housing', 'commercial real estate', 'residential', 'realty'],
+  'finance': ['finance', 'investment', 'banking', 'financial', 'hedge fund', 'private equity', 'venture capital', 'vc'],
+  'technology': ['technology', 'tech', 'software', 'saas', 'ai', 'artificial intelligence', 'machine learning', 'startup'],
+  'healthcare': ['healthcare', 'health', 'medical', 'pharma', 'pharmaceutical', 'biotech', 'hospital'],
+  'consulting': ['consulting', 'advisory', 'strategy', 'management consulting'],
+  'legal': ['legal', 'law', 'attorney', 'lawyer', 'law firm'],
+  'marketing': ['marketing', 'advertising', 'media', 'digital marketing', 'branding'],
+  'retail': ['retail', 'e-commerce', 'ecommerce', 'consumer goods'],
+  'manufacturing': ['manufacturing', 'industrial', 'production'],
+  'energy': ['energy', 'oil', 'gas', 'renewable', 'solar', 'utilities'],
+  'education': ['education', 'edtech', 'university', 'school', 'academic'],
+  'hospitality': ['hospitality', 'hotel', 'restaurant', 'food service'],
+};
+
+const STOP_WORDS = new Set([
+  'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday',
+  'january', 'february', 'march', 'april', 'may', 'june',
+  'july', 'august', 'september', 'october', 'november', 'december',
+  'today', 'tomorrow', 'yesterday', 'morning', 'afternoon', 'evening', 'night',
+  'the', 'this', 'that', 'these', 'those', 'here', 'there',
+  'where', 'when', 'what', 'which', 'who', 'how',
+  'just', 'only', 'also', 'even', 'still',
+]);
+
+// ----- Helpers -----
+
+function titleCase(s) {
+  return s.replace(/\b\w/g, c => c.toUpperCase());
+}
+
+/** Normalize entity name for matching (remove titles, lowercase, trim). */
+export function canonicalName(name) {
+  return name.replace(/^(?:Dr\.?|Mr\.?|Mrs\.?|Ms\.?|Prof\.?)\s*/i, '').toLowerCase().trim();
+}
+
+function matchAll(pattern, text) {
+  const re = new RegExp(pattern.source, pattern.flags.includes('g') ? pattern.flags : pattern.flags + 'g');
+  const results = [];
+  let m;
+  while ((m = re.exec(text)) !== null) {
+    results.push(m);
+  }
+  return results;
+}
+
+// ----- Entity Extraction -----
+
+/**
+ * Extract named entities from text using regex patterns.
+ * @param {string} text
+ * @returns {{ name: string, type: string, canonical_name: string, confidence: number }[]}
+ */
+export function extractEntities(text) {
+  const entities = [];
+  const seenCanonical = new Set();
+
+  function add(name, type, confidence) {
+    const cn = canonicalName(name);
+    if (!cn || cn.length <= 1 || STOP_WORDS.has(cn) || seenCanonical.has(cn)) return;
+    seenCanonical.add(cn);
+    entities.push({ name, type, canonical_name: cn, confidence });
+  }
+
+  for (const pat of PERSON_PATTERNS) {
+    for (const m of matchAll(pat, text)) {
+      add(m[1] || m[0], 'person', 0.6);
+    }
+  }
+
+  for (const pat of ORGANIZATION_PATTERNS) {
+    for (const m of matchAll(pat, text)) {
+      add(m[1] || m[0], 'organization', 0.5);
+    }
+  }
+
+  for (const pat of PROJECT_PATTERNS) {
+    for (const m of matchAll(pat, text)) {
+      const name = m[1] || m[0];
+      const cn = canonicalName(name);
+      if (cn.length > 2) add(name, 'project', 0.5);
+    }
+  }
+
+  return entities;
+}
+
+/**
+ * Extract memories/facts from text (commitments, preferences).
+ * @param {string} text
+ * @param {string[]} [entityNames] - Known entity names for linking
+ * @returns {{ content: string, type: string, entities: string[], confidence: number }[]}
+ */
+export function extractMemories(text, entityNames = []) {
+  const memories = [];
+
+  for (const pat of COMMITMENT_PATTERNS) {
+    for (const m of matchAll(pat, text)) {
+      const content = m[0].trim();
+      if (content.length > 10) {
+        const related = entityNames.filter(e => content.toLowerCase().includes(e.toLowerCase()));
+        memories.push({ content, type: 'commitment', entities: related, confidence: 0.7 });
+      }
+    }
+  }
+
+  for (const pat of PREFERENCE_PATTERNS) {
+    for (const m of matchAll(pat, text)) {
+      const content = m[0].trim();
+      if (content.length > 10) {
+        const related = entityNames.filter(e => content.toLowerCase().includes(e.toLowerCase()));
+        memories.push({ content, type: 'preference', entities: related, confidence: 0.6 });
+      }
+    }
+  }
+
+  return memories;
+}
+
+/**
+ * Extract both entities and memories from text.
+ * @param {string} text
+ * @returns {{ entities: object[], memories: object[] }}
+ */
+export function extractAll(text) {
+  const entities = extractEntities(text);
+  const entityNames = entities.map(e => e.name);
+  const memories = extractMemories(text, entityNames);
+  return { entities, memories };
+}
+
+// ----- Attribute Extraction -----
+
+/**
+ * Extract structured attributes from text about an entity.
+ * @param {string} text
+ * @returns {{ geography: object|null, industries: string[]|null, role: string|null, company: string|null, communities: string[]|null }}
+ */
+export function extractAttributes(text) {
+  return {
+    geography: _extractGeography(text),
+    industries: _extractIndustries(text) || null,
+    role: _extractRole(text),
+    company: _extractCompany(text),
+    communities: _extractCommunities(text) || null,
+  };
+}
+
+function _extractGeography(text) {
+  const textLower = text.toLowerCase();
+
+  for (const city of MAJOR_CITIES) {
+    if (textLower.includes(city)) {
+      const cityTitle = titleCase(city);
+      const escaped = cityTitle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const stateMatch = text.match(new RegExp(`${escaped},?\\s*([A-Z]{2})\\b`, 'i'));
+      if (stateMatch && US_STATES.has(stateMatch[1].toUpperCase())) {
+        return { city: cityTitle, state: stateMatch[1].toUpperCase(), country: 'US' };
+      }
+      return { city: cityTitle, country: 'US' };
+    }
+  }
+
+  for (const pat of GEOGRAPHY_PATTERNS) {
+    const m = matchAll(pat, text)[0];
+    if (m) {
+      if (m[2]) {
+        const state = m[2].trim().toUpperCase();
+        if (US_STATES.has(state)) {
+          return { city: m[1].trim(), state, country: 'US' };
+        }
+        return { city: m[1].trim(), state: m[2].trim() };
+      }
+      return { city: m[1].trim() };
+    }
+  }
+
+  return null;
+}
+
+function _extractIndustries(text) {
+  const textLower = text.toLowerCase();
+  const industries = [];
+  for (const [industry, keywords] of Object.entries(INDUSTRY_KEYWORDS)) {
+    for (const kw of keywords) {
+      if (textLower.includes(kw)) {
+        if (!industries.includes(industry)) industries.push(industry);
+        break;
+      }
+    }
+  }
+  return industries.length > 0 ? industries : null;
+}
+
+function _extractRole(text) {
+  for (const pat of ROLE_PATTERNS) {
+    const m = matchAll(pat, text)[0];
+    if (m) {
+      const role = (m[1] || m[0]).trim();
+      if (role.length > 1 && !STOP_WORDS.has(role.toLowerCase())) {
+        return titleCase(role);
+      }
+    }
+  }
+  return null;
+}
+
+function _extractCompany(text) {
+  const patterns = [
+    /(?:works at|employed by|CEO of|founder of|partner at|director at)\s+([A-Z][A-Za-z]+(?:\s+[A-Z][A-Za-z]+)*)/g,
+    /\bat\s+([A-Z][A-Za-z]+(?:\s+(?:Inc|Corp|LLC|Ltd|Co|Company|Group|Partners))?\.?)\b/g,
+  ];
+  for (const pat of patterns) {
+    const m = matchAll(pat, text)[0];
+    if (m) {
+      const company = (m[1] || m[0]).trim();
+      if (company.length > 1 && !STOP_WORDS.has(company.toLowerCase())) return company;
+    }
+  }
+  return null;
+}
+
+function _extractCommunities(text) {
+  const textLower = text.toLowerCase();
+  const communities = [];
+
+  for (const c of KNOWN_COMMUNITIES) {
+    if (textLower.includes(c)) {
+      communities.push(c.length <= 3 ? c.toUpperCase() : titleCase(c));
+    }
+  }
+
+  for (const pat of COMMUNITY_PATTERNS) {
+    for (const m of matchAll(pat, text)) {
+      const name = (m[1] || m[0]).trim();
+      if (name.length > 2 && !STOP_WORDS.has(name.toLowerCase())) {
+        if (!communities.some(c => c.toLowerCase() === name.toLowerCase())) {
+          communities.push(titleCase(name));
+        }
+      }
+    }
+  }
+
+  return communities.length > 0 ? communities : null;
+}

--- a/cli/services/ingest.js
+++ b/cli/services/ingest.js
@@ -1,0 +1,176 @@
+/**
+ * Ingest service for Claudia CLI.
+ * Port of memory-daemon/claudia_memory/services/ingest.py.
+ *
+ * Uses a local language model (via Ollama) to extract structured data from
+ * raw text: meeting transcripts, emails, documents, notes.
+ *
+ * When no language model is available, returns a fallback response so
+ * Claude handles the extraction directly (current behavior).
+ */
+
+import { generate } from '../core/language-model.js';
+
+// ----- Extraction Prompts -----
+
+const SYSTEM_BASE = `/no_think
+You are a structured data extraction assistant. You receive raw text and
+extract entities, facts, commitments, and action items into JSON.
+
+RULES:
+- Return ONLY valid JSON. No markdown, no commentary, no explanation.
+- Use the exact schema provided.
+- If a field has no matches, use an empty array [].
+- For importance scores: 1.0 = critical, 0.7 = notable, 0.4 = minor.
+- For entity types: person, organization, project, concept, location.
+- For memory types: fact, preference, observation, commitment, learning.
+`;
+
+const PROMPTS = {
+  meeting: SYSTEM_BASE + `
+You are extracting structured data from a MEETING TRANSCRIPT.
+
+Return JSON with this exact schema:
+{
+  "participants": [{"name": "string", "role": "string or null"}],
+  "key_decisions": [{"decision": "string", "made_by": "string or null"}],
+  "action_items": [{"task": "string", "owner": "string or null", "deadline": "string or null"}],
+  "commitments": [{"content": "string", "who": "string", "importance": number}],
+  "facts": [{"content": "string", "type": "string", "about": ["string"], "importance": number}],
+  "entities": [{"name": "string", "type": "string", "description": "string or null"}],
+  "relationships": [{"source": "string", "target": "string", "relationship": "string"}],
+  "topics": ["string"],
+  "sentiment_summary": "string"
+}
+`,
+
+  email: SYSTEM_BASE + `
+You are extracting structured data from an EMAIL.
+
+Return JSON with this exact schema:
+{
+  "from": "string or null",
+  "to": ["string"],
+  "cc": ["string"],
+  "date": "string or null",
+  "subject": "string or null",
+  "action_items": [{"task": "string", "owner": "string or null", "deadline": "string or null"}],
+  "commitments": [{"content": "string", "who": "string", "importance": number}],
+  "facts": [{"content": "string", "type": "string", "about": ["string"], "importance": number}],
+  "entities": [{"name": "string", "type": "string", "description": "string or null"}],
+  "relationships": [{"source": "string", "target": "string", "relationship": "string"}],
+  "tone": "string",
+  "summary": "string"
+}
+`,
+
+  document: SYSTEM_BASE + `
+You are extracting structured data from a DOCUMENT or article.
+
+Return JSON with this exact schema:
+{
+  "title": "string or null",
+  "author": "string or null",
+  "facts": [{"content": "string", "type": "string", "about": ["string"], "importance": number}],
+  "entities": [{"name": "string", "type": "string", "description": "string or null"}],
+  "relationships": [{"source": "string", "target": "string", "relationship": "string"}],
+  "key_points": ["string"],
+  "topics": ["string"],
+  "summary": "string"
+}
+`,
+
+  general: SYSTEM_BASE + `
+You are extracting structured data from RAW TEXT.
+
+Return JSON with this exact schema:
+{
+  "facts": [{"content": "string", "type": "string", "about": ["string"], "importance": number}],
+  "commitments": [{"content": "string", "who": "string or null", "importance": number}],
+  "action_items": [{"task": "string", "owner": "string or null", "deadline": "string or null"}],
+  "entities": [{"name": "string", "type": "string", "description": "string or null"}],
+  "relationships": [{"source": "string", "target": "string", "relationship": "string"}],
+  "topics": ["string"],
+  "summary": "string"
+}
+`,
+};
+
+// ----- JSON Parsing -----
+
+function parseJsonResponse(text) {
+  text = text.trim();
+
+  // Direct parse
+  try { return JSON.parse(text); } catch { /* continue */ }
+
+  // Strip markdown code fences
+  if (text.startsWith('```')) {
+    const lines = text.split('\n').filter(l => !l.trim().startsWith('```'));
+    text = lines.join('\n').trim();
+    try { return JSON.parse(text); } catch { /* continue */ }
+  }
+
+  // Extract first { ... } block
+  const start = text.indexOf('{');
+  const end = text.lastIndexOf('}');
+  if (start !== -1 && end !== -1 && end > start) {
+    try { return JSON.parse(text.slice(start, end + 1)); } catch { /* continue */ }
+  }
+
+  return null;
+}
+
+// ----- Ingest Function -----
+
+/**
+ * Extract structured data from raw text using a local language model.
+ * @param {string} text - Raw text to process
+ * @param {object} [options]
+ * @param {string} [options.sourceType='general'] - One of: meeting, email, document, general
+ * @param {string} [options.context] - Optional extra context for extraction
+ * @returns {Promise<object>} Extraction result with status, data, raw_text
+ */
+export async function ingest(text, { sourceType = 'general', context } = {}) {
+  const systemPrompt = PROMPTS[sourceType] || PROMPTS.general;
+
+  let prompt = text;
+  if (context) {
+    prompt = `Context: ${context}\n\n---\n\n${text}`;
+  }
+
+  // Generate structured extraction
+  const rawOutput = await generate(prompt, {
+    system: systemPrompt,
+    temperature: 0.1,
+    formatJson: true,
+  });
+
+  if (rawOutput === null) {
+    return {
+      status: 'llm_unavailable',
+      source_type: sourceType,
+      data: null,
+      raw_text: text,
+    };
+  }
+
+  // Parse JSON response
+  const parsed = parseJsonResponse(rawOutput);
+  if (parsed === null) {
+    return {
+      status: 'parse_error',
+      source_type: sourceType,
+      data: null,
+      raw_text: text,
+      raw_output: rawOutput,
+    };
+  }
+
+  return {
+    status: 'extracted',
+    source_type: sourceType,
+    data: parsed,
+    raw_text: text,
+  };
+}

--- a/cli/services/recall.js
+++ b/cli/services/recall.js
@@ -1,0 +1,2683 @@
+/**
+ * Recall service for Claudia CLI.
+ * Port of memory-daemon/claudia_memory/services/recall.py.
+ *
+ * Handles semantic search and retrieval of memories, entities, and relationships.
+ * Uses vector similarity (sqlite-vec) combined with FTS5, importance, and recency scoring.
+ *
+ * Functions that need embeddings are async; pure SQL queries are sync.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { canonicalName } from './extraction.js';
+import { embed } from '../core/embeddings.js';
+
+// ---------------------------------------------------------------------------
+// Internal state
+// ---------------------------------------------------------------------------
+
+let _vec0Warned = false;
+
+// ---------------------------------------------------------------------------
+// Helper: safe row field access
+// ---------------------------------------------------------------------------
+
+/** Get a value from a row, returning fallback if key doesn't exist. */
+function rowGet(row, key, fallback = null) {
+  return row[key] !== undefined ? row[key] : fallback;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: scoring math
+// ---------------------------------------------------------------------------
+
+/** Compute recency score using exponential half-life decay. */
+function recencyScore(createdAt, now, halfLifeDays) {
+  const created = new Date(createdAt);
+  const daysOld = (now - created) / (1000 * 60 * 60 * 24);
+  const decay = Math.log(2) / halfLifeDays;
+  return Math.exp(-decay * daysOld);
+}
+
+// ---------------------------------------------------------------------------
+// Helper: format result objects
+// ---------------------------------------------------------------------------
+
+/** Convert a memory row + scores into a recall result with combined scoring. */
+function rowToResult(row, vectorScore, ftsScore, now, config) {
+  const importanceScore = row.importance;
+
+  // Recency score (configurable half-life decay)
+  const created = new Date(row.created_at);
+  const daysOld = (now - created) / (1000 * 60 * 60 * 24);
+  const rec = Math.exp(-daysOld / config.recency_half_life_days);
+
+  // Combined weighted score (vector + FTS + importance + recency)
+  let combinedScore =
+    config.vector_weight * vectorScore +
+    config.fts_weight * ftsScore +
+    config.importance_weight * importanceScore +
+    config.recency_weight * rec;
+
+  // Sacred memory boost: +50% importance weight component
+  const lifecycleTier = rowGet(row, 'lifecycle_tier');
+  if (lifecycleTier === 'sacred') {
+    combinedScore += config.importance_weight * 0.5;
+  }
+
+  // Parse entity names
+  const entityNamesVal = rowGet(row, 'entity_names');
+  const entities = entityNamesVal
+    ? entityNamesVal.split(',').map(n => n.trim())
+    : [];
+
+  // Parse metadata
+  const metadataVal = rowGet(row, 'metadata');
+  let metadata = null;
+  if (metadataVal) {
+    try { metadata = JSON.parse(metadataVal); } catch { /* ignore */ }
+  }
+
+  return {
+    id: row.id,
+    content: row.content,
+    type: row.type,
+    score: combinedScore,
+    importance: row.importance,
+    created_at: row.created_at,
+    entities,
+    metadata,
+    source: rowGet(row, 'source'),
+    source_id: rowGet(row, 'source_id'),
+    source_context: rowGet(row, 'source_context'),
+    confidence: rowGet(row, 'confidence', 1.0),
+    verification_status: rowGet(row, 'verification_status', 'pending'),
+    origin_type: rowGet(row, 'origin_type', 'inferred'),
+    source_channel: rowGet(row, 'source_channel'),
+    lifecycle_tier: lifecycleTier,
+    fact_id: rowGet(row, 'fact_id'),
+  };
+}
+
+/** Convert a database row to a recall result without scoring.
+ *  Used by temporal recall methods. */
+function rowToSimpleResult(row) {
+  const entityStr = rowGet(row, 'entity_names', '');
+  let metadata = null;
+  const metadataVal = rowGet(row, 'metadata');
+  if (metadataVal) {
+    try { metadata = JSON.parse(metadataVal); } catch { /* ignore */ }
+  }
+
+  return {
+    id: row.id,
+    content: row.content,
+    type: row.type,
+    score: row.importance,
+    importance: row.importance,
+    created_at: row.created_at,
+    entities: entityStr ? entityStr.split(',').map(s => s.trim()) : [],
+    metadata,
+    source: rowGet(row, 'source'),
+    source_id: rowGet(row, 'source_id'),
+    source_context: rowGet(row, 'source_context'),
+    confidence: rowGet(row, 'confidence', 1.0),
+    verification_status: rowGet(row, 'verification_status', 'pending'),
+    origin_type: rowGet(row, 'origin_type', 'inferred'),
+    source_channel: rowGet(row, 'source_channel'),
+    lifecycle_tier: rowGet(row, 'lifecycle_tier'),
+    fact_id: rowGet(row, 'fact_id'),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers (pure SQL, synchronous)
+// ---------------------------------------------------------------------------
+
+/** Apply common filters to SQL query (mutates sqlParts and params). */
+function applyFilters(db, sqlParts, params, {
+  memoryTypes,
+  minImportance,
+  dateAfter,
+  dateBefore,
+  aboutEntity,
+  includeArchived = false,
+} = {}) {
+  sqlParts.push('AND m.invalidated_at IS NULL');
+
+  if (!includeArchived) {
+    sqlParts.push("AND (m.lifecycle_tier IS NULL OR m.lifecycle_tier != 'archived')");
+  }
+
+  // View-as-of temporal filter for rollback support
+  try {
+    const viewRow = db.queryOne("SELECT value FROM _meta WHERE key = 'view_as_of'");
+    if (viewRow && viewRow.value) {
+      sqlParts.push('AND m.created_at <= ?');
+      params.push(viewRow.value);
+    }
+  } catch {
+    // _meta table may not exist on very old schemas
+  }
+
+  if (memoryTypes && memoryTypes.length > 0) {
+    const placeholders = memoryTypes.map(() => '?').join(', ');
+    sqlParts.push(`AND m.type IN (${placeholders})`);
+    params.push(...memoryTypes);
+  }
+
+  if (minImportance != null) {
+    sqlParts.push('AND m.importance >= ?');
+    params.push(minImportance);
+  }
+
+  if (dateAfter) {
+    sqlParts.push('AND m.created_at >= ?');
+    params.push(typeof dateAfter === 'string' ? dateAfter : dateAfter.toISOString());
+  }
+
+  if (dateBefore) {
+    sqlParts.push('AND m.created_at <= ?');
+    params.push(typeof dateBefore === 'string' ? dateBefore : dateBefore.toISOString());
+  }
+
+  if (aboutEntity) {
+    const canonical = canonicalName(aboutEntity);
+    sqlParts.push('AND e.canonical_name = ?');
+    params.push(canonical);
+  }
+}
+
+/** FTS5 full-text search with BM25 scoring. Returns Map<memoryId, normalizedScore>. */
+function ftsSearch(db, query, limit, memoryTypes, minImportance) {
+  try {
+    let sql = `
+      SELECT m.id, fts.rank
+      FROM memories_fts fts
+      JOIN memories m ON m.id = fts.rowid
+      WHERE memories_fts MATCH ?
+      AND m.invalidated_at IS NULL
+      AND (m.lifecycle_tier IS NULL OR m.lifecycle_tier != 'archived')
+    `;
+    const params = [query];
+
+    if (memoryTypes && memoryTypes.length > 0) {
+      const ph = memoryTypes.map(() => '?').join(', ');
+      sql += ` AND m.type IN (${ph})`;
+      params.push(...memoryTypes);
+    }
+
+    if (minImportance != null) {
+      sql += ' AND m.importance >= ?';
+      params.push(minImportance);
+    }
+
+    sql += ' ORDER BY fts.rank LIMIT ?';
+    params.push(limit);
+
+    const rows = db.query(sql, params);
+    if (!rows || rows.length === 0) return {};
+
+    // Normalize FTS5 rank scores to 0-1 range
+    // FTS5 rank is BM25: negative float, closer to 0 = better match
+    const ranks = rows.map(r => r.rank);
+    const minRank = Math.min(...ranks); // best match (most negative)
+    const maxRank = Math.max(...ranks); // worst match (closest to 0)
+
+    const result = {};
+    for (const row of rows) {
+      if (minRank === maxRank) {
+        result[row.id] = 1.0;
+      } else {
+        result[row.id] = (row.rank - maxRank) / (minRank - maxRank);
+      }
+    }
+    return result;
+  } catch {
+    return {};
+  }
+}
+
+/** Fallback keyword-based search. Tries FTS5 MATCH first, then LIKE. */
+function keywordSearch(db, query, limit, memoryTypes, minImportance) {
+  // Try FTS5 first
+  try {
+    let sql = `
+      SELECT m.*, GROUP_CONCAT(e.name) as entity_names
+      FROM memories_fts fts
+      JOIN memories m ON m.id = fts.rowid
+      LEFT JOIN memory_entities me ON m.id = me.memory_id
+      LEFT JOIN entities e ON me.entity_id = e.id
+      WHERE memories_fts MATCH ?
+      AND m.invalidated_at IS NULL
+      AND (m.lifecycle_tier IS NULL OR m.lifecycle_tier != 'archived')
+    `;
+    const params = [query];
+
+    if (memoryTypes && memoryTypes.length > 0) {
+      const ph = memoryTypes.map(() => '?').join(', ');
+      sql += ` AND m.type IN (${ph})`;
+      params.push(...memoryTypes);
+    }
+
+    if (minImportance != null) {
+      sql += ' AND m.importance >= ?';
+      params.push(minImportance);
+    }
+
+    sql += ' GROUP BY m.id ORDER BY fts.rank LIMIT ?';
+    params.push(limit);
+
+    const rows = db.query(sql, params);
+    if (rows && rows.length > 0) return rows;
+  } catch {
+    // FTS5 not available, fall through to LIKE
+  }
+
+  // Final fallback: LIKE search
+  let sql = `
+    SELECT m.*, GROUP_CONCAT(e.name) as entity_names
+    FROM memories m
+    LEFT JOIN memory_entities me ON m.id = me.memory_id
+    LEFT JOIN entities e ON me.entity_id = e.id
+    WHERE m.content LIKE ?
+    AND m.invalidated_at IS NULL
+    AND (m.lifecycle_tier IS NULL OR m.lifecycle_tier != 'archived')
+  `;
+  const params = [`%${query}%`];
+
+  if (memoryTypes && memoryTypes.length > 0) {
+    const ph = memoryTypes.map(() => '?').join(', ');
+    sql += ` AND m.type IN (${ph})`;
+    params.push(...memoryTypes);
+  }
+
+  if (minImportance != null) {
+    sql += ' AND m.importance >= ?';
+    params.push(minImportance);
+  }
+
+  sql += ' GROUP BY m.id ORDER BY m.importance DESC, m.created_at DESC LIMIT ?';
+  params.push(limit);
+
+  return db.query(sql, params) || [];
+}
+
+/** Update access counts for rehearsal effect. */
+function updateAccessCounts(db, results, now) {
+  const isoNow = now.toISOString();
+  for (const result of results) {
+    try {
+      db.run(
+        'UPDATE memories SET last_accessed_at = ?, access_count = access_count + 1 WHERE id = ?',
+        [isoNow, result.id],
+      );
+    } catch {
+      // Non-fatal
+    }
+  }
+}
+
+/** Reciprocal Rank Fusion across multiple ranking signals. */
+function rrfScore(memoryIds, signalRankings, k = 60) {
+  const scores = {};
+  for (const mid of memoryIds) {
+    scores[mid] = 0.0;
+  }
+  for (const rankedIds of Object.values(signalRankings)) {
+    for (let rank = 0; rank < rankedIds.length; rank++) {
+      const mid = rankedIds[rank];
+      if (mid in scores) {
+        scores[mid] += 1.0 / (k + rank + 1);
+      }
+    }
+  }
+  return scores;
+}
+
+/** Resolve entity IDs from text by matching canonical names and aliases. */
+function resolveEntitiesFromText(db, text) {
+  if (!text || text.trim().length < 2) return [];
+
+  const textLower = text.toLowerCase();
+  const entityIds = [];
+
+  try {
+    const entities = db.query(
+      'SELECT id, canonical_name FROM entities WHERE importance > 0.05',
+    ) || [];
+
+    for (const entity of entities) {
+      const canonical = entity.canonical_name;
+      if (canonical && canonical.length > 1) {
+        const escaped = canonical.toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const re = new RegExp(`\\b${escaped}\\b`);
+        if (re.test(textLower)) {
+          entityIds.push(entity.id);
+        }
+      }
+    }
+
+    // Also check aliases if no matches from canonical names
+    if (entityIds.length === 0) {
+      try {
+        const aliases = db.query(
+          'SELECT entity_id, canonical_alias FROM entity_aliases',
+        ) || [];
+        for (const alias of aliases) {
+          const aliasVal = alias.canonical_alias;
+          if (aliasVal && aliasVal.length > 1) {
+            const escaped = aliasVal.toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            const re = new RegExp(`\\b${escaped}\\b`);
+            if (re.test(textLower)) {
+              entityIds.push(alias.entity_id);
+            }
+          }
+        }
+      } catch {
+        // entity_aliases table may not exist
+      }
+    }
+  } catch {
+    // Graceful degradation
+  }
+
+  return [...new Set(entityIds)];
+}
+
+/** Traverse the relationship graph with strength-aware scoring. */
+function expandGraphWeighted(db, entityId, depth = 2, limitPerHop = 15) {
+  try {
+    const directRows = db.query(
+      `SELECT DISTINCT
+        CASE WHEN r.source_entity_id = ? THEN r.target_entity_id
+             ELSE r.source_entity_id END as neighbor_id,
+        e.name, e.type, e.importance,
+        r.strength as rel_strength,
+        r.relationship_type
+      FROM relationships r
+      JOIN entities e ON e.id = CASE
+        WHEN r.source_entity_id = ? THEN r.target_entity_id
+        ELSE r.source_entity_id END
+      WHERE (r.source_entity_id = ? OR r.target_entity_id = ?)
+        AND r.strength > 0.1
+        AND r.invalid_at IS NULL
+        AND e.importance > 0.05
+        AND e.id != ?
+      ORDER BY r.strength DESC, e.importance DESC
+      LIMIT ?`,
+      [entityId, entityId, entityId, entityId, entityId, limitPerHop],
+    ) || [];
+
+    const connected = [];
+    const seenIds = new Set([entityId]);
+
+    for (const row of directRows) {
+      const nid = row.neighbor_id;
+      if (seenIds.has(nid)) continue;
+      seenIds.add(nid);
+      connected.push({
+        id: nid,
+        name: row.name,
+        type: row.type,
+        importance: row.importance,
+        distance: 1,
+        path_strength: row.rel_strength,
+        via_relationship: row.relationship_type,
+      });
+    }
+
+    // Second hop if requested
+    if (depth >= 2) {
+      const hop1Slice = connected.slice(0, 10); // Limit fan-out
+      for (const hop1 of hop1Slice) {
+        const hop2Rows = db.query(
+          `SELECT DISTINCT
+            CASE WHEN r.source_entity_id = ? THEN r.target_entity_id
+                 ELSE r.source_entity_id END as neighbor_id,
+            e.name, e.type, e.importance,
+            r.strength as rel_strength,
+            r.relationship_type
+          FROM relationships r
+          JOIN entities e ON e.id = CASE
+            WHEN r.source_entity_id = ? THEN r.target_entity_id
+            ELSE r.source_entity_id END
+          WHERE (r.source_entity_id = ? OR r.target_entity_id = ?)
+            AND r.strength > 0.1
+            AND r.invalid_at IS NULL
+            AND e.importance > 0.05
+            AND e.id != ?
+          ORDER BY r.strength DESC
+          LIMIT ?`,
+          [hop1.id, hop1.id, hop1.id, hop1.id, entityId, Math.floor(limitPerHop / 2)],
+        ) || [];
+
+        for (const row of hop2Rows) {
+          const nid = row.neighbor_id;
+          if (seenIds.has(nid)) continue;
+          seenIds.add(nid);
+          // Path strength is product of edge strengths
+          const pathStrength = hop1.path_strength * row.rel_strength;
+          connected.push({
+            id: nid,
+            name: row.name,
+            type: row.type,
+            importance: row.importance,
+            distance: 2,
+            path_strength: pathStrength,
+            via_relationship: row.relationship_type,
+          });
+        }
+      }
+    }
+
+    return connected;
+  } catch {
+    return [];
+  }
+}
+
+/** Compute graph proximity scores for candidate memories. */
+function computeGraphScores(db, config, query, candidateIds) {
+  if (!config.graph_proximity_enabled || candidateIds.size === 0) return {};
+
+  const queryEntityIds = resolveEntitiesFromText(db, query);
+  if (queryEntityIds.length === 0) return {};
+
+  const scores = {};
+
+  try {
+    // Build entity -> (hop_distance, path_strength) mapping
+    const entityProximity = new Map();
+    for (const eid of queryEntityIds) {
+      entityProximity.set(eid, { distance: 0, pathStrength: 1.0 });
+
+      const neighbors = expandGraphWeighted(db, eid, 2, 15);
+      for (const neighbor of neighbors) {
+        const nid = neighbor.id;
+        const dist = neighbor.distance || 1;
+        const pathStrength = neighbor.path_strength || 0.5;
+        const existing = entityProximity.get(nid);
+        if (!existing || dist < existing.distance) {
+          entityProximity.set(nid, { distance: dist, pathStrength });
+        } else if (dist === existing.distance && pathStrength > existing.pathStrength) {
+          entityProximity.set(nid, { distance: dist, pathStrength });
+        }
+      }
+    }
+
+    // Score each candidate memory by its entity links
+    const idArr = [...candidateIds];
+    const placeholders = idArr.map(() => '?').join(', ');
+    const memEntities = db.query(
+      `SELECT memory_id, entity_id FROM memory_entities WHERE memory_id IN (${placeholders})`,
+      idArr,
+    ) || [];
+
+    for (const row of memEntities) {
+      const mid = row.memory_id;
+      const eid = row.entity_id;
+      const prox = entityProximity.get(eid);
+      if (prox) {
+        let score;
+        if (prox.distance === 0) {
+          score = 1.0;
+        } else if (prox.distance === 1) {
+          score = 0.5 + 0.3 * prox.pathStrength; // 0.5-0.8
+        } else {
+          score = 0.2 + 0.3 * prox.pathStrength; // 0.2-0.5
+        }
+        scores[mid] = Math.max(scores[mid] || 0.0, score);
+      }
+    }
+
+    // Multi-entity bonus
+    if (queryEntityIds.length > 1) {
+      const memEntityHits = {};
+      for (const row of memEntities) {
+        if (entityProximity.has(row.entity_id)) {
+          memEntityHits[row.memory_id] = (memEntityHits[row.memory_id] || 0) + 1;
+        }
+      }
+      for (const [mid, hitCount] of Object.entries(memEntityHits)) {
+        if (hitCount > 1 && mid in scores) {
+          scores[mid] = Math.min(1.0, scores[mid] * (1.0 + 0.15 * (hitCount - 1)));
+        }
+      }
+    }
+  } catch {
+    // Graceful degradation
+  }
+
+  return scores;
+}
+
+/** Expand graph using recursive CTE (simple, for recallAbout). */
+function expandGraph(db, entityId, depth = 1, limitPerHop = 3) {
+  try {
+    const rows = db.query(
+      `WITH RECURSIVE graph(entity_id, hop) AS (
+        SELECT CASE
+          WHEN r.source_entity_id = ? THEN r.target_entity_id
+          ELSE r.source_entity_id
+        END, 1
+        FROM relationships r
+        WHERE (r.source_entity_id = ? OR r.target_entity_id = ?)
+          AND r.strength > 0.1
+
+        UNION
+
+        SELECT CASE
+          WHEN r.source_entity_id = g.entity_id THEN r.target_entity_id
+          ELSE r.source_entity_id
+        END, g.hop + 1
+        FROM relationships r
+        JOIN graph g ON (r.source_entity_id = g.entity_id OR r.target_entity_id = g.entity_id)
+        WHERE g.hop < ?
+          AND r.strength > 0.1
+          AND CASE
+            WHEN r.source_entity_id = g.entity_id THEN r.target_entity_id
+            ELSE r.source_entity_id
+          END != ?
+      )
+      SELECT DISTINCT e.id, e.name, e.type, e.description, e.importance,
+             MIN(g.hop) as distance
+      FROM graph g
+      JOIN entities e ON g.entity_id = e.id
+      WHERE e.id != ? AND e.importance > 0.1
+      GROUP BY e.id
+      ORDER BY distance ASC, e.importance DESC
+      LIMIT ?`,
+      [entityId, entityId, entityId, depth, entityId, entityId, limitPerHop * depth],
+    ) || [];
+
+    const connected = [];
+    for (const row of rows) {
+      const memRows = db.query(
+        `SELECT m.content, m.type, m.importance
+         FROM memories m
+         JOIN memory_entities me ON m.id = me.memory_id
+         WHERE me.entity_id = ?
+         ORDER BY m.importance DESC
+         LIMIT 2`,
+        [row.id],
+      ) || [];
+
+      connected.push({
+        id: row.id,
+        name: row.name,
+        type: row.type,
+        description: row.description,
+        importance: row.importance,
+        distance: row.distance,
+        top_memories: memRows.map(m => ({ content: m.content, type: m.type })),
+      });
+    }
+
+    return connected;
+  } catch {
+    return [];
+  }
+}
+
+/** Name similarity using longest common subsequence ratio with first-letter boost. */
+function nameSimilarity(name1, name2) {
+  if (!name1 || !name2) return 0.0;
+
+  const a = name1.toLowerCase();
+  const b = name2.toLowerCase();
+
+  // Simple Levenshtein-based similarity (matches SequenceMatcher behavior reasonably)
+  const lenA = a.length;
+  const lenB = b.length;
+  if (lenA === 0 || lenB === 0) return 0.0;
+
+  // Use LCS-based ratio (equivalent to SequenceMatcher.ratio())
+  const dp = Array(lenA + 1).fill(null).map(() => Array(lenB + 1).fill(0));
+  for (let i = 1; i <= lenA; i++) {
+    for (let j = 1; j <= lenB; j++) {
+      if (a[i - 1] === b[j - 1]) {
+        dp[i][j] = dp[i - 1][j - 1] + 1;
+      } else {
+        dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+      }
+    }
+  }
+  const lcsLen = dp[lenA][lenB];
+  let ratio = (2.0 * lcsLen) / (lenA + lenB);
+
+  // First letter boost
+  if (a[0] === b[0]) {
+    ratio = Math.min(1.0, ratio + 0.05);
+  }
+
+  return ratio;
+}
+
+/** Build a human-readable provenance chain for a memory. */
+function buildProvenanceChain(memoryRow, traceResult) {
+  const chain = [];
+
+  // Step 1: Origin type
+  const origin = rowGet(memoryRow, 'origin_type', 'inferred');
+  const sourceChannel = rowGet(memoryRow, 'source_channel', 'claude_code');
+  chain.push({
+    type: 'origin',
+    label: `Origin: ${origin} via ${sourceChannel || 'claude_code'}`,
+    timestamp: memoryRow.created_at,
+  });
+
+  // Step 2: Source document (if linked)
+  if (traceResult.documents && traceResult.documents.length > 0) {
+    const doc = traceResult.documents[0];
+    chain.push({
+      type: 'source_document',
+      label: `Source: ${doc.source_type} - ${doc.filename}`,
+      timestamp: doc.created_at,
+    });
+  }
+
+  // Step 3: Episode context (if from a session)
+  if (traceResult.episode) {
+    const ep = traceResult.episode;
+    const topics = (ep.key_topics || []).slice(0, 3).join(', ') || 'general';
+    chain.push({
+      type: 'episode',
+      label: `Session (${topics})`,
+      timestamp: ep.started_at,
+    });
+  }
+
+  // Step 4: Source context breadcrumb
+  const sourceContext = rowGet(memoryRow, 'source_context');
+  if (sourceContext) {
+    chain.push({
+      type: 'context',
+      label: `Context: ${sourceContext}`,
+    });
+  }
+
+  // Step 5: Extracted fact
+  chain.push({
+    type: 'memory',
+    label: `Stored as ${memoryRow.type} (importance: ${memoryRow.importance.toFixed(2)}, confidence: ${memoryRow.confidence.toFixed(2)})`,
+    timestamp: memoryRow.created_at,
+  });
+
+  // Step 6: Corrections (if any)
+  const correctedAt = rowGet(memoryRow, 'corrected_at');
+  const correctedFrom = rowGet(memoryRow, 'corrected_from');
+  if (correctedAt) {
+    chain.push({
+      type: 'correction',
+      label: correctedFrom ? `Corrected: was '${correctedFrom.slice(0, 80)}...'` : 'Corrected by user',
+      timestamp: correctedAt,
+    });
+  }
+
+  // Step 7: Invalidation (if any)
+  const invalidatedAt = rowGet(memoryRow, 'invalidated_at');
+  const invalidatedReason = rowGet(memoryRow, 'invalidated_reason');
+  if (invalidatedAt) {
+    chain.push({
+      type: 'invalidation',
+      label: `Invalidated: ${invalidatedReason || 'no reason given'}`,
+      timestamp: invalidatedAt,
+    });
+  }
+
+  // Step 8: Related entities
+  if (traceResult.entities && traceResult.entities.length > 0) {
+    const entityNames = traceResult.entities.slice(0, 5).map(e => e.name);
+    chain.push({
+      type: 'entities',
+      label: `About: ${entityNames.join(', ')}`,
+    });
+  }
+
+  return chain;
+}
+
+// ===========================================================================
+// EXPORTED FUNCTIONS
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// 1. recall() -- THE CORE METHOD (async, needs embeddings)
+// ---------------------------------------------------------------------------
+
+/**
+ * Search memories using hybrid vector + FTS5 similarity and filters.
+ *
+ * @param {object} db - ClaudiaDatabase instance
+ * @param {object} config - Config object
+ * @param {string} query - Search query text
+ * @param {object} [options]
+ * @param {number} [options.limit] - Maximum results to return
+ * @param {string[]} [options.memoryTypes] - Filter by memory types
+ * @param {string} [options.aboutEntity] - Filter to memories about a specific entity
+ * @param {number} [options.minImportance] - Minimum importance threshold
+ * @param {boolean} [options.includeLowImportance=false] - Include memories below default threshold
+ * @param {string|Date} [options.dateAfter] - Only memories after this date
+ * @param {string|Date} [options.dateBefore] - Only memories before this date
+ * @param {boolean} [options.includeArchived=false] - Include archived memories
+ * @returns {Promise<object[]>} List of recall results ordered by relevance
+ */
+export async function recall(db, config, query, {
+  limit,
+  memoryTypes,
+  aboutEntity,
+  minImportance,
+  includeLowImportance = false,
+  dateAfter,
+  dateBefore,
+  includeArchived = false,
+} = {}) {
+  if (limit == null) limit = config.max_recall_results || 50;
+  if (minImportance == null && !includeLowImportance) {
+    minImportance = config.min_importance_threshold || 0.1;
+  }
+
+  // Get query embedding
+  const queryEmbedding = await embed(query);
+
+  // --- Vector search ---
+  const vectorScores = {};   // memoryId -> score
+  const vectorRows = {};     // memoryId -> row
+
+  if (queryEmbedding) {
+    const sqlParts = [
+      'SELECT m.*, GROUP_CONCAT(e.name) as entity_names, (1.0 / (1.0 + me.distance)) as vector_score',
+    ];
+    const params = [];
+    sqlParts.push(`
+      FROM memory_embeddings me
+      JOIN memories m ON m.id = me.memory_id
+      LEFT JOIN memory_entities me2 ON m.id = me2.memory_id
+      LEFT JOIN entities e ON me2.entity_id = e.id
+      WHERE me.embedding MATCH ?
+    `);
+    params.push(JSON.stringify(queryEmbedding));
+
+    applyFilters(db, sqlParts, params, {
+      memoryTypes, minImportance, dateAfter, dateBefore, aboutEntity, includeArchived,
+    });
+
+    sqlParts.push('GROUP BY m.id ORDER BY vector_score DESC LIMIT ?');
+    params.push(limit * 2);
+
+    try {
+      const rows = db.query(sqlParts.join('\n'), params) || [];
+      for (const row of rows) {
+        const mid = row.id;
+        vectorScores[mid] = row.vector_score || 0.0;
+        vectorRows[mid] = row;
+      }
+    } catch (e) {
+      if (!_vec0Warned) {
+        process.stderr.write(`[recall] Vector search failed (will fall back silently): ${e.message}\n`);
+        _vec0Warned = true;
+      }
+    }
+  }
+
+  // --- FTS5 search ---
+  const ftsScores = ftsSearch(db, query, limit * 2, memoryTypes, minImportance);
+
+  // --- Fallback: if neither vector nor FTS returned results, use keyword LIKE ---
+  const hasVectorResults = Object.keys(vectorScores).length > 0;
+  const hasFtsResults = Object.keys(ftsScores).length > 0;
+
+  if (!hasVectorResults && !hasFtsResults) {
+    const rows = keywordSearch(db, query, limit, memoryTypes, minImportance);
+    const now = new Date();
+    let results = rows.map(row => rowToResult(row, 0.5, 0.0, now, config));
+    results.sort((a, b) => b.score - a.score);
+    results = results.slice(0, limit);
+    updateAccessCounts(db, results, now);
+    return results;
+  }
+
+  // --- Merge: collect all memory IDs from both sources ---
+  const allIds = new Set([
+    ...Object.keys(vectorScores).map(Number),
+    ...Object.keys(ftsScores).map(Number),
+  ]);
+
+  // Fetch full rows for FTS-only results not already in vectorRows
+  const ftsOnlyIds = [...Object.keys(ftsScores).map(Number)].filter(id => !(id in vectorRows));
+  if (ftsOnlyIds.length > 0) {
+    const placeholders = ftsOnlyIds.map(() => '?').join(', ');
+    const ftsRows = db.query(
+      `SELECT m.*, GROUP_CONCAT(e.name) as entity_names
+       FROM memories m
+       LEFT JOIN memory_entities me2 ON m.id = me2.memory_id
+       LEFT JOIN entities e ON me2.entity_id = e.id
+       WHERE m.id IN (${placeholders})
+       GROUP BY m.id`,
+      ftsOnlyIds,
+    ) || [];
+    for (const row of ftsRows) {
+      vectorRows[row.id] = row;
+    }
+  }
+
+  // --- Score and build results ---
+  const now = new Date();
+  let results;
+
+  if (config.enable_rrf && allIds.size > 0) {
+    // Build independent rankings for RRF
+    const signalRankings = {};
+
+    // Vector ranking (sorted by vector score, best first)
+    if (hasVectorResults) {
+      signalRankings.vector = Object.keys(vectorScores)
+        .map(Number)
+        .sort((a, b) => vectorScores[b] - vectorScores[a]);
+    }
+
+    // FTS ranking (sorted by FTS score, best first)
+    if (hasFtsResults) {
+      signalRankings.fts = Object.keys(ftsScores)
+        .map(Number)
+        .sort((a, b) => ftsScores[b] - ftsScores[a]);
+    }
+
+    // Importance ranking
+    const importanceData = {};
+    for (const mid of allIds) {
+      const row = vectorRows[mid];
+      if (row) importanceData[mid] = row.importance;
+    }
+    if (Object.keys(importanceData).length > 0) {
+      signalRankings.importance = Object.keys(importanceData)
+        .map(Number)
+        .sort((a, b) => importanceData[b] - importanceData[a]);
+    }
+
+    // Recency ranking (sorted by created_at, newest first)
+    const recencyData = {};
+    for (const mid of allIds) {
+      const row = vectorRows[mid];
+      if (row) {
+        try {
+          const created = new Date(row.created_at);
+          recencyData[mid] = (now - created) / 1000; // seconds old
+        } catch {
+          recencyData[mid] = Infinity;
+        }
+      }
+    }
+    if (Object.keys(recencyData).length > 0) {
+      signalRankings.recency = Object.keys(recencyData)
+        .map(Number)
+        .sort((a, b) => recencyData[a] - recencyData[b]); // smallest age = most recent = best
+    }
+
+    // Graph proximity ranking
+    const graphScores = computeGraphScores(db, config, query, allIds);
+    if (Object.keys(graphScores).length > 0) {
+      signalRankings.graph = Object.keys(graphScores)
+        .map(Number)
+        .sort((a, b) => graphScores[b] - graphScores[a]);
+    }
+
+    // Fuse via RRF
+    const rrfScores = rrfScore(allIds, signalRankings, config.rrf_k || 60);
+
+    results = [];
+    for (const mid of allIds) {
+      const row = vectorRows[mid];
+      if (!row) continue;
+      const result = rowToResult(row, vectorScores[mid] || 0.0, ftsScores[mid] || 0.0, now, config);
+      result.score = rrfScores[mid] || 0.0;
+      results.push(result);
+    }
+  } else {
+    // Legacy weighted-sum scoring
+    results = [];
+    for (const mid of allIds) {
+      const row = vectorRows[mid];
+      if (!row) continue;
+      const vs = vectorScores[mid] || 0.0;
+      const fs = ftsScores[mid] || 0.0;
+      results.push(rowToResult(row, vs, fs, now, config));
+    }
+  }
+
+  // Sort by combined score and limit
+  results.sort((a, b) => b.score - a.score);
+  results = results.slice(0, limit);
+
+  updateAccessCounts(db, results, now);
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// 2. recallAbout() -- All context for an entity (sync)
+// ---------------------------------------------------------------------------
+
+/**
+ * Get everything known about an entity.
+ *
+ * @param {object} db
+ * @param {object} config
+ * @param {string} entityName
+ * @param {object} [options]
+ * @param {number} [options.limit]
+ * @param {string[]} [options.memoryTypes]
+ * @param {boolean} [options.includeHistorical=false]
+ * @returns {object}
+ */
+export function recallAbout(db, config, entityName, {
+  limit,
+  memoryTypes,
+  includeHistorical = false,
+} = {}) {
+  if (limit == null) limit = config.max_recall_results || 50;
+
+  const canonical = canonicalName(entityName);
+
+  // Find entity
+  let entity = db.queryOne('SELECT * FROM entities WHERE canonical_name = ?', [canonical]);
+
+  if (!entity) {
+    // Try alias
+    try {
+      const alias = db.queryOne('SELECT * FROM entity_aliases WHERE canonical_alias = ?', [canonical]);
+      if (alias) {
+        entity = db.queryOne('SELECT * FROM entities WHERE id = ?', [alias.entity_id]);
+      }
+    } catch {
+      // entity_aliases may not exist
+    }
+  }
+
+  if (!entity) {
+    return { entity: null, memories: [], relationships: [] };
+  }
+
+  // Get memories about this entity
+  let sql = `
+    SELECT m.* FROM memories m
+    JOIN memory_entities me ON m.id = me.memory_id
+    WHERE me.entity_id = ?
+    AND m.invalidated_at IS NULL
+  `;
+  const params = [entity.id];
+
+  if (memoryTypes && memoryTypes.length > 0) {
+    const ph = memoryTypes.map(() => '?').join(', ');
+    sql += ` AND m.type IN (${ph})`;
+    params.push(...memoryTypes);
+  }
+
+  sql += ' ORDER BY m.importance DESC, m.created_at DESC LIMIT ?';
+  params.push(limit);
+
+  const memoryRows = db.query(sql, params) || [];
+
+  const memories = memoryRows.map(row => ({
+    id: row.id,
+    content: row.content,
+    type: row.type,
+    score: row.importance,
+    importance: row.importance,
+    created_at: row.created_at,
+    entities: [entity.name],
+    metadata: row.metadata ? JSON.parse(row.metadata) : null,
+    source: rowGet(row, 'source'),
+    source_id: rowGet(row, 'source_id'),
+    source_context: rowGet(row, 'source_context'),
+    lifecycle_tier: rowGet(row, 'lifecycle_tier'),
+    fact_id: rowGet(row, 'fact_id'),
+  }));
+
+  // Get relationships
+  let relSql = `
+    SELECT r.*,
+           s.name as source_name, s.type as source_type,
+           t.name as target_name, t.type as target_type
+    FROM relationships r
+    JOIN entities s ON r.source_entity_id = s.id
+    JOIN entities t ON r.target_entity_id = t.id
+    WHERE (r.source_entity_id = ? OR r.target_entity_id = ?)
+  `;
+  if (!includeHistorical) {
+    relSql += ' AND r.invalid_at IS NULL';
+  }
+  relSql += ' ORDER BY r.strength DESC';
+
+  const relRows = db.query(relSql, [entity.id, entity.id]) || [];
+
+  const relationships = relRows.map(row => {
+    const rel = {
+      type: row.relationship_type,
+      direction: row.direction,
+      strength: row.strength,
+      origin_type: rowGet(row, 'origin_type', 'extracted'),
+      other_entity: row.source_entity_id === entity.id ? row.target_name : row.source_name,
+      other_entity_type: row.source_entity_id === entity.id ? row.target_type : row.source_type,
+    };
+    if (includeHistorical) {
+      rel.valid_at = rowGet(row, 'valid_at');
+      rel.invalid_at = rowGet(row, 'invalid_at');
+    }
+    return rel;
+  });
+
+  // Get relevant episode narratives mentioning this entity
+  const episodeRows = db.query(
+    `SELECT id, session_id, narrative, started_at, ended_at, key_topics
+     FROM episodes
+     WHERE is_summarized = 1 AND narrative LIKE ?
+     ORDER BY started_at DESC
+     LIMIT 5`,
+    [`%${entity.name}%`],
+  ) || [];
+
+  const recentSessions = episodeRows.map(row => ({
+    episode_id: row.id,
+    narrative: row.narrative,
+    started_at: row.started_at,
+    key_topics: row.key_topics ? JSON.parse(row.key_topics) : [],
+  }));
+
+  // Expand graph: get connected entities
+  const connected = expandGraph(db, entity.id);
+
+  return {
+    entity: {
+      id: entity.id,
+      name: entity.name,
+      type: entity.type,
+      description: entity.description,
+      importance: entity.importance,
+    },
+    memories,
+    relationships,
+    connected,
+    recent_sessions: recentSessions,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 3. recallSince() -- Memories after a date (sync)
+// ---------------------------------------------------------------------------
+
+/**
+ * Retrieve memories created or updated since a timestamp.
+ *
+ * @param {object} db
+ * @param {object} config
+ * @param {string} since - ISO datetime string
+ * @param {object} [options]
+ * @param {string} [options.entityName]
+ * @param {number} [options.limit=50]
+ * @returns {object[]}
+ */
+export function recallSince(db, config, since, { entityName, limit = 50 } = {}) {
+  const conditions = [
+    '(m.created_at >= ? OR m.updated_at >= ?)',
+    'm.invalidated_at IS NULL',
+    "(m.lifecycle_tier IS NULL OR m.lifecycle_tier != 'archived')",
+  ];
+  const params = [since, since];
+
+  if (entityName) {
+    conditions.push(`
+      m.id IN (
+        SELECT me.memory_id FROM memory_entities me
+        JOIN entities e ON me.entity_id = e.id
+        WHERE e.canonical_name = ? OR e.name = ?
+      )
+    `);
+    params.push(entityName.toLowerCase(), entityName);
+  }
+
+  const where = conditions.join(' AND ');
+
+  const rows = db.query(
+    `SELECT m.*, GROUP_CONCAT(e.name) as entity_names
+     FROM memories m
+     LEFT JOIN memory_entities me ON m.id = me.memory_id
+     LEFT JOIN entities e ON me.entity_id = e.id
+     WHERE ${where}
+     GROUP BY m.id
+     ORDER BY m.created_at DESC
+     LIMIT ?`,
+    [...params, limit],
+  ) || [];
+
+  return rows.map(row => rowToSimpleResult(row));
+}
+
+// ---------------------------------------------------------------------------
+// 4. recallTemporal() -- Semantic search within a time window (async)
+// ---------------------------------------------------------------------------
+
+/**
+ * Semantic search within a time window.
+ *
+ * @param {object} db
+ * @param {object} config
+ * @param {string} query
+ * @param {object} [options]
+ * @param {string} [options.dateFrom]
+ * @param {string} [options.dateTo]
+ * @param {number} [options.limit=20]
+ * @returns {Promise<object[]>}
+ */
+export async function recallTemporal(db, config, query, { dateFrom, dateTo, limit = 20 } = {}) {
+  // First get semantic results
+  const results = await recall(db, config, query, { limit: limit * 2 });
+
+  // Filter by date range
+  const filtered = [];
+  for (const r of results) {
+    const created = r.created_at;
+    if (!created) continue;
+    if (dateFrom && created < dateFrom) continue;
+    if (dateTo && created > dateTo) continue;
+    filtered.push(r);
+    if (filtered.length >= limit) break;
+  }
+
+  return filtered;
+}
+
+// ---------------------------------------------------------------------------
+// 5. recallTimeline() -- Chronological memories for entity (sync)
+// ---------------------------------------------------------------------------
+
+/**
+ * Temporal view of an entity: all memories sorted by time.
+ *
+ * @param {object} db
+ * @param {object} config
+ * @param {string} entityName
+ * @param {object} [options]
+ * @param {number} [options.limit=50]
+ * @returns {object[]}
+ */
+export function recallTimeline(db, config, entityName, { limit = 50 } = {}) {
+  const rows = db.query(
+    `SELECT m.*, GROUP_CONCAT(e2.name) as entity_names
+     FROM memories m
+     JOIN memory_entities me ON m.id = me.memory_id
+     JOIN entities e ON me.entity_id = e.id
+     LEFT JOIN memory_entities me2 ON m.id = me2.memory_id
+     LEFT JOIN entities e2 ON me2.entity_id = e2.id
+     WHERE (e.canonical_name = ? OR e.name = ?)
+       AND m.invalidated_at IS NULL
+       AND (m.lifecycle_tier IS NULL OR m.lifecycle_tier != 'archived')
+     GROUP BY m.id
+     ORDER BY COALESCE(m.deadline_at, m.created_at) ASC
+     LIMIT ?`,
+    [entityName.toLowerCase(), entityName, limit],
+  ) || [];
+
+  return rows.map(row => {
+    const r = rowToSimpleResult(row);
+    const deadlineAt = rowGet(row, 'deadline_at');
+    if (deadlineAt) {
+      r.metadata = r.metadata || {};
+      r.metadata.deadline_at = deadlineAt;
+      r.metadata.has_deadline = true;
+    }
+    return r;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 6. recallUpcomingDeadlines() -- Memories with upcoming deadlines (sync)
+// ---------------------------------------------------------------------------
+
+/**
+ * Retrieve memories with upcoming deadlines, sorted by urgency.
+ *
+ * @param {object} db
+ * @param {object} config
+ * @param {object} [options]
+ * @param {number} [options.daysAhead=14]
+ * @param {boolean} [options.includeOverdue=true]
+ * @returns {object[]}
+ */
+export function recallUpcomingDeadlines(db, config, { daysAhead = 14, includeOverdue = true } = {}) {
+  const now = new Date();
+  const future = new Date(now.getTime() + daysAhead * 24 * 60 * 60 * 1000);
+
+  const conditions = [
+    'm.deadline_at IS NOT NULL',
+    'm.invalidated_at IS NULL',
+    "(m.lifecycle_tier IS NULL OR m.lifecycle_tier != 'archived')",
+  ];
+  const params = [];
+
+  if (includeOverdue) {
+    conditions.push('m.deadline_at <= ?');
+    params.push(future.toISOString().replace('T', ' ').slice(0, 19));
+  } else {
+    conditions.push('m.deadline_at BETWEEN ? AND ?');
+    params.push(
+      now.toISOString().replace('T', ' ').slice(0, 19),
+      future.toISOString().replace('T', ' ').slice(0, 19),
+    );
+  }
+
+  const where = conditions.join(' AND ');
+
+  const rows = db.query(
+    `SELECT m.*, GROUP_CONCAT(e.name) as entity_names
+     FROM memories m
+     LEFT JOIN memory_entities me ON m.id = me.memory_id
+     LEFT JOIN entities e ON me.entity_id = e.id
+     WHERE ${where}
+     GROUP BY m.id
+     ORDER BY m.deadline_at ASC`,
+    params,
+  ) || [];
+
+  return rows.map(row => {
+    const deadlineStr = rowGet(row, 'deadline_at');
+    let urgency = 'later';
+    if (deadlineStr) {
+      try {
+        const deadlineDt = new Date(deadlineStr);
+        const oneDayMs = 24 * 60 * 60 * 1000;
+        if (deadlineDt < now) {
+          urgency = 'overdue';
+        } else if (deadlineDt < new Date(now.getTime() + oneDayMs)) {
+          urgency = 'today';
+        } else if (deadlineDt < new Date(now.getTime() + 2 * oneDayMs)) {
+          urgency = 'tomorrow';
+        } else if (deadlineDt < new Date(now.getTime() + 7 * oneDayMs)) {
+          urgency = 'this_week';
+        }
+      } catch {
+        // ignore
+      }
+    }
+
+    const entityStr = rowGet(row, 'entity_names', '');
+    return {
+      id: row.id,
+      content: row.content,
+      type: row.type,
+      score: row.importance,
+      importance: row.importance,
+      created_at: row.created_at,
+      entities: entityStr ? entityStr.split(',').map(s => s.trim()) : [],
+      metadata: { urgency, deadline_at: deadlineStr },
+      lifecycle_tier: rowGet(row, 'lifecycle_tier'),
+      fact_id: rowGet(row, 'fact_id'),
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 7. searchEntities() -- Entity search with type/name filters (sync)
+// ---------------------------------------------------------------------------
+
+/**
+ * Search for entities by name or description.
+ *
+ * @param {object} db
+ * @param {object} config
+ * @param {string} query
+ * @param {object} [options]
+ * @param {string[]} [options.entityTypes]
+ * @param {number} [options.limit=10]
+ * @returns {object[]}
+ */
+export function searchEntities(db, config, query, { entityTypes, limit = 10 } = {}) {
+  const canonical = canonicalName(query);
+
+  let sql = `
+    SELECT e.*,
+           COUNT(DISTINCT me.memory_id) as memory_count,
+           COUNT(DISTINCT r.id) as relationship_count,
+           MAX(m.created_at) as last_mentioned
+    FROM entities e
+    LEFT JOIN memory_entities me ON e.id = me.entity_id
+    LEFT JOIN memories m ON me.memory_id = m.id
+    LEFT JOIN relationships r ON e.id = r.source_entity_id OR e.id = r.target_entity_id
+    WHERE e.canonical_name LIKE ? OR e.name LIKE ?
+  `;
+  const params = [`%${canonical}%`, `%${query}%`];
+
+  if (entityTypes && entityTypes.length > 0) {
+    const ph = entityTypes.map(() => '?').join(', ');
+    sql += ` AND e.type IN (${ph})`;
+    params.push(...entityTypes);
+  }
+
+  sql += ' GROUP BY e.id ORDER BY e.importance DESC LIMIT ?';
+  params.push(limit);
+
+  const rows = db.query(sql, params) || [];
+
+  return rows.map(row => ({
+    id: row.id,
+    name: row.name,
+    type: row.type,
+    description: row.description,
+    importance: row.importance,
+    memory_count: row.memory_count,
+    relationship_count: row.relationship_count,
+    last_mentioned: row.last_mentioned,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// 8. getProjectNetwork() -- Entity relationship graph (sync)
+// ---------------------------------------------------------------------------
+
+/**
+ * Get all people and organizations connected to a project.
+ *
+ * @param {object} db
+ * @param {object} config
+ * @param {string} projectName
+ * @returns {object}
+ */
+export function getProjectNetwork(db, config, projectName) {
+  const canonical = canonicalName(projectName);
+
+  // Find project entity
+  let project = db.queryOne(
+    "SELECT * FROM entities WHERE canonical_name = ? AND type = 'project'",
+    [canonical],
+  );
+
+  if (!project) {
+    project = db.queryOne(
+      "SELECT * FROM entities WHERE canonical_name LIKE ? AND type = 'project'",
+      [`%${canonical}%`],
+    );
+  }
+
+  if (!project) {
+    return { error: `Project '${projectName}' not found`, project: null };
+  }
+
+  const result = {
+    project: {
+      id: project.id,
+      name: project.name,
+      description: project.description,
+      importance: project.importance,
+    },
+    direct_participants: [],
+    organizations: [],
+    extended_network: [],
+    total_people: 0,
+    total_orgs: 0,
+  };
+
+  try {
+    // Get direct relationships to project
+    const directRels = db.query(
+      `SELECT r.*, e.id as entity_id, e.name, e.type, e.description, e.importance
+       FROM relationships r
+       JOIN entities e ON (
+         (r.source_entity_id = ? AND r.target_entity_id = e.id) OR
+         (r.target_entity_id = ? AND r.source_entity_id = e.id)
+       )
+       WHERE r.strength > 0.1 AND r.invalid_at IS NULL
+       ORDER BY r.strength DESC`,
+      [project.id, project.id],
+    ) || [];
+
+    const peopleIds = [];
+    for (const rel of directRels) {
+      const entityData = {
+        id: rel.entity_id,
+        name: rel.name,
+        type: rel.type,
+        description: rel.description,
+        importance: rel.importance,
+        relationship: rel.relationship_type,
+        strength: rel.strength,
+      };
+
+      if (rel.type === 'person') {
+        result.direct_participants.push(entityData);
+        peopleIds.push(rel.entity_id);
+      } else if (rel.type === 'organization') {
+        result.organizations.push(entityData);
+      }
+    }
+
+    // Get 1-hop connections from direct participants
+    const extendedIds = new Set();
+    for (const personId of peopleIds.slice(0, 10)) {
+      const neighbors = expandGraph(db, personId, 1, 5);
+      for (const neighbor of neighbors) {
+        if (!peopleIds.includes(neighbor.id) && neighbor.id !== project.id) {
+          if (!extendedIds.has(neighbor.id)) {
+            extendedIds.add(neighbor.id);
+            result.extended_network.push({
+              id: neighbor.id,
+              name: neighbor.name,
+              type: neighbor.type,
+              description: neighbor.description,
+              connected_via: result.direct_participants.length > 0
+                ? result.direct_participants[0].name
+                : 'unknown',
+            });
+          }
+        }
+      }
+    }
+
+    result.total_people = result.direct_participants.length +
+      result.extended_network.filter(e => e.type === 'person').length;
+    result.total_orgs = result.organizations.length;
+  } catch (e) {
+    result.error = e.message;
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// 9. findPath() -- BFS shortest path between entities (sync)
+// ---------------------------------------------------------------------------
+
+/**
+ * Find shortest path between two entities via relationships.
+ *
+ * @param {object} db
+ * @param {object} config
+ * @param {string} entityA
+ * @param {string} entityB
+ * @param {object} [options]
+ * @param {number} [options.maxDepth=4]
+ * @returns {object[]|null} Path steps or null if no path found
+ */
+export function findPath(db, config, entityA, entityB, { maxDepth = 4 } = {}) {
+  const canonicalA = canonicalName(entityA);
+  const canonicalB = canonicalName(entityB);
+
+  const entA = db.queryOne('SELECT * FROM entities WHERE canonical_name = ?', [canonicalA]);
+  const entB = db.queryOne('SELECT * FROM entities WHERE canonical_name = ?', [canonicalB]);
+
+  if (!entA || !entB) return null;
+  if (entA.id === entB.id) {
+    return [{ entity: entA.name, relationship: null, direction: null }];
+  }
+
+  try {
+    const rows = db.query(
+      `WITH RECURSIVE path_search(entity_id, path, depth) AS (
+        SELECT ?, json_array(json_object('entity_id', ?, 'name', ?)), 0
+
+        UNION ALL
+
+        SELECT
+          CASE
+            WHEN r.source_entity_id = ps.entity_id THEN r.target_entity_id
+            ELSE r.source_entity_id
+          END,
+          json_insert(
+            ps.path,
+            '$[#]',
+            json_object(
+              'entity_id', CASE WHEN r.source_entity_id = ps.entity_id THEN r.target_entity_id ELSE r.source_entity_id END,
+              'name', e.name,
+              'relationship', r.relationship_type,
+              'direction', CASE WHEN r.source_entity_id = ps.entity_id THEN 'forward' ELSE 'backward' END
+            )
+          ),
+          ps.depth + 1
+        FROM path_search ps
+        JOIN relationships r ON (r.source_entity_id = ps.entity_id OR r.target_entity_id = ps.entity_id)
+        JOIN entities e ON e.id = CASE WHEN r.source_entity_id = ps.entity_id THEN r.target_entity_id ELSE r.source_entity_id END
+        WHERE ps.depth < ?
+          AND r.strength > 0.1
+          AND r.invalid_at IS NULL
+          AND json_extract(ps.path, '$[#-1].entity_id') != CASE WHEN r.source_entity_id = ps.entity_id THEN r.target_entity_id ELSE r.source_entity_id END
+      )
+      SELECT path, depth FROM path_search
+      WHERE entity_id = ?
+      ORDER BY depth ASC
+      LIMIT 1`,
+      [entA.id, entA.id, entA.name, maxDepth, entB.id],
+    );
+
+    if (rows && rows.length > 0) {
+      return JSON.parse(rows[0].path);
+    }
+  } catch {
+    // Path finding failed
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// 10. getHubEntities() -- Most-connected entities (sync)
+// ---------------------------------------------------------------------------
+
+/**
+ * Find most connected entities in the graph.
+ *
+ * @param {object} db
+ * @param {object} config
+ * @param {object} [options]
+ * @param {number} [options.minConnections=5]
+ * @param {string} [options.entityType]
+ * @param {number} [options.limit=20]
+ * @returns {object[]}
+ */
+export function getHubEntities(db, config, { minConnections = 5, entityType, limit = 20 } = {}) {
+  try {
+    let sql = `
+      SELECT
+        e.id, e.name, e.type, e.description, e.importance,
+        COUNT(DISTINCT r.id) as connection_count,
+        GROUP_CONCAT(DISTINCT
+          CASE
+            WHEN r.source_entity_id = e.id THEN t.name
+            ELSE s.name
+          END
+        ) as connected_names
+      FROM entities e
+      LEFT JOIN relationships r ON (e.id = r.source_entity_id OR e.id = r.target_entity_id)
+        AND r.strength > 0.1 AND r.invalid_at IS NULL
+      LEFT JOIN entities s ON r.source_entity_id = s.id
+      LEFT JOIN entities t ON r.target_entity_id = t.id
+      WHERE e.importance > 0.1
+    `;
+    const params = [];
+
+    if (entityType) {
+      sql += ' AND e.type = ?';
+      params.push(entityType);
+    }
+
+    sql += `
+      GROUP BY e.id
+      HAVING connection_count >= ?
+      ORDER BY connection_count DESC, e.importance DESC
+      LIMIT ?
+    `;
+    params.push(minConnections, limit);
+
+    const rows = db.query(sql, params) || [];
+
+    return rows.map(row => {
+      const connectedNames = row.connected_names ? row.connected_names.split(',') : [];
+      return {
+        id: row.id,
+        name: row.name,
+        type: row.type,
+        description: row.description,
+        importance: row.importance,
+        connection_count: row.connection_count,
+        top_connections: connectedNames.slice(0, 5),
+      };
+    });
+  } catch {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 11. getDormantRelationships() -- Relationships not updated recently (sync)
+// ---------------------------------------------------------------------------
+
+/**
+ * Find relationships with no recent activity.
+ *
+ * @param {object} db
+ * @param {object} config
+ * @param {object} [options]
+ * @param {number} [options.days=60]
+ * @param {number} [options.minStrength=0.3]
+ * @param {number} [options.limit=20]
+ * @returns {object[]}
+ */
+export function getDormantRelationships(db, config, { days = 60, minStrength = 0.3, limit = 20 } = {}) {
+  const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+
+  try {
+    const rows = db.query(
+      `SELECT
+        r.id as relationship_id,
+        r.relationship_type,
+        r.strength,
+        r.created_at as relationship_created,
+        s.id as source_id, s.name as source_name, s.type as source_type,
+        t.id as target_id, t.name as target_name, t.type as target_type,
+        MAX(COALESCE(sm.created_at, '2000-01-01')) as source_last_memory,
+        MAX(COALESCE(tm.created_at, '2000-01-01')) as target_last_memory
+      FROM relationships r
+      JOIN entities s ON r.source_entity_id = s.id
+      JOIN entities t ON r.target_entity_id = t.id
+      LEFT JOIN memory_entities sme ON sme.entity_id = s.id
+      LEFT JOIN memories sm ON sme.memory_id = sm.id
+      LEFT JOIN memory_entities tme ON tme.entity_id = t.id
+      LEFT JOIN memories tm ON tme.memory_id = tm.id
+      WHERE r.strength >= ?
+        AND r.invalid_at IS NULL
+      GROUP BY r.id
+      HAVING MAX(source_last_memory) < ? AND MAX(target_last_memory) < ?
+      ORDER BY r.strength DESC, source_last_memory ASC
+      LIMIT ?`,
+      [minStrength, cutoff, cutoff, limit],
+    ) || [];
+
+    const now = new Date();
+    return rows.map(row => {
+      const sourceLast = new Date(row.source_last_memory);
+      const targetLast = new Date(row.target_last_memory);
+      const mostRecent = sourceLast > targetLast ? sourceLast : targetLast;
+      const daysDormant = Math.floor((now - mostRecent) / (1000 * 60 * 60 * 24));
+
+      return {
+        relationship_id: row.relationship_id,
+        relationship_type: row.relationship_type,
+        strength: row.strength,
+        source: {
+          id: row.source_id,
+          name: row.source_name,
+          type: row.source_type,
+        },
+        target: {
+          id: row.target_id,
+          name: row.target_name,
+          type: row.target_type,
+        },
+        days_dormant: daysDormant,
+        last_activity: mostRecent.toISOString(),
+      };
+    });
+  } catch {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 12. getReflections() -- Retrieve reflections with filters (sync)
+// ---------------------------------------------------------------------------
+
+/**
+ * Get reflections with optional filtering.
+ *
+ * @param {object} db
+ * @param {object} config
+ * @param {object} [options]
+ * @param {number} [options.limit=20]
+ * @param {string[]} [options.reflectionTypes]
+ * @param {number} [options.minImportance=0.1]
+ * @param {string} [options.aboutEntity]
+ * @returns {object[]}
+ */
+export function getReflections(db, config, {
+  limit = 20,
+  reflectionTypes,
+  minImportance = 0.1,
+  aboutEntity,
+} = {}) {
+  let sql = `
+    SELECT r.*, e.name as entity_name
+    FROM reflections r
+    LEFT JOIN entities e ON r.about_entity_id = e.id
+    WHERE r.importance >= ?
+  `;
+  const params = [minImportance];
+
+  if (reflectionTypes && reflectionTypes.length > 0) {
+    const ph = reflectionTypes.map(() => '?').join(', ');
+    sql += ` AND r.reflection_type IN (${ph})`;
+    params.push(...reflectionTypes);
+  }
+
+  if (aboutEntity) {
+    const canonical = canonicalName(aboutEntity);
+    sql += ' AND e.canonical_name = ?';
+    params.push(canonical);
+  }
+
+  sql += ' ORDER BY r.importance DESC, r.last_confirmed_at DESC LIMIT ?';
+  params.push(limit);
+
+  const rows = db.query(sql, params) || [];
+
+  return rows.map(row => ({
+    id: row.id,
+    content: row.content,
+    reflection_type: row.reflection_type,
+    importance: row.importance,
+    confidence: row.confidence,
+    about_entity: row.entity_name,
+    first_observed_at: row.first_observed_at,
+    last_confirmed_at: row.last_confirmed_at,
+    aggregation_count: row.aggregation_count,
+    episode_id: row.episode_id,
+    score: row.importance,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// 13. searchReflections() -- Search reflections by content (async)
+// ---------------------------------------------------------------------------
+
+/**
+ * Semantic search for reflections.
+ *
+ * @param {object} db
+ * @param {object} config
+ * @param {string} query
+ * @param {object} [options]
+ * @param {number} [options.limit=10]
+ * @param {string[]} [options.reflectionTypes]
+ * @returns {Promise<object[]>}
+ */
+export async function searchReflections(db, config, query, { limit = 10, reflectionTypes } = {}) {
+  const queryEmbedding = await embed(query);
+
+  let results = [];
+
+  if (queryEmbedding) {
+    try {
+      let sql = `
+        SELECT r.*, e.name as entity_name, (1.0 / (1.0 + re.distance)) as vector_score
+        FROM reflection_embeddings re
+        JOIN reflections r ON r.id = re.reflection_id
+        LEFT JOIN entities e ON r.about_entity_id = e.id
+        WHERE re.embedding MATCH ?
+      `;
+      const params = [JSON.stringify(queryEmbedding)];
+
+      if (reflectionTypes && reflectionTypes.length > 0) {
+        const ph = reflectionTypes.map(() => '?').join(', ');
+        sql += ` AND r.reflection_type IN (${ph})`;
+        params.push(...reflectionTypes);
+      }
+
+      sql += ' ORDER BY vector_score DESC LIMIT ?';
+      params.push(limit);
+
+      const rows = db.query(sql, params) || [];
+
+      results = rows.map(row => ({
+        id: row.id,
+        content: row.content,
+        reflection_type: row.reflection_type,
+        importance: row.importance,
+        confidence: row.confidence,
+        about_entity: row.entity_name,
+        first_observed_at: row.first_observed_at,
+        last_confirmed_at: row.last_confirmed_at,
+        aggregation_count: row.aggregation_count,
+        episode_id: row.episode_id,
+        score: row.vector_score,
+      }));
+    } catch {
+      // Reflection vector search failed
+    }
+  }
+
+  // Fallback to keyword search if vector search failed or returned nothing
+  if (results.length === 0) {
+    let sql = `
+      SELECT r.*, e.name as entity_name
+      FROM reflections r
+      LEFT JOIN entities e ON r.about_entity_id = e.id
+      WHERE r.content LIKE ?
+    `;
+    const params = [`%${query}%`];
+
+    if (reflectionTypes && reflectionTypes.length > 0) {
+      const ph = reflectionTypes.map(() => '?').join(', ');
+      sql += ` AND r.reflection_type IN (${ph})`;
+      params.push(...reflectionTypes);
+    }
+
+    sql += ' ORDER BY r.importance DESC LIMIT ?';
+    params.push(limit);
+
+    const rows = db.query(sql, params) || [];
+
+    results = rows.map(row => ({
+      id: row.id,
+      content: row.content,
+      reflection_type: row.reflection_type,
+      importance: row.importance,
+      confidence: row.confidence,
+      about_entity: row.entity_name,
+      first_observed_at: row.first_observed_at,
+      last_confirmed_at: row.last_confirmed_at,
+      aggregation_count: row.aggregation_count,
+      episode_id: row.episode_id,
+      score: 0.5, // Default score for keyword match
+    }));
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// 14. fetchByIds() -- Fetch memories by ID list (sync)
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch specific memories by their IDs.
+ *
+ * @param {object} db
+ * @param {object} config
+ * @param {number[]} memoryIds
+ * @returns {object[]}
+ */
+export function fetchByIds(db, config, memoryIds) {
+  if (!memoryIds || memoryIds.length === 0) return [];
+
+  const placeholders = memoryIds.map(() => '?').join(', ');
+  const rows = db.query(
+    `SELECT m.*, GROUP_CONCAT(e.name) as entity_names
+     FROM memories m
+     LEFT JOIN memory_entities me2 ON m.id = me2.memory_id
+     LEFT JOIN entities e ON me2.entity_id = e.id
+     WHERE m.id IN (${placeholders})
+     GROUP BY m.id`,
+    memoryIds,
+  ) || [];
+
+  const now = new Date();
+  return rows.map(row => rowToResult(row, 0.0, 0.0, now, config));
+}
+
+// ---------------------------------------------------------------------------
+// 15. traceMemory() -- Provenance chain (sync)
+// ---------------------------------------------------------------------------
+
+/**
+ * Reconstruct full provenance for a memory.
+ *
+ * @param {object} db
+ * @param {object} config
+ * @param {number} memoryId
+ * @returns {object}
+ */
+export function traceMemory(db, config, memoryId) {
+  const result = {
+    memory: null,
+    episode: null,
+    archived_turns: null,
+    source_file: null,
+    source_file_preview: null,
+    entities: [],
+  };
+
+  // 1. Fetch the memory row
+  const memoryRow = db.queryOne('SELECT * FROM memories WHERE id = ?', [memoryId]);
+  if (!memoryRow) return result;
+
+  result.memory = {
+    id: memoryRow.id,
+    content: memoryRow.content,
+    type: memoryRow.type,
+    importance: memoryRow.importance,
+    confidence: memoryRow.confidence,
+    source: rowGet(memoryRow, 'source'),
+    source_id: rowGet(memoryRow, 'source_id'),
+    source_context: rowGet(memoryRow, 'source_context'),
+    created_at: memoryRow.created_at,
+    updated_at: memoryRow.updated_at,
+    access_count: memoryRow.access_count,
+  };
+
+  // 2. Fetch related entities
+  const entityRows = db.query(
+    `SELECT e.name, e.type FROM entities e
+     JOIN memory_entities me ON e.id = me.entity_id
+     WHERE me.memory_id = ?`,
+    [memoryId],
+  ) || [];
+  result.entities = entityRows.map(r => ({ name: r.name, type: r.type }));
+
+  // 3. If source_id points to an episode, fetch it with archived turns
+  const sourceId = result.memory.source_id;
+  if (sourceId) {
+    try {
+      const episodeId = parseInt(sourceId, 10);
+      if (!isNaN(episodeId)) {
+        const episodeRow = db.queryOne('SELECT * FROM episodes WHERE id = ?', [episodeId]);
+        if (episodeRow) {
+          result.episode = {
+            id: episodeRow.id,
+            narrative: rowGet(episodeRow, 'narrative'),
+            started_at: episodeRow.started_at,
+            ended_at: rowGet(episodeRow, 'ended_at'),
+            key_topics: episodeRow.key_topics ? JSON.parse(episodeRow.key_topics) : [],
+          };
+
+          // Fetch archived turns
+          const turnRows = db.query(
+            `SELECT turn_number, user_content, assistant_content, created_at
+             FROM turn_buffer
+             WHERE episode_id = ? AND is_archived = 1
+             ORDER BY turn_number ASC`,
+            [episodeId],
+          ) || [];
+          if (turnRows.length > 0) {
+            result.archived_turns = turnRows.map(r => ({
+              turn: r.turn_number,
+              user: r.user_content,
+              assistant: r.assistant_content,
+              timestamp: r.created_at,
+            }));
+          }
+        }
+      }
+    } catch {
+      // source_id wasn't a numeric episode ID
+    }
+  }
+
+  // 4. Check for source material file on disk (legacy path)
+  try {
+    const sourcesDir = join(dirname(db.dbPath), 'sources');
+    const sourceFile = join(sourcesDir, `${memoryId}.md`);
+    if (existsSync(sourceFile)) {
+      result.source_file = sourceFile;
+      try {
+        let fileText = readFileSync(sourceFile, 'utf-8');
+        // Skip frontmatter for preview
+        if (fileText.startsWith('---')) {
+          const endIdx = fileText.indexOf('---', 3);
+          if (endIdx !== -1) {
+            fileText = fileText.slice(endIdx + 3).trim();
+          }
+        }
+        result.source_file_preview = fileText.slice(0, 200);
+      } catch {
+        result.source_file_preview = '(could not read file)';
+      }
+    }
+  } catch {
+    // File system access may fail
+  }
+
+  // 5. Check for linked documents via memory_sources (provenance)
+  try {
+    const docRows = db.query(
+      `SELECT d.id, d.filename, d.source_type, d.summary,
+              d.storage_path, d.created_at, ms.excerpt
+       FROM documents d
+       JOIN memory_sources ms ON d.id = ms.document_id
+       WHERE ms.memory_id = ?
+       ORDER BY d.created_at DESC`,
+      [memoryId],
+    ) || [];
+    if (docRows.length > 0) {
+      result.documents = docRows.map(r => ({
+        id: r.id,
+        filename: r.filename,
+        source_type: r.source_type,
+        summary: r.summary,
+        excerpt: r.excerpt,
+        storage_path: r.storage_path,
+        created_at: r.created_at,
+      }));
+    }
+  } catch {
+    // Graceful degradation if documents table doesn't exist yet
+  }
+
+  // 6. Build provenance chain
+  result.provenance_chain = buildProvenanceChain(memoryRow, result);
+
+  // 7. Fetch audit trail for this memory
+  try {
+    const auditRows = db.query(
+      `SELECT operation, details, timestamp
+       FROM audit_log
+       WHERE memory_id = ?
+       ORDER BY timestamp ASC`,
+      [memoryId],
+    ) || [];
+    if (auditRows.length > 0) {
+      result.audit_trail = auditRows.map(r => ({
+        operation: r.operation,
+        details: r.details,
+        timestamp: r.timestamp,
+      }));
+    }
+  } catch {
+    // audit_log may not exist
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// 16. getBriefing() -- Compact session-start data (sync)
+// ---------------------------------------------------------------------------
+
+/**
+ * Get compact session-start briefing data.
+ *
+ * @param {object} db
+ * @param {object} config
+ * @returns {object}
+ */
+export function getBriefing(db, config) {
+  const now = new Date();
+  const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
+  const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString();
+
+  // Memory counts
+  const totalRow = db.queryOne(
+    "SELECT COUNT(*) as cnt FROM memories WHERE invalidated_at IS NULL",
+  );
+  const recentRow = db.queryOne(
+    "SELECT COUNT(*) as cnt FROM memories WHERE created_at >= ? AND invalidated_at IS NULL",
+    [oneDayAgo],
+  );
+  const entityRow = db.queryOne(
+    "SELECT COUNT(*) as cnt FROM entities WHERE deleted_at IS NULL",
+  );
+
+  // Recent memories (last 24h)
+  const recentMemories = db.query(
+    `SELECT m.content, m.type, m.importance, GROUP_CONCAT(e.name) as entity_names
+     FROM memories m
+     LEFT JOIN memory_entities me ON m.id = me.memory_id
+     LEFT JOIN entities e ON me.entity_id = e.id
+     WHERE m.created_at >= ? AND m.invalidated_at IS NULL
+     GROUP BY m.id
+     ORDER BY m.importance DESC
+     LIMIT 10`,
+    [oneDayAgo],
+  ) || [];
+
+  // Upcoming deadlines (next 7 days)
+  const deadlines = recallUpcomingDeadlines(db, config, { daysAhead: 7, includeOverdue: true });
+
+  // Active reflections
+  const reflections = getActiveReflections(db, config);
+
+  // Recent sessions
+  let recentSessions = [];
+  try {
+    recentSessions = db.query(
+      `SELECT id, session_id, narrative, started_at, key_topics
+       FROM episodes
+       WHERE is_summarized = 1 AND started_at >= ?
+       ORDER BY started_at DESC
+       LIMIT 3`,
+      [sevenDaysAgo],
+    ) || [];
+    recentSessions = recentSessions.map(row => ({
+      episode_id: row.id,
+      narrative: row.narrative,
+      started_at: row.started_at,
+      key_topics: row.key_topics ? JSON.parse(row.key_topics) : [],
+    }));
+  } catch {
+    // episodes table may not exist
+  }
+
+  return {
+    counts: {
+      total_memories: totalRow ? totalRow.cnt : 0,
+      recent_24h: recentRow ? recentRow.cnt : 0,
+      total_entities: entityRow ? entityRow.cnt : 0,
+    },
+    recent_memories: recentMemories.map(r => ({
+      content: r.content,
+      type: r.type,
+      importance: r.importance,
+      entities: r.entity_names ? r.entity_names.split(',').map(s => s.trim()) : [],
+    })),
+    upcoming_deadlines: deadlines.slice(0, 5),
+    active_reflections: reflections,
+    recent_sessions: recentSessions,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 17. getProjectHealth() -- Project-specific metrics (sync)
+// ---------------------------------------------------------------------------
+
+/**
+ * Project relationship velocity projection.
+ *
+ * @param {object} db
+ * @param {object} config
+ * @param {string} entityName
+ * @param {object} [options]
+ * @param {number} [options.daysAhead=30]
+ * @returns {object}
+ */
+export function getProjectHealth(db, config, entityName, { daysAhead = 30 } = {}) {
+  const canonical = canonicalName(entityName);
+  const entity = db.queryOne(
+    'SELECT * FROM entities WHERE canonical_name = ? AND deleted_at IS NULL',
+    [canonical],
+  );
+
+  if (!entity) {
+    return { error: `Entity '${entityName}' not found` };
+  }
+
+  const lastContact = rowGet(entity, 'last_contact_at');
+  const frequency = rowGet(entity, 'contact_frequency_days');
+  const trend = rowGet(entity, 'contact_trend', 'unknown') || 'unknown';
+
+  // If no velocity data, return basic info
+  if (!lastContact || !frequency) {
+    return {
+      entity: entity.name,
+      status: 'insufficient_data',
+      trend,
+      message: 'Not enough contact history to project. Need at least 2 recorded interactions.',
+    };
+  }
+
+  let lastDt;
+  try {
+    lastDt = new Date(lastContact);
+    if (isNaN(lastDt.getTime())) throw new Error('Invalid date');
+  } catch {
+    return { entity: entity.name, status: 'parse_error' };
+  }
+
+  const now = new Date();
+  const daysSince = Math.floor((now - lastDt) / (1000 * 60 * 60 * 24));
+
+  // Dormancy threshold: 2x average frequency
+  const dormancyThreshold = frequency * 2.0;
+
+  // Apply trend modifiers
+  const trendMultiplier = {
+    accelerating: 0.7,
+    stable: 1.0,
+    decelerating: 1.3,
+    dormant: 1.5,
+  }[trend] || 1.0;
+
+  const projectedDaysToDormancy = dormancyThreshold * trendMultiplier;
+  const projectedDormantDate = new Date(lastDt.getTime() + projectedDaysToDormancy * 24 * 60 * 60 * 1000);
+
+  // Recommended contact: at 1x frequency from last contact (or now if overdue)
+  let recommendedContactDate = new Date(lastDt.getTime() + frequency * 24 * 60 * 60 * 1000);
+  if (recommendedContactDate < now) {
+    recommendedContactDate = now;
+  }
+
+  // Risk level
+  const daysUntilDormant = Math.floor((projectedDormantDate - now) / (1000 * 60 * 60 * 24));
+  let riskLevel;
+  if (daysUntilDormant <= 0) riskLevel = 'dormant';
+  else if (daysUntilDormant <= 7) riskLevel = 'critical';
+  else if (daysUntilDormant <= 14) riskLevel = 'high';
+  else if (daysUntilDormant <= 30) riskLevel = 'medium';
+  else riskLevel = 'low';
+
+  // Check for open commitments
+  const openCommitments = db.query(
+    `SELECT m.content FROM memories m
+     JOIN memory_entities me ON m.id = me.memory_id
+     WHERE me.entity_id = ?
+       AND m.type = 'commitment'
+       AND m.invalidated_at IS NULL
+     ORDER BY m.importance DESC
+     LIMIT 5`,
+    [entity.id],
+  ) || [];
+
+  return {
+    entity: entity.name,
+    days_since_contact: daysSince,
+    contact_frequency_days: Math.round(frequency * 10) / 10,
+    trend,
+    attention_tier: rowGet(entity, 'attention_tier', 'standard'),
+    projected_dormant_date: projectedDormantDate.toISOString().slice(0, 10),
+    days_until_dormant: Math.max(0, daysUntilDormant),
+    recommended_contact_date: recommendedContactDate.toISOString().slice(0, 10),
+    risk_level: riskLevel,
+    open_commitments: openCommitments.map(c => c.content),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Additional methods
+// ---------------------------------------------------------------------------
+
+/**
+ * Get high-value reflections for session context.
+ *
+ * @param {object} db
+ * @param {object} config
+ * @param {object} [options]
+ * @param {number} [options.limit=5]
+ * @param {number} [options.minImportance=0.6]
+ * @returns {object[]}
+ */
+export function getActiveReflections(db, config, { limit = 5, minImportance = 0.6 } = {}) {
+  const rows = db.query(
+    `SELECT r.*, e.name as entity_name
+     FROM reflections r
+     LEFT JOIN entities e ON r.about_entity_id = e.id
+     WHERE r.importance >= ?
+     ORDER BY r.importance DESC, r.last_confirmed_at DESC
+     LIMIT ?`,
+    [minImportance, limit],
+  ) || [];
+
+  return rows.map(row => ({
+    id: row.id,
+    content: row.content,
+    reflection_type: row.reflection_type,
+    importance: row.importance,
+    confidence: row.confidence,
+    about_entity: row.entity_name,
+    first_observed_at: row.first_observed_at,
+    last_confirmed_at: row.last_confirmed_at,
+    aggregation_count: row.aggregation_count,
+    episode_id: row.episode_id,
+    score: row.importance,
+  }));
+}
+
+/**
+ * Get a single reflection by ID.
+ *
+ * @param {object} db
+ * @param {object} config
+ * @param {number} reflectionId
+ * @returns {object|null}
+ */
+export function getReflectionById(db, config, reflectionId) {
+  const row = db.queryOne(
+    `SELECT r.*, e.name as entity_name
+     FROM reflections r
+     LEFT JOIN entities e ON r.about_entity_id = e.id
+     WHERE r.id = ?`,
+    [reflectionId],
+  );
+
+  if (!row) return null;
+
+  return {
+    id: row.id,
+    content: row.content,
+    reflection_type: row.reflection_type,
+    importance: row.importance,
+    confidence: row.confidence,
+    about_entity: row.entity_name,
+    first_observed_at: row.first_observed_at,
+    last_confirmed_at: row.last_confirmed_at,
+    aggregation_count: row.aggregation_count,
+    episode_id: row.episode_id,
+    score: row.importance,
+  };
+}
+
+/**
+ * Get recent memories within a time window.
+ *
+ * @param {object} db
+ * @param {object} config
+ * @param {object} [options]
+ * @param {number} [options.limit=10]
+ * @param {string[]} [options.memoryTypes]
+ * @param {number} [options.hours=24]
+ * @param {string} [options.sourceFilter]
+ * @returns {object[]}
+ */
+export function getRecentMemories(db, config, { limit = 10, memoryTypes, hours = 24, sourceFilter } = {}) {
+  const cutoff = new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
+
+  let sql = `
+    SELECT m.*, GROUP_CONCAT(e.name) as entity_names
+    FROM memories m
+    LEFT JOIN memory_entities me ON m.id = me.memory_id
+    LEFT JOIN entities e ON me.entity_id = e.id
+    WHERE m.created_at >= ?
+    AND m.invalidated_at IS NULL
+    AND (m.lifecycle_tier IS NULL OR m.lifecycle_tier != 'archived')
+  `;
+  const params = [cutoff];
+
+  if (memoryTypes && memoryTypes.length > 0) {
+    const ph = memoryTypes.map(() => '?').join(', ');
+    sql += ` AND m.type IN (${ph})`;
+    params.push(...memoryTypes);
+  }
+
+  if (sourceFilter) {
+    sql += ' AND m.source = ?';
+    params.push(sourceFilter);
+  }
+
+  sql += ' GROUP BY m.id ORDER BY m.created_at DESC LIMIT ?';
+  params.push(limit);
+
+  const rows = db.query(sql, params) || [];
+
+  return rows.map(row => ({
+    id: row.id,
+    content: row.content,
+    type: row.type,
+    score: row.importance,
+    importance: row.importance,
+    created_at: row.created_at,
+    entities: row.entity_names ? row.entity_names.split(',').map(s => s.trim()) : [],
+    metadata: row.metadata ? JSON.parse(row.metadata) : null,
+    source: rowGet(row, 'source'),
+    source_id: rowGet(row, 'source_id'),
+    source_context: rowGet(row, 'source_context'),
+    lifecycle_tier: rowGet(row, 'lifecycle_tier'),
+    fact_id: rowGet(row, 'fact_id'),
+  }));
+}
+
+/**
+ * Search episode narratives by semantic similarity.
+ *
+ * @param {object} db
+ * @param {object} config
+ * @param {string} query
+ * @param {object} [options]
+ * @param {number} [options.limit=5]
+ * @returns {Promise<object[]>}
+ */
+export async function recallEpisodes(db, config, query, { limit = 5 } = {}) {
+  const queryEmbedding = await embed(query);
+
+  let rows;
+
+  if (queryEmbedding) {
+    try {
+      rows = db.query(
+        `SELECT e.*, (1.0 / (1.0 + ee.distance)) as relevance
+         FROM episode_embeddings ee
+         JOIN episodes e ON e.id = ee.episode_id
+         WHERE ee.embedding MATCH ?
+         AND e.is_summarized = 1
+         ORDER BY relevance DESC
+         LIMIT ?`,
+        [JSON.stringify(queryEmbedding), limit],
+      ) || [];
+    } catch {
+      // Vector search failed, fall back to keyword
+      rows = db.query(
+        `SELECT e.*, 0.5 as relevance
+         FROM episodes e
+         WHERE e.narrative LIKE ?
+         AND e.is_summarized = 1
+         ORDER BY e.started_at DESC
+         LIMIT ?`,
+        [`%${query}%`, limit],
+      ) || [];
+    }
+  } else {
+    rows = db.query(
+      `SELECT e.*, 0.5 as relevance
+       FROM episodes e
+       WHERE e.narrative LIKE ?
+       AND e.is_summarized = 1
+       ORDER BY e.started_at DESC
+       LIMIT ?`,
+      [`%${query}%`, limit],
+    ) || [];
+  }
+
+  return rows.map(row => ({
+    episode_id: row.id,
+    session_id: row.session_id,
+    narrative: row.narrative,
+    summary: row.summary,
+    started_at: row.started_at,
+    ended_at: row.ended_at,
+    key_topics: row.key_topics ? JSON.parse(row.key_topics) : [],
+    relevance: row.relevance,
+  }));
+}
+
+/**
+ * Find potential duplicate entities using fuzzy name matching.
+ *
+ * @param {object} db
+ * @param {object} config
+ * @param {object} [options]
+ * @param {number} [options.threshold=0.85]
+ * @param {string} [options.entityType]
+ * @param {number} [options.limit=50]
+ * @returns {object[]}
+ */
+export function findDuplicateEntities(db, config, { threshold = 0.85, entityType, limit = 50 } = {}) {
+  let sql = `
+    SELECT id, name, canonical_name, type, importance
+    FROM entities
+    WHERE deleted_at IS NULL
+  `;
+  const params = [];
+  if (entityType) {
+    sql += ' AND type = ?';
+    params.push(entityType);
+  }
+
+  const entities = db.query(sql, params) || [];
+  const duplicates = [];
+  const seenPairs = new Set();
+
+  for (let i = 0; i < entities.length; i++) {
+    const e1 = entities[i];
+    for (let j = i + 1; j < entities.length; j++) {
+      const e2 = entities[j];
+
+      // Skip if different types
+      if (e1.type !== e2.type) continue;
+
+      const pairKey = `${Math.min(e1.id, e2.id)}-${Math.max(e1.id, e2.id)}`;
+      if (seenPairs.has(pairKey)) continue;
+      seenPairs.add(pairKey);
+
+      const ratio = nameSimilarity(e1.canonical_name, e2.canonical_name);
+
+      if (ratio >= threshold) {
+        duplicates.push({
+          entity_1: {
+            id: e1.id,
+            name: e1.name,
+            type: e1.type,
+            importance: e1.importance,
+          },
+          entity_2: {
+            id: e2.id,
+            name: e2.name,
+            type: e2.type,
+            importance: e2.importance,
+          },
+          similarity: Math.round(ratio * 1000) / 1000,
+        });
+
+        if (duplicates.length >= limit) break;
+      }
+    }
+    if (duplicates.length >= limit) break;
+  }
+
+  // Sort by similarity descending
+  duplicates.sort((a, b) => b.similarity - a.similarity);
+  return duplicates;
+}
+
+/**
+ * Generate a community-style overview of one or more entities.
+ *
+ * @param {object} db
+ * @param {object} config
+ * @param {string[]} entityNames
+ * @param {object} [options]
+ * @param {boolean} [options.includeNetwork=true]
+ * @param {boolean} [options.includeSummaries=true]
+ * @returns {object}
+ */
+export function entityOverview(db, config, entityNames, { includeNetwork = true, includeSummaries = true } = {}) {
+  const result = {
+    entities: [],
+    cross_entity_patterns: [],
+    clusters: [],
+    relationship_map: [],
+    open_commitments: [],
+  };
+
+  const entityIds = [];
+  for (const name of entityNames) {
+    const canonical = canonicalName(name);
+    let entity = db.queryOne(
+      'SELECT * FROM entities WHERE canonical_name = ? AND deleted_at IS NULL',
+      [canonical],
+    );
+    if (!entity) {
+      entity = db.queryOne(
+        'SELECT * FROM entities WHERE canonical_name LIKE ? AND deleted_at IS NULL',
+        [`%${canonical}%`],
+      );
+    }
+    if (entity) {
+      entityIds.push(entity.id);
+
+      const entityData = {
+        id: entity.id,
+        name: entity.name,
+        type: entity.type,
+        description: entity.description,
+        importance: entity.importance,
+        attention_tier: rowGet(entity, 'attention_tier', 'standard'),
+        contact_trend: rowGet(entity, 'contact_trend'),
+      };
+
+      // Attach cached summary if available
+      if (includeSummaries) {
+        try {
+          const summary = db.queryOne(
+            "SELECT * FROM entity_summaries WHERE entity_id = ? AND summary_type = 'overview'",
+            [entity.id],
+          );
+          if (summary) {
+            entityData.summary = summary.summary;
+            entityData.summary_generated_at = summary.generated_at;
+          }
+        } catch {
+          // entity_summaries table may not exist
+        }
+      }
+
+      result.entities.push(entityData);
+    }
+  }
+
+  if (entityIds.length === 0) return result;
+
+  // Cross-entity relationships
+  if (entityIds.length >= 2) {
+    for (let i = 0; i < entityIds.length; i++) {
+      for (let j = i + 1; j < entityIds.length; j++) {
+        const rels = db.query(
+          `SELECT r.relationship_type, r.strength, r.origin_type,
+                  s.name as source_name, t.name as target_name
+           FROM relationships r
+           JOIN entities s ON r.source_entity_id = s.id
+           JOIN entities t ON r.target_entity_id = t.id
+           WHERE ((r.source_entity_id = ? AND r.target_entity_id = ?)
+               OR (r.source_entity_id = ? AND r.target_entity_id = ?))
+             AND r.invalid_at IS NULL`,
+          [entityIds[i], entityIds[j], entityIds[j], entityIds[i]],
+        ) || [];
+        for (const rel of rels) {
+          result.relationship_map.push({
+            source: rel.source_name,
+            target: rel.target_name,
+            type: rel.relationship_type,
+            strength: rel.strength,
+            origin: rel.origin_type,
+          });
+        }
+      }
+    }
+  }
+
+  // Network connections for each entity (1-hop)
+  if (includeNetwork) {
+    for (const eid of entityIds) {
+      const neighbors = expandGraphWeighted(db, eid, 1, 10);
+      for (const n of neighbors) {
+        if (!entityIds.includes(n.id)) {
+          const sourceName = result.entities.find(e => e.id === eid)?.name || 'unknown';
+          result.relationship_map.push({
+            source: sourceName,
+            target: n.name,
+            type: n.via_relationship || 'connected_to',
+            strength: n.path_strength || 0.5,
+            hop: 1,
+          });
+        }
+      }
+    }
+  }
+
+  // Co-mentioned memories across the queried entities
+  if (entityIds.length >= 2) {
+    const ph = entityIds.map(() => '?').join(', ');
+    const coMemories = db.query(
+      `SELECT m.content, m.type, m.importance,
+              GROUP_CONCAT(e.name) as entity_names,
+              COUNT(DISTINCT me.entity_id) as entity_hit_count
+       FROM memories m
+       JOIN memory_entities me ON m.id = me.memory_id
+       JOIN entities e ON me.entity_id = e.id
+       WHERE me.entity_id IN (${ph})
+         AND m.invalidated_at IS NULL
+       GROUP BY m.id
+       HAVING entity_hit_count >= 2
+       ORDER BY m.importance DESC
+       LIMIT 10`,
+      entityIds,
+    ) || [];
+
+    for (const mem of coMemories) {
+      result.cross_entity_patterns.push({
+        content: mem.content,
+        type: mem.type,
+        importance: mem.importance,
+        entities_involved: mem.entity_names ? mem.entity_names.split(',').map(s => s.trim()) : [],
+      });
+    }
+  }
+
+  // Open commitments across all entities
+  const ph = entityIds.map(() => '?').join(', ');
+  const commitments = db.query(
+    `SELECT m.content, m.deadline_at, e.name as entity_name
+     FROM memories m
+     JOIN memory_entities me ON m.id = me.memory_id
+     JOIN entities e ON me.entity_id = e.id
+     WHERE me.entity_id IN (${ph})
+       AND m.type = 'commitment'
+       AND m.invalidated_at IS NULL
+     ORDER BY m.deadline_at ASC, m.importance DESC
+     LIMIT 10`,
+    entityIds,
+  ) || [];
+
+  for (const c of commitments) {
+    result.open_commitments.push({
+      content: c.content,
+      deadline: c.deadline_at,
+      entity: c.entity_name,
+    });
+  }
+
+  return result;
+}

--- a/cli/services/remember.js
+++ b/cli/services/remember.js
@@ -1,0 +1,1804 @@
+/**
+ * Remember Service for Claudia CLI (Node.js port).
+ *
+ * Port of memory-daemon/claudia_memory/services/remember.py.
+ *
+ * Handles storing memories, entities, relationships, conversation turns,
+ * session finalization, reflections, corrections, invalidations, merges,
+ * and batch operations.
+ *
+ * All functions take `db` (ClaudiaDatabase instance) as the first parameter.
+ * Functions that need embeddings are async; pure-DB functions are synchronous.
+ */
+
+import { createHash, randomUUID } from 'node:crypto';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import { contentHash } from '../core/database.js';
+import { getConfig } from '../core/config.js';
+import { embed, embedBatch } from '../core/embeddings.js';
+import {
+  validateMemory,
+  validateEntity,
+  validateRelationship,
+  canonicalName,
+  ORIGIN_STRENGTH_CEILING,
+  REINFORCEMENT_BY_ORIGIN,
+} from '../core/guards.js';
+import { auditLog } from './audit.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function _now() {
+  return new Date().toISOString();
+}
+
+/**
+ * Compute SHA-256 chain hash for memory integrity verification.
+ * @param {string} content
+ * @param {object|null} metadata
+ * @param {string|null} prevHash
+ * @returns {string}
+ */
+function _computeChainHash(content, metadata, prevHash) {
+  const metaStr = metadata ? JSON.stringify(metadata, Object.keys(metadata).sort()) : '';
+  const payload = `${content}|${metaStr}|${prevHash || ''}`;
+  return createHash('sha256').update(payload, 'utf-8').digest('hex');
+}
+
+/**
+ * Safe audit log wrapper. Audit failures never crash the caller.
+ */
+function _audit(db, operation, options = {}) {
+  try {
+    auditLog(db, operation, options);
+  } catch {
+    // Swallow audit errors
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Entity lookup helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Find entity by name (canonical match or alias), or create if not found.
+ * Synchronous helper (entity creation itself calls rememberEntity which needs
+ * to be called in an async context for embeddings, but this sync version
+ * skips embedding for the quick-create path used internally).
+ *
+ * @param {object} db
+ * @param {string} name
+ * @param {string} [entityType='person']
+ * @returns {number|null} Entity ID
+ */
+function _findOrCreateEntitySync(db, name, entityType = 'person') {
+  const canonical = canonicalName(name);
+
+  // Try exact canonical match
+  const existing = db.queryOne(
+    'SELECT id FROM entities WHERE canonical_name = ?',
+    [canonical]
+  );
+  if (existing) return existing.id;
+
+  // Try alias match
+  const aliasMatch = db.queryOne(
+    'SELECT entity_id FROM entity_aliases WHERE canonical_alias = ?',
+    [canonical]
+  );
+  if (aliasMatch) return aliasMatch.entity_id;
+
+  // Create new entity (no embedding in sync path; embedding added later if needed)
+  const now = _now();
+  const id = db.insert('entities', {
+    name,
+    type: entityType,
+    canonical_name: canonical,
+    importance: 1.0,
+    created_at: now,
+    updated_at: now,
+  });
+
+  _audit(db, 'entity_create', { details: { name, type: entityType } });
+  return id;
+}
+
+/**
+ * Async version of find-or-create that generates embeddings for new entities.
+ * @param {object} db
+ * @param {string} name
+ * @param {string} [entityType='person']
+ * @returns {Promise<number|null>} Entity ID
+ */
+async function _findOrCreateEntity(db, name, entityType = 'person') {
+  const canonical = canonicalName(name);
+
+  const existing = db.queryOne(
+    'SELECT id FROM entities WHERE canonical_name = ?',
+    [canonical]
+  );
+  if (existing) return existing.id;
+
+  const aliasMatch = db.queryOne(
+    'SELECT entity_id FROM entity_aliases WHERE canonical_alias = ?',
+    [canonical]
+  );
+  if (aliasMatch) return aliasMatch.entity_id;
+
+  // Create new entity with embedding
+  return rememberEntity(db, name, entityType);
+}
+
+// ---------------------------------------------------------------------------
+// Episode helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a new episode.
+ * @param {object} db
+ * @param {string|null} [source=null]
+ * @returns {number} Episode ID
+ */
+function _getOrCreateEpisode(db, source = null) {
+  const sessionId = randomUUID();
+  const data = {
+    session_id: sessionId,
+    started_at: _now(),
+    message_count: 0,
+  };
+  if (source) data.source = source;
+  return db.insert('episodes', data);
+}
+
+// ---------------------------------------------------------------------------
+// rememberFact
+// ---------------------------------------------------------------------------
+
+/**
+ * Store a discrete fact/memory.
+ *
+ * @param {object} db - ClaudiaDatabase instance
+ * @param {string} content - The memory content
+ * @param {object} [options]
+ * @param {string} [options.memoryType='fact'] - fact, preference, observation, learning, commitment, pattern
+ * @param {string[]} [options.aboutEntities] - List of entity names this memory relates to
+ * @param {number} [options.importance=1.0] - 0.0-1.0
+ * @param {number} [options.confidence=1.0] - 0.0-1.0
+ * @param {string} [options.source] - Where this came from
+ * @param {string} [options.sourceId] - Reference to source
+ * @param {string} [options.sourceContext] - One-line breadcrumb
+ * @param {object} [options.metadata] - Additional metadata
+ * @param {string} [options.originType] - user_stated, extracted, inferred, corrected
+ * @param {string} [options.sourceChannel] - claude_code, telegram, slack
+ * @param {boolean} [options.critical=false] - If true, mark sacred (immune to decay)
+ * @param {string} [options.factId] - UUID for the memory; auto-generated if omitted
+ * @param {number[]} [options.precomputedEmbedding] - Skip Ollama call if provided
+ * @returns {Promise<number|null>} Memory ID or null if duplicate
+ */
+export async function rememberFact(db, content, options = {}) {
+  const {
+    memoryType = 'fact',
+    aboutEntities = null,
+    importance: rawImportance = 1.0,
+    confidence = 1.0,
+    source = null,
+    sourceId = null,
+    sourceContext = null,
+    metadata = null,
+    originType: rawOriginType = null,
+    sourceChannel = null,
+    critical = false,
+    factId: rawFactId = null,
+    precomputedEmbedding = null,
+  } = options;
+
+  let importance = rawImportance;
+  let originType = rawOriginType;
+  let factId = rawFactId;
+
+  // Check for duplicate
+  const memHash = contentHash(content);
+  const existing = db.queryOne(
+    'SELECT id, access_count FROM memories WHERE content_hash = ?',
+    [memHash]
+  );
+  if (existing) {
+    // Update access count and timestamp
+    db.update(
+      'memories',
+      {
+        last_accessed_at: _now(),
+        access_count: (existing.access_count || 0) + 1,
+      },
+      'id = ?',
+      [existing.id]
+    );
+    return existing.id;
+  }
+
+  if (!factId) {
+    factId = randomUUID();
+  }
+
+  // Run deterministic guards
+  const guardResult = validateMemory(content, memoryType, importance);
+  for (const w of guardResult.warnings) {
+    process.stderr.write(`[remember] Memory guard: ${w}\n`);
+  }
+  if ('content' in guardResult.adjustments) {
+    content = guardResult.adjustments.content;
+  }
+  if ('importance' in guardResult.adjustments) {
+    importance = guardResult.adjustments.importance;
+  }
+
+  // Determine origin_type (Trust North Star)
+  if (!originType) {
+    if (source === 'conversation' && importance >= 0.9) {
+      originType = 'user_stated';
+    } else if (['transcript', 'email', 'document', 'session_summary'].includes(source)) {
+      originType = 'extracted';
+    } else {
+      originType = 'inferred';
+    }
+  }
+
+  // Extract deadline for commitments (temporal intelligence)
+  let deadlineAt = null;
+  let temporalMarkersJson = null;
+  if (memoryType === 'commitment') {
+    try {
+      // Simple deadline extraction from guards
+      const { hasDeadlinePattern } = await import('../core/guards.js');
+      if (hasDeadlinePattern(content)) {
+        // Extract date-like patterns for the deadline_at field
+        const dateMatch = content.match(
+          /\b(\d{4}-\d{2}-\d{2}|\d{1,2}[/-]\d{1,2}(?:[/-]\d{2,4})?)\b/
+        );
+        if (dateMatch) {
+          deadlineAt = dateMatch[1];
+        }
+      }
+    } catch {
+      // Deadline extraction is best-effort
+    }
+  }
+
+  // Insert new memory
+  const now = _now();
+  const insertData = {
+    content,
+    content_hash: memHash,
+    type: memoryType,
+    importance,
+    confidence,
+    source,
+    source_id: sourceId,
+    created_at: now,
+    updated_at: now,
+    metadata: metadata ? JSON.stringify(metadata) : null,
+    origin_type: originType,
+    fact_id: factId,
+  };
+  if (sourceContext) insertData.source_context = sourceContext;
+  if (sourceChannel) insertData.source_channel = sourceChannel;
+  if (deadlineAt) insertData.deadline_at = deadlineAt;
+  if (temporalMarkersJson) insertData.temporal_markers = temporalMarkersJson;
+  if (critical) {
+    insertData.lifecycle_tier = 'sacred';
+    insertData.sacred_reason = 'user-protected';
+  }
+
+  const memoryId = db.insert('memories', insertData);
+
+  // SHA-256 chain linking for memory integrity verification
+  try {
+    const config = getConfig();
+    if (config.enable_chain_verification) {
+      const prevHashRow = db.queryOne(
+        "SELECT value FROM _meta WHERE key = 'chain_head'"
+      );
+      const prevHash = prevHashRow ? prevHashRow.value : null;
+      const chainHash = _computeChainHash(content, metadata, prevHash);
+      db.run(
+        'UPDATE memories SET hash = ?, prev_hash = ? WHERE id = ?',
+        [chainHash, prevHash, memoryId]
+      );
+      db.run(
+        `INSERT INTO _meta (key, value, updated_at)
+         VALUES ('chain_head', ?, datetime('now'))
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+        [chainHash]
+      );
+    }
+  } catch {
+    // Chain hash is best-effort
+  }
+
+  // Store embedding (use precomputed if available, otherwise generate)
+  const embedding = precomputedEmbedding || (await embed(content));
+  if (embedding) {
+    try {
+      db.run(
+        'INSERT OR REPLACE INTO memory_embeddings (memory_id, embedding) VALUES (?, ?)',
+        [memoryId, JSON.stringify(embedding)]
+      );
+    } catch (e) {
+      process.stderr.write(`[remember] Could not store memory embedding: ${e.message}\n`);
+    }
+  }
+
+  // Link to entities
+  if (aboutEntities && aboutEntities.length > 0) {
+    for (const entityName of aboutEntities) {
+      const entityId = _findOrCreateEntitySync(db, entityName);
+      if (entityId) {
+        try {
+          db.insert('memory_entities', {
+            memory_id: memoryId,
+            entity_id: entityId,
+            relationship: 'about',
+          });
+        } catch {
+          // Duplicate link, ignore
+        }
+      }
+    }
+  }
+
+  // Audit log
+  _audit(db, 'memory_create', {
+    details: { type: memoryType, source, importance },
+    memoryId,
+  });
+
+  return memoryId;
+}
+
+// ---------------------------------------------------------------------------
+// rememberEntity
+// ---------------------------------------------------------------------------
+
+/**
+ * Create or update an entity.
+ *
+ * @param {object} db
+ * @param {string} name
+ * @param {string} [entityType='person']
+ * @param {object} [options]
+ * @param {string} [options.description]
+ * @param {string[]} [options.aliases]
+ * @param {object} [options.metadata]
+ * @param {number[]} [options.precomputedEmbedding]
+ * @returns {Promise<number>} Entity ID
+ */
+export async function rememberEntity(db, name, entityType = 'person', options = {}) {
+  const {
+    description = null,
+    aliases = null,
+    metadata = null,
+    precomputedEmbedding = null,
+  } = options;
+
+  // Run deterministic guards
+  const existingNames = db.query('SELECT canonical_name FROM entities')
+    .map(r => r.canonical_name);
+  const guardResult = validateEntity(name, entityType, existingNames);
+  for (const w of guardResult.warnings) {
+    process.stderr.write(`[remember] Entity guard: ${w}\n`);
+  }
+  if ('type' in guardResult.adjustments) {
+    entityType = guardResult.adjustments.type;
+  }
+
+  const canonical = canonicalName(name);
+
+  // Check for existing
+  const existing = db.queryOne(
+    'SELECT * FROM entities WHERE canonical_name = ? AND type = ?',
+    [canonical, entityType]
+  );
+
+  let entityId;
+
+  if (existing) {
+    // Update existing
+    const updateData = { updated_at: _now() };
+    if (description) {
+      updateData.description = description;
+    }
+    if (metadata) {
+      const existingMeta = JSON.parse(existing.metadata || '{}');
+      Object.assign(existingMeta, metadata);
+      updateData.metadata = JSON.stringify(existingMeta);
+    }
+
+    db.update('entities', updateData, 'id = ?', [existing.id]);
+    entityId = existing.id;
+  } else {
+    // Create new
+    const now = _now();
+    entityId = db.insert('entities', {
+      name,
+      type: entityType,
+      canonical_name: canonical,
+      description,
+      importance: 1.0,
+      created_at: now,
+      updated_at: now,
+      metadata: metadata ? JSON.stringify(metadata) : null,
+    });
+
+    // Store embedding (use precomputed if available, otherwise generate)
+    const embedText = `${name}. ${description || ''}`;
+    const embedding = precomputedEmbedding || (await embed(embedText));
+    if (embedding) {
+      try {
+        db.run(
+          'INSERT OR REPLACE INTO entity_embeddings (entity_id, embedding) VALUES (?, ?)',
+          [entityId, JSON.stringify(embedding)]
+        );
+      } catch (e) {
+        process.stderr.write(`[remember] Could not store entity embedding: ${e.message}\n`);
+      }
+    }
+
+    // Audit log for new entity
+    _audit(db, 'entity_create', {
+      details: { name, type: entityType },
+      entityId,
+    });
+  }
+
+  // Add aliases
+  if (aliases && aliases.length > 0) {
+    const now = _now();
+    for (const alias of aliases) {
+      const canonicalAlias = canonicalName(alias);
+      try {
+        db.insert('entity_aliases', {
+          entity_id: entityId,
+          alias,
+          canonical_alias: canonicalAlias,
+          created_at: now,
+        });
+      } catch {
+        // Duplicate alias, ignore
+      }
+    }
+  }
+
+  return entityId;
+}
+
+// ---------------------------------------------------------------------------
+// relateEntities
+// ---------------------------------------------------------------------------
+
+/**
+ * Create or strengthen a relationship between entities.
+ *
+ * @param {object} db
+ * @param {string} sourceName - Source entity name
+ * @param {string} targetName - Target entity name
+ * @param {string} relationshipType - works_with, manages, etc.
+ * @param {object} [options]
+ * @param {number} [options.strength=1.0]
+ * @param {string} [options.direction='bidirectional'] - forward, backward, bidirectional
+ * @param {object} [options.metadata]
+ * @param {string} [options.validAt] - ISO string
+ * @param {boolean} [options.supersedes=false] - Invalidate existing before creating new
+ * @param {string} [options.originType='extracted']
+ * @returns {number|null} Relationship ID or null
+ */
+export function relateEntities(db, sourceName, targetName, relationshipType, options = {}) {
+  let {
+    strength = 1.0,
+    direction = 'bidirectional',
+    metadata = null,
+    validAt = null,
+    supersedes = false,
+    originType = 'extracted',
+  } = options;
+
+  // Run deterministic guards (origin-aware)
+  const guardResult = validateRelationship(strength, originType);
+  for (const w of guardResult.warnings) {
+    process.stderr.write(`[remember] Relationship guard: ${w}\n`);
+  }
+  if ('strength' in guardResult.adjustments) {
+    strength = guardResult.adjustments.strength;
+  }
+
+  const sourceId = _findOrCreateEntitySync(db, sourceName);
+  const targetId = _findOrCreateEntitySync(db, targetName);
+
+  if (!sourceId || !targetId) return null;
+
+  const now = _now();
+  const effectiveValidAt = validAt || now;
+
+  if (supersedes) {
+    // Invalidate existing relationship of same type between same entities (atomic)
+    const existingToSupersede = db.queryOne(
+      `SELECT * FROM relationships
+       WHERE source_entity_id = ? AND target_entity_id = ?
+         AND relationship_type = ? AND invalid_at IS NULL`,
+      [sourceId, targetId, relationshipType]
+    );
+
+    if (existingToSupersede) {
+      const txn = db.createTransaction(() => {
+        // Invalidate the old relationship (mark when it ended)
+        db.run(
+          'UPDATE relationships SET invalid_at = ?, updated_at = ? WHERE id = ?',
+          [now, now, existingToSupersede.id]
+        );
+        // Rename the type to free the UNIQUE constraint slot
+        const oldMeta = JSON.parse(existingToSupersede.metadata || '{}');
+        oldMeta.superseded_by_at = now;
+        db.run(
+          'UPDATE relationships SET relationship_type = ?, metadata = ? WHERE id = ?',
+          [
+            `${relationshipType}__superseded_${existingToSupersede.id}`,
+            JSON.stringify(oldMeta),
+            existingToSupersede.id,
+          ]
+        );
+      });
+      txn();
+
+      _audit(db, 'relationship_supersede', {
+        details: {
+          old_id: existingToSupersede.id,
+          source: sourceName,
+          target: targetName,
+          type: relationshipType,
+        },
+      });
+    }
+
+    // Supersede always sets origin_type to 'corrected'
+    const supersedeOrigin = 'corrected';
+    const ceiling = ORIGIN_STRENGTH_CEILING[supersedeOrigin] ?? 0.5;
+    const cappedStrength = Math.min(strength, ceiling);
+
+    // Create new relationship
+    const newId = db.insert('relationships', {
+      source_entity_id: sourceId,
+      target_entity_id: targetId,
+      relationship_type: relationshipType,
+      strength: cappedStrength,
+      origin_type: supersedeOrigin,
+      direction,
+      valid_at: effectiveValidAt,
+      created_at: now,
+      updated_at: now,
+      metadata: metadata ? JSON.stringify(metadata) : null,
+    });
+
+    _audit(db, 'relationship_create', {
+      details: {
+        id: newId,
+        source: sourceName,
+        target: targetName,
+        type: relationshipType,
+        origin_type: supersedeOrigin,
+        strength: cappedStrength,
+      },
+    });
+
+    return newId;
+  }
+
+  // Check for existing current relationship (non-supersede path)
+  const existing = db.queryOne(
+    `SELECT * FROM relationships
+     WHERE source_entity_id = ? AND target_entity_id = ?
+       AND relationship_type = ? AND invalid_at IS NULL`,
+    [sourceId, targetId, relationshipType]
+  );
+
+  if (existing) {
+    // Determine ceiling: if new origin is higher-authority, upgrade
+    const existingOrigin = existing.origin_type || 'extracted';
+    let effectiveOrigin = existingOrigin;
+
+    // Origin upgrade: user_stated/corrected outrank extracted, which outranks inferred
+    const originRank = { inferred: 0, extracted: 1, user_stated: 2, corrected: 2 };
+    if ((originRank[originType] ?? 0) > (originRank[existingOrigin] ?? 0)) {
+      effectiveOrigin = originType;
+    }
+
+    const ceiling = ORIGIN_STRENGTH_CEILING[effectiveOrigin] ?? 0.5;
+    const increment = REINFORCEMENT_BY_ORIGIN[originType] ?? 0.1;
+    const newStrength = Math.min(ceiling, existing.strength + increment);
+
+    const updateData = {
+      strength: newStrength,
+      updated_at: now,
+      origin_type: effectiveOrigin,
+    };
+    // Ensure valid_at is set on existing relationships
+    if (!existing.valid_at) {
+      updateData.valid_at = existing.created_at;
+    }
+
+    db.update('relationships', updateData, 'id = ?', [existing.id]);
+    return existing.id;
+  }
+
+  // Create new relationship
+  const newId = db.insert('relationships', {
+    source_entity_id: sourceId,
+    target_entity_id: targetId,
+    relationship_type: relationshipType,
+    strength,
+    origin_type: originType,
+    direction,
+    valid_at: effectiveValidAt,
+    created_at: now,
+    updated_at: now,
+    metadata: metadata ? JSON.stringify(metadata) : null,
+  });
+
+  _audit(db, 'relationship_create', {
+    details: {
+      id: newId,
+      source: sourceName,
+      target: targetName,
+      type: relationshipType,
+      origin_type: originType,
+      strength,
+    },
+  });
+
+  return newId;
+}
+
+// ---------------------------------------------------------------------------
+// invalidateRelationship
+// ---------------------------------------------------------------------------
+
+/**
+ * Invalidate a relationship without creating a replacement.
+ *
+ * Finds the active relationship by source + target + type, marks it with
+ * invalid_at, and renames the type to free the UNIQUE constraint. Atomic.
+ *
+ * @param {object} db
+ * @param {string} sourceName
+ * @param {string} targetName
+ * @param {string} relationshipType
+ * @param {object} [options]
+ * @param {string} [options.reason]
+ * @returns {object|null} Dict with invalidated relationship info, or null if not found
+ */
+export function invalidateRelationship(db, sourceName, targetName, relationshipType, options = {}) {
+  const { reason = null } = options;
+
+  const sourceId = _findOrCreateEntitySync(db, sourceName);
+  const targetId = _findOrCreateEntitySync(db, targetName);
+
+  if (!sourceId || !targetId) return null;
+
+  const existing = db.queryOne(
+    `SELECT * FROM relationships
+     WHERE source_entity_id = ? AND target_entity_id = ?
+       AND relationship_type = ? AND invalid_at IS NULL`,
+    [sourceId, targetId, relationshipType]
+  );
+
+  if (!existing) return null;
+
+  const now = _now();
+
+  const txn = db.createTransaction(() => {
+    // Invalidate and rename type atomically
+    const oldMeta = JSON.parse(existing.metadata || '{}');
+    oldMeta.invalidated_reason = reason;
+    oldMeta.invalidated_at = now;
+
+    db.run(
+      `UPDATE relationships SET invalid_at = ?, updated_at = ?,
+       relationship_type = ?, metadata = ? WHERE id = ?`,
+      [
+        now,
+        now,
+        `${relationshipType}__invalidated_${existing.id}`,
+        JSON.stringify(oldMeta),
+        existing.id,
+      ]
+    );
+  });
+  txn();
+
+  _audit(db, 'relationship_invalidate', {
+    details: {
+      id: existing.id,
+      source: sourceName,
+      target: targetName,
+      type: relationshipType,
+      reason,
+    },
+  });
+
+  return {
+    relationship_id: existing.id,
+    source: sourceName,
+    target: targetName,
+    relationship_type: relationshipType,
+    invalidated_at: now,
+    reason,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// correctMemory
+// ---------------------------------------------------------------------------
+
+/**
+ * Correct a memory's content, preserving history.
+ *
+ * Stores original content in corrected_from, updates content,
+ * and sets corrected_at timestamp for audit trail.
+ *
+ * @param {object} db
+ * @param {number} memoryId
+ * @param {string} correction - New corrected content
+ * @param {object} [options]
+ * @param {string} [options.reason]
+ * @returns {Promise<object>} Correction status
+ */
+export async function correctMemory(db, memoryId, correction, options = {}) {
+  const { reason = null } = options;
+
+  const memory = db.queryOne('SELECT * FROM memories WHERE id = ?', [memoryId]);
+  if (!memory) {
+    return { success: false, error: `Memory ${memoryId} not found` };
+  }
+
+  const now = _now();
+  const originalContent = memory.content;
+
+  // Build metadata with correction history
+  const existingMeta = JSON.parse(memory.metadata || '{}');
+  const correctionsHistory = existingMeta.corrections || [];
+  correctionsHistory.push({
+    original: originalContent,
+    corrected_to: correction,
+    reason,
+    corrected_at: now,
+  });
+  existingMeta.corrections = correctionsHistory;
+
+  // Update the memory
+  const newHash = contentHash(correction);
+  db.update(
+    'memories',
+    {
+      content: correction,
+      content_hash: newHash,
+      corrected_at: now,
+      corrected_from: originalContent,
+      updated_at: now,
+      metadata: JSON.stringify(existingMeta),
+      origin_type: 'corrected',
+      confidence: 1.0,
+    },
+    'id = ?',
+    [memoryId]
+  );
+
+  // Re-generate embedding for new content
+  const embedding = await embed(correction);
+  if (embedding) {
+    try {
+      db.run(
+        'INSERT OR REPLACE INTO memory_embeddings (memory_id, embedding) VALUES (?, ?)',
+        [memoryId, JSON.stringify(embedding)]
+      );
+    } catch (e) {
+      process.stderr.write(`[remember] Could not update memory embedding: ${e.message}\n`);
+    }
+  }
+
+  _audit(db, 'memory_correct', {
+    details: {
+      original_content: originalContent.slice(0, 200),
+      corrected_content: correction.slice(0, 200),
+      reason,
+    },
+    memoryId,
+    userInitiated: true,
+  });
+
+  return {
+    success: true,
+    memory_id: memoryId,
+    original_content: originalContent,
+    corrected_content: correction,
+    corrected_at: now,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// invalidateMemory
+// ---------------------------------------------------------------------------
+
+/**
+ * Mark a memory as no longer true (soft delete).
+ *
+ * Sets invalidated_at timestamp but preserves the memory for
+ * historical queries.
+ *
+ * @param {object} db
+ * @param {number} memoryId
+ * @param {object} [options]
+ * @param {string} [options.reason]
+ * @returns {object} Invalidation status
+ */
+export function invalidateMemory(db, memoryId, options = {}) {
+  const { reason = null } = options;
+
+  const memory = db.queryOne('SELECT * FROM memories WHERE id = ?', [memoryId]);
+  if (!memory) {
+    return { success: false, error: `Memory ${memoryId} not found` };
+  }
+
+  const now = _now();
+
+  // Build metadata with invalidation reason
+  const existingMeta = JSON.parse(memory.metadata || '{}');
+  existingMeta.invalidation = {
+    reason: reason || 'User requested invalidation',
+    invalidated_at: now,
+  };
+
+  db.update(
+    'memories',
+    {
+      invalidated_at: now,
+      invalidated_reason: reason || 'User requested invalidation',
+      updated_at: now,
+      metadata: JSON.stringify(existingMeta),
+    },
+    'id = ?',
+    [memoryId]
+  );
+
+  _audit(db, 'memory_invalidate', {
+    details: {
+      content: memory.content.slice(0, 200),
+      reason: reason || 'User requested invalidation',
+    },
+    memoryId,
+    userInitiated: true,
+  });
+
+  return {
+    success: true,
+    memory_id: memoryId,
+    content: memory.content,
+    invalidated_at: now,
+    reason,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// bufferTurn
+// ---------------------------------------------------------------------------
+
+/**
+ * Buffer a conversation turn for later summarization.
+ *
+ * Lightweight storage -- no embeddings, no extraction, no processing.
+ * The raw exchange is held in turn_buffer until Claude summarizes the session.
+ *
+ * @param {object} db
+ * @param {object} [options]
+ * @param {string} [options.userContent]
+ * @param {string} [options.assistantContent]
+ * @param {number} [options.episodeId] - Creates one if null
+ * @param {string} [options.source] - Origin channel
+ * @returns {object} { episode_id, turn_number }
+ */
+export function bufferTurn(db, options = {}) {
+  let {
+    userContent = null,
+    assistantContent = null,
+    episodeId = null,
+    source = null,
+  } = options;
+
+  if (episodeId == null) {
+    episodeId = _getOrCreateEpisode(db, source);
+  }
+
+  // Get next turn number
+  const row = db.queryOne(
+    'SELECT COALESCE(MAX(turn_number), 0) as max_turn FROM turn_buffer WHERE episode_id = ?',
+    [episodeId]
+  );
+  const nextTurn = (row ? row.max_turn : 0) + 1;
+
+  const insertData = {
+    episode_id: episodeId,
+    turn_number: nextTurn,
+    user_content: userContent,
+    assistant_content: assistantContent,
+    created_at: _now(),
+  };
+  if (source) insertData.source = source;
+
+  db.insert('turn_buffer', insertData);
+
+  // Update episode turn count
+  db.run(
+    'UPDATE episodes SET turn_count = turn_count + 1 WHERE id = ?',
+    [episodeId]
+  );
+
+  return { episode_id: episodeId, turn_number: nextTurn };
+}
+
+// ---------------------------------------------------------------------------
+// endSession
+// ---------------------------------------------------------------------------
+
+/**
+ * Finalize a session with Claude's narrative summary and structured extractions.
+ *
+ * @param {object} db
+ * @param {number} episodeId
+ * @param {string} narrative - Free-form narrative summary
+ * @param {object} [options]
+ * @param {Array<{content:string, type?:string, about?:string[], importance?:number, source?:string, source_context?:string, source_material?:string}>} [options.facts]
+ * @param {Array<{content:string, about?:string[], importance?:number, source?:string, source_context?:string, source_material?:string}>} [options.commitments]
+ * @param {Array<{name:string, type?:string, description?:string, aliases?:string[]}>} [options.entities]
+ * @param {Array<{source:string, target:string, relationship:string, strength?:number}>} [options.relationships]
+ * @param {string[]} [options.keyTopics]
+ * @returns {Promise<object>} Counts of what was stored
+ */
+export async function endSession(db, episodeId, narrative, options = {}) {
+  const {
+    facts = null,
+    commitments = null,
+    entities = null,
+    relationships = null,
+    keyTopics = null,
+  } = options;
+
+  const result = {
+    episode_id: episodeId,
+    narrative_stored: false,
+    facts_stored: 0,
+    commitments_stored: 0,
+    entities_stored: 0,
+    relationships_stored: 0,
+  };
+
+  // Validate episode exists
+  const episode = db.queryOne('SELECT id FROM episodes WHERE id = ?', [episodeId]);
+  if (!episode) {
+    result.error = `Episode ${episodeId} not found. Call memory.buffer_turn first to create an episode.`;
+    return result;
+  }
+
+  // 1. Store narrative in episode
+  const updateData = {
+    narrative,
+    ended_at: _now(),
+    is_summarized: 1,
+  };
+  if (keyTopics) {
+    updateData.key_topics = JSON.stringify(keyTopics);
+  }
+  db.update('episodes', updateData, 'id = ?', [episodeId]);
+  result.narrative_stored = true;
+
+  // 2. Generate and store embedding for narrative
+  const narrativeEmbedding = await embed(narrative);
+  if (narrativeEmbedding) {
+    try {
+      db.run(
+        'INSERT OR REPLACE INTO episode_embeddings (episode_id, embedding) VALUES (?, ?)',
+        [episodeId, JSON.stringify(narrativeEmbedding)]
+      );
+    } catch (e) {
+      process.stderr.write(`[remember] Could not store episode embedding: ${e.message}\n`);
+    }
+  }
+
+  // 3. Store structured facts
+  if (facts) {
+    for (const fact of facts) {
+      const memId = await rememberFact(db, fact.content, {
+        memoryType: fact.type || 'fact',
+        aboutEntities: fact.about,
+        importance: fact.importance ?? 1.0,
+        source: fact.source || 'session_summary',
+        sourceId: String(episodeId),
+        sourceContext: fact.source_context,
+      });
+      if (memId) {
+        result.facts_stored++;
+        if (fact.source_material) {
+          saveSourceMaterial(db, memId, fact.source_material, {
+            source: fact.source || 'session_summary',
+            source_context: fact.source_context,
+          });
+        }
+      }
+    }
+  }
+
+  // 4. Store commitments
+  if (commitments) {
+    for (const commitment of commitments) {
+      const memId = await rememberFact(db, commitment.content, {
+        memoryType: 'commitment',
+        aboutEntities: commitment.about,
+        importance: commitment.importance ?? 1.0,
+        source: commitment.source || 'session_summary',
+        sourceId: String(episodeId),
+        sourceContext: commitment.source_context,
+      });
+      if (memId) {
+        result.commitments_stored++;
+        if (commitment.source_material) {
+          saveSourceMaterial(db, memId, commitment.source_material, {
+            source: commitment.source || 'session_summary',
+            source_context: commitment.source_context,
+          });
+        }
+      }
+    }
+  }
+
+  // 5. Store entities
+  if (entities) {
+    for (const entity of entities) {
+      const entId = await rememberEntity(db, entity.name, entity.type || 'person', {
+        description: entity.description,
+        aliases: entity.aliases,
+      });
+      if (entId) {
+        result.entities_stored++;
+      }
+    }
+  }
+
+  // 6. Store relationships
+  if (relationships) {
+    for (const rel of relationships) {
+      const relId = relateEntities(db, rel.source, rel.target, rel.relationship, {
+        strength: rel.strength ?? 1.0,
+      });
+      if (relId) {
+        result.relationships_stored++;
+      }
+    }
+  }
+
+  // 7. Archive turn buffer for this episode
+  db.run(
+    'UPDATE turn_buffer SET is_archived = 1 WHERE episode_id = ?',
+    [episodeId]
+  );
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// storeReflection
+// ---------------------------------------------------------------------------
+
+/**
+ * Store a reflection (observation, pattern, learning, question) from /meditate.
+ *
+ * Reflections are user-approved persistent learnings that decay very slowly.
+ *
+ * @param {object} db
+ * @param {string} content
+ * @param {string} reflectionType - observation, pattern, learning, question
+ * @param {object} [options]
+ * @param {number} [options.episodeId]
+ * @param {string} [options.aboutEntity] - Entity name
+ * @param {number} [options.importance=0.7]
+ * @param {number} [options.confidence=0.8]
+ * @returns {Promise<number|null>} Reflection ID or null if duplicate
+ */
+export async function storeReflection(db, content, reflectionType, options = {}) {
+  const {
+    episodeId = null,
+    aboutEntity = null,
+    importance = 0.7,
+    confidence = 0.8,
+  } = options;
+
+  // Check for near-duplicate
+  const refHash = contentHash(content);
+  const existing = db.queryOne(
+    'SELECT * FROM reflections WHERE content_hash = ?',
+    [refHash]
+  );
+  if (existing) {
+    // Duplicate content - confirm the existing one instead of creating new
+    db.update(
+      'reflections',
+      {
+        last_confirmed_at: _now(),
+        aggregation_count: (existing.aggregation_count || 0) + 1,
+        confidence: Math.min(1.0, (existing.confidence || 0) + 0.05),
+        updated_at: _now(),
+      },
+      'id = ?',
+      [existing.id]
+    );
+    return existing.id;
+  }
+
+  // Find entity if specified
+  let entityId = null;
+  if (aboutEntity) {
+    entityId = _findOrCreateEntitySync(db, aboutEntity);
+  }
+
+  // Insert new reflection
+  const now = _now();
+  const reflectionId = db.insert('reflections', {
+    episode_id: episodeId,
+    reflection_type: reflectionType,
+    content,
+    content_hash: refHash,
+    about_entity_id: entityId,
+    importance,
+    confidence,
+    decay_rate: 0.999,
+    aggregation_count: 1,
+    first_observed_at: now,
+    last_confirmed_at: now,
+    created_at: now,
+  });
+
+  // Generate and store embedding
+  const embedding = await embed(content);
+  if (embedding) {
+    try {
+      db.run(
+        'INSERT OR REPLACE INTO reflection_embeddings (reflection_id, embedding) VALUES (?, ?)',
+        [reflectionId, JSON.stringify(embedding)]
+      );
+    } catch (e) {
+      process.stderr.write(`[remember] Could not store reflection embedding: ${e.message}\n`);
+    }
+  }
+
+  return reflectionId;
+}
+
+// ---------------------------------------------------------------------------
+// updateReflection
+// ---------------------------------------------------------------------------
+
+/**
+ * Update an existing reflection.
+ *
+ * @param {object} db
+ * @param {number} reflectionId
+ * @param {object} [options]
+ * @param {string} [options.content]
+ * @param {number} [options.importance]
+ * @returns {Promise<boolean>} True if updated, false if not found
+ */
+export async function updateReflection(db, reflectionId, options = {}) {
+  const { content = null, importance = null } = options;
+
+  const existing = db.queryOne(
+    'SELECT id FROM reflections WHERE id = ?',
+    [reflectionId]
+  );
+  if (!existing) return false;
+
+  const updateData = { updated_at: _now() };
+
+  if (content !== null) {
+    updateData.content = content;
+    updateData.content_hash = contentHash(content);
+    // Re-generate embedding
+    const embedding = await embed(content);
+    if (embedding) {
+      try {
+        db.run(
+          'INSERT OR REPLACE INTO reflection_embeddings (reflection_id, embedding) VALUES (?, ?)',
+          [reflectionId, JSON.stringify(embedding)]
+        );
+      } catch (e) {
+        process.stderr.write(`[remember] Could not update reflection embedding: ${e.message}\n`);
+      }
+    }
+  }
+
+  if (importance !== null) {
+    updateData.importance = importance;
+  }
+
+  db.update('reflections', updateData, 'id = ?', [reflectionId]);
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// deleteReflection
+// ---------------------------------------------------------------------------
+
+/**
+ * Delete a reflection.
+ *
+ * @param {object} db
+ * @param {number} reflectionId
+ * @returns {boolean} True if deleted, false if not found
+ */
+export function deleteReflection(db, reflectionId) {
+  const { changes } = db.run('DELETE FROM reflections WHERE id = ?', [reflectionId]);
+  if (changes > 0) {
+    try {
+      db.run(
+        'DELETE FROM reflection_embeddings WHERE reflection_id = ?',
+        [reflectionId]
+      );
+    } catch {
+      // Ignore embedding cleanup errors
+    }
+    return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// getUnsummarizedTurns
+// ---------------------------------------------------------------------------
+
+/**
+ * Find episodes with buffered turns that were never summarized.
+ *
+ * @param {object} db
+ * @returns {object[]} List of episode info with turns
+ */
+export function getUnsummarizedTurns(db) {
+  const episodes = db.query(
+    `SELECT e.id, e.session_id, e.turn_count, e.started_at
+     FROM episodes e
+     WHERE e.is_summarized = 0
+       AND e.turn_count > 0
+     ORDER BY e.started_at DESC`
+  );
+
+  const results = [];
+  for (const ep of episodes) {
+    const turns = db.query(
+      `SELECT turn_number, user_content, assistant_content, created_at
+       FROM turn_buffer
+       WHERE episode_id = ? AND (is_archived = 0 OR is_archived IS NULL)
+       ORDER BY turn_number ASC`,
+      [ep.id]
+    );
+
+    if (turns.length > 0) {
+      results.push({
+        episode_id: ep.id,
+        session_id: ep.session_id,
+        started_at: ep.started_at,
+        turn_count: ep.turn_count,
+        turns: turns.map(t => ({
+          turn_number: t.turn_number,
+          user: t.user_content,
+          assistant: t.assistant_content,
+          timestamp: t.created_at,
+        })),
+      });
+    }
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// mergeEntities
+// ---------------------------------------------------------------------------
+
+/**
+ * Merge source entity into target entity.
+ *
+ * Updates all references to point to target, adds source name as alias of target,
+ * then soft-deletes the source entity. Preserves full history.
+ *
+ * @param {object} db
+ * @param {number} sourceId - Entity ID to merge FROM (will be deleted)
+ * @param {number} targetId - Entity ID to merge INTO (will be kept)
+ * @param {object} [options]
+ * @param {string} [options.reason]
+ * @returns {object} Merge statistics
+ */
+export function mergeEntities(db, sourceId, targetId, options = {}) {
+  const { reason = null } = options;
+  const now = _now();
+
+  const result = {
+    source_id: sourceId,
+    target_id: targetId,
+    aliases_moved: 0,
+    memories_moved: 0,
+    relationships_moved: 0,
+    reflections_moved: 0,
+    success: false,
+  };
+
+  // Verify both entities exist
+  const source = db.queryOne('SELECT * FROM entities WHERE id = ?', [sourceId]);
+  const target = db.queryOne('SELECT * FROM entities WHERE id = ?', [targetId]);
+
+  if (!source) {
+    result.error = `Source entity ${sourceId} not found`;
+    return result;
+  }
+  if (!target) {
+    result.error = `Target entity ${targetId} not found`;
+    return result;
+  }
+
+  // 1. Add source name as alias of target
+  try {
+    db.insert('entity_aliases', {
+      entity_id: targetId,
+      alias: source.name,
+      canonical_alias: source.canonical_name,
+      created_at: now,
+    });
+    result.aliases_moved++;
+  } catch {
+    // Duplicate alias, ignore
+  }
+
+  // 2. Move source's aliases to target
+  const sourceAliases = db.query(
+    'SELECT * FROM entity_aliases WHERE entity_id = ?',
+    [sourceId]
+  );
+  for (const alias of sourceAliases) {
+    try {
+      db.insert('entity_aliases', {
+        entity_id: targetId,
+        alias: alias.alias,
+        canonical_alias: alias.canonical_alias,
+        created_at: now,
+      });
+      result.aliases_moved++;
+    } catch {
+      // Duplicate alias, ignore
+    }
+  }
+  // Delete moved aliases from source
+  db.run('DELETE FROM entity_aliases WHERE entity_id = ?', [sourceId]);
+
+  // 3. Update memory_entities references
+  const memoriesResult = db.run(
+    `UPDATE memory_entities SET entity_id = ?
+     WHERE entity_id = ?
+       AND NOT EXISTS (
+         SELECT 1 FROM memory_entities me2
+         WHERE me2.memory_id = memory_entities.memory_id
+           AND me2.entity_id = ?
+       )`,
+    [targetId, sourceId, targetId]
+  );
+  // Delete any remaining duplicates
+  db.run('DELETE FROM memory_entities WHERE entity_id = ?', [sourceId]);
+  result.memories_moved = memoriesResult.changes || 0;
+
+  // 4. Update relationships (both source and target directions)
+  const relsSource = db.run(
+    `UPDATE relationships SET source_entity_id = ?, updated_at = ?
+     WHERE source_entity_id = ?
+       AND NOT EXISTS (
+         SELECT 1 FROM relationships r2
+         WHERE r2.source_entity_id = ?
+           AND r2.target_entity_id = relationships.target_entity_id
+           AND r2.relationship_type = relationships.relationship_type
+       )`,
+    [targetId, now, sourceId, targetId]
+  );
+  const relsTarget = db.run(
+    `UPDATE relationships SET target_entity_id = ?, updated_at = ?
+     WHERE target_entity_id = ?
+       AND NOT EXISTS (
+         SELECT 1 FROM relationships r2
+         WHERE r2.source_entity_id = relationships.source_entity_id
+           AND r2.target_entity_id = ?
+           AND r2.relationship_type = relationships.relationship_type
+       )`,
+    [targetId, now, sourceId, targetId]
+  );
+  // Delete any remaining duplicates
+  db.run(
+    'DELETE FROM relationships WHERE source_entity_id = ? OR target_entity_id = ?',
+    [sourceId, sourceId]
+  );
+  result.relationships_moved = (relsSource.changes || 0) + (relsTarget.changes || 0);
+
+  // 5. Update reflections about_entity_id
+  const reflectionsResult = db.run(
+    'UPDATE reflections SET about_entity_id = ? WHERE about_entity_id = ?',
+    [targetId, sourceId]
+  );
+  result.reflections_moved = reflectionsResult.changes || 0;
+
+  // 6. Merge attributes (target wins on conflicts, but preserve metadata)
+  if (source.description && !target.description) {
+    db.update('entities', { description: source.description }, 'id = ?', [targetId]);
+  }
+
+  const sourceMeta = JSON.parse(source.metadata || '{}');
+  const targetMeta = JSON.parse(target.metadata || '{}');
+  // Merge: source values fill in target gaps
+  const mergedMeta = { ...sourceMeta, ...targetMeta };
+  if (!mergedMeta.merged_from) mergedMeta.merged_from = [];
+  mergedMeta.merged_from.push({
+    entity_id: sourceId,
+    name: source.name,
+    merged_at: now,
+    reason,
+  });
+  db.update(
+    'entities',
+    { metadata: JSON.stringify(mergedMeta), updated_at: now },
+    'id = ?',
+    [targetId]
+  );
+
+  // 7. Soft-delete source entity
+  db.update(
+    'entities',
+    {
+      deleted_at: now,
+      deleted_reason: `Merged into entity ${targetId}` + (reason ? `: ${reason}` : ''),
+    },
+    'id = ?',
+    [sourceId]
+  );
+
+  result.success = true;
+
+  _audit(db, 'entity_merge', {
+    details: {
+      source_name: source.name,
+      target_name: target.name,
+      reason,
+      aliases_moved: result.aliases_moved,
+      memories_moved: result.memories_moved,
+      relationships_moved: result.relationships_moved,
+    },
+    entityId: targetId,
+    userInitiated: true,
+  });
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// deleteEntity
+// ---------------------------------------------------------------------------
+
+/**
+ * Soft-delete an entity.
+ *
+ * Sets deleted_at timestamp. Does NOT remove references (memories, relationships)
+ * as they may have historical value.
+ *
+ * @param {object} db
+ * @param {number} entityId
+ * @param {object} [options]
+ * @param {string} [options.reason]
+ * @returns {object} Deletion status
+ */
+export function deleteEntity(db, entityId, options = {}) {
+  const { reason = null } = options;
+
+  const entity = db.queryOne('SELECT * FROM entities WHERE id = ?', [entityId]);
+  if (!entity) {
+    return { success: false, error: `Entity ${entityId} not found` };
+  }
+
+  const now = _now();
+  db.update(
+    'entities',
+    {
+      deleted_at: now,
+      deleted_reason: reason || 'User requested deletion',
+    },
+    'id = ?',
+    [entityId]
+  );
+
+  _audit(db, 'entity_delete', {
+    details: { name: entity.name, reason },
+    entityId,
+    userInitiated: true,
+  });
+
+  return {
+    success: true,
+    entity_id: entityId,
+    name: entity.name,
+    deleted_at: now,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// setCloseCircle
+// ---------------------------------------------------------------------------
+
+/**
+ * Mark an entity as close-circle and auto-promote core facts to sacred.
+ *
+ * @param {object} db
+ * @param {number} entityId
+ * @param {object} [options]
+ * @param {string} [options.reason='user-designated']
+ * @returns {object} { entity_id, close_circle, facts_promoted_to_sacred }
+ */
+export function setCloseCircle(db, entityId, options = {}) {
+  const { reason = 'user-designated' } = options;
+  const config = getConfig();
+
+  db.run(
+    "UPDATE entities SET close_circle = 1, close_circle_reason = ?, updated_at = datetime('now') WHERE id = ?",
+    [reason, entityId]
+  );
+
+  let promoted = 0;
+  if (config.enable_auto_sacred) {
+    const keywords = config.sacred_core_keywords || [];
+    for (const keyword of keywords) {
+      const rows = db.query(
+        `SELECT m.id FROM memories m
+         JOIN memory_entities me ON m.id = me.memory_id
+         WHERE me.entity_id = ?
+           AND m.invalidated_at IS NULL
+           AND (m.lifecycle_tier IS NULL OR m.lifecycle_tier != 'sacred')
+           AND LOWER(m.content) LIKE '%' || LOWER(?) || '%'`,
+        [entityId, keyword]
+      );
+      for (const row of rows) {
+        db.run(
+          `UPDATE memories SET lifecycle_tier = 'sacred',
+           sacred_reason = ?,
+           updated_at = datetime('now')
+           WHERE id = ? AND (lifecycle_tier IS NULL OR lifecycle_tier != 'sacred')`,
+          [`auto: close-circle keyword '${keyword}'`, row.id]
+        );
+        promoted++;
+      }
+    }
+  }
+
+  _audit(db, 'close_circle_set', {
+    details: { entity_id: entityId, reason, promoted },
+    entityId,
+  });
+
+  return { entity_id: entityId, close_circle: true, facts_promoted_to_sacred: promoted };
+}
+
+// ---------------------------------------------------------------------------
+// saveSourceMaterial
+// ---------------------------------------------------------------------------
+
+/**
+ * Save raw source material (email, transcript, document) to disk.
+ *
+ * Files are plain markdown with a YAML frontmatter header, stored at
+ * {dbDir}/sources/{memoryId}.md.
+ *
+ * Also registers the file in the documents table and creates a
+ * memory_sources link for provenance tracking.
+ *
+ * @param {object} db
+ * @param {number} memoryId
+ * @param {string} content
+ * @param {object} [metadata]
+ * @returns {string|null} Path to saved file, or null on failure
+ */
+export function saveSourceMaterial(db, memoryId, content, metadata = null) {
+  try {
+    const sourcesDir = join(dirname(db.dbPath), 'sources');
+    mkdirSync(sourcesDir, { recursive: true });
+
+    const filePath = join(sourcesDir, `${memoryId}.md`);
+
+    // Build frontmatter
+    const headerLines = ['---'];
+    headerLines.push(`memory_id: ${memoryId}`);
+    if (metadata) {
+      for (const [key, value] of Object.entries(metadata)) {
+        if (value != null) {
+          headerLines.push(`${key}: "${value}"`);
+        }
+      }
+    }
+    headerLines.push(`saved_at: ${_now()}`);
+    headerLines.push('---');
+    headerLines.push('');
+
+    const fileContent = headerLines.join('\n') + content;
+    writeFileSync(filePath, fileContent, 'utf-8');
+
+    // Register in documents table for provenance
+    _registerDocumentProvenance(db, memoryId, content, filePath, metadata);
+
+    return filePath;
+  } catch (e) {
+    process.stderr.write(`[remember] Could not save source material for memory ${memoryId}: ${e.message}\n`);
+    return null;
+  }
+}
+
+/**
+ * Register a source material file in the documents table and link to memory.
+ */
+function _registerDocumentProvenance(db, memoryId, content, filePath, metadata = null) {
+  try {
+    const fileHash = createHash('sha256').update(content, 'utf-8').digest('hex');
+    const sourceType = (metadata || {}).source || 'session';
+    const sourceContext = (metadata || {}).source_context || null;
+    const filename = typeof filePath === 'string' ? filePath.split('/').pop() : String(filePath);
+
+    const validSourceTypes = ['gmail', 'transcript', 'upload', 'capture', 'session'];
+    const docSourceType = validSourceTypes.includes(sourceType) ? sourceType : 'session';
+    const now = _now();
+
+    const docId = db.insert('documents', {
+      file_hash: fileHash,
+      filename,
+      mime_type: 'text/markdown',
+      file_size: Buffer.byteLength(content, 'utf-8'),
+      storage_provider: 'local',
+      storage_path: String(filePath),
+      source_type: docSourceType,
+      source_ref: sourceContext,
+      lifecycle: 'active',
+      last_accessed_at: now,
+      created_at: now,
+      updated_at: now,
+    });
+
+    // Create provenance link
+    db.insert('memory_sources', {
+      memory_id: memoryId,
+      document_id: docId,
+      created_at: now,
+    });
+  } catch {
+    // Graceful degradation: documents table may not exist on older schemas
+  }
+}
+
+// ---------------------------------------------------------------------------
+// batchOperations
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute multiple memory operations in a single call with parallel embedding.
+ *
+ * Operations are: entity, remember, relate.
+ * Embeddings for all remember/entity ops are collected and computed in one
+ * parallel batch before executing the actual DB writes.
+ *
+ * @param {object} db
+ * @param {object[]} operations - Array of operation descriptors
+ * @param {object} [options]
+ * @param {string} [options.sourceChannel]
+ * @returns {Promise<object[]>} Array of per-operation results
+ */
+export async function batchOperations(db, operations, options = {}) {
+  const { sourceChannel = null } = options;
+
+  // --- Pass 1: Collect all texts that need embeddings ---
+  const embedTasks = []; // { index, text }
+  for (let i = 0; i < operations.length; i++) {
+    const op = operations[i];
+    const opType = op.op;
+    if (opType === 'remember') {
+      embedTasks.push({ index: i, text: op.content });
+    } else if (opType === 'entity') {
+      const embedText = `${op.name}. ${op.description || ''}`;
+      embedTasks.push({ index: i, text: embedText });
+    }
+  }
+
+  // --- Parallel embedding pass ---
+  const embeddingsMap = {}; // index -> embedding
+  if (embedTasks.length > 0) {
+    try {
+      const texts = embedTasks.map(t => t.text);
+      const allEmbeddings = await embedBatch(texts);
+      for (let j = 0; j < embedTasks.length; j++) {
+        if (allEmbeddings[j] != null) {
+          embeddingsMap[embedTasks[j].index] = allEmbeddings[j];
+        }
+      }
+    } catch (e) {
+      process.stderr.write(`[remember] Batch parallel embedding failed, falling back to per-op: ${e.message}\n`);
+      // embeddingsMap stays empty; individual ops will embed themselves
+    }
+  }
+
+  // --- Pass 2: Execute operations with pre-computed embeddings ---
+  const results = [];
+  for (let i = 0; i < operations.length; i++) {
+    const op = operations[i];
+    const opType = op.op;
+    const opResult = { index: i, op: opType };
+
+    try {
+      if (opType === 'entity') {
+        const entityId = await rememberEntity(db, op.name, op.type || 'person', {
+          description: op.description,
+          aliases: op.aliases,
+          precomputedEmbedding: embeddingsMap[i] || null,
+        });
+        opResult.success = true;
+        opResult.entity_id = entityId;
+      } else if (opType === 'remember') {
+        const memoryId = await rememberFact(db, op.content, {
+          memoryType: op.type || 'fact',
+          aboutEntities: op.about,
+          importance: op.importance ?? 1.0,
+          source: op.source,
+          sourceContext: op.source_context,
+          sourceChannel: op.source_channel || sourceChannel,
+          precomputedEmbedding: embeddingsMap[i] || null,
+        });
+        opResult.success = true;
+        opResult.memory_id = memoryId;
+        // Save source material to disk if provided
+        if (memoryId && op.source_material) {
+          saveSourceMaterial(db, memoryId, op.source_material, {
+            source: op.source,
+            source_context: op.source_context,
+          });
+        }
+      } else if (opType === 'relate') {
+        const relId = relateEntities(
+          db,
+          op.source,
+          op.target,
+          op.relationship,
+          {
+            strength: op.strength ?? 1.0,
+            supersedes: op.supersedes || false,
+            validAt: op.valid_at,
+            direction: op.direction || 'bidirectional',
+            originType: op.origin_type || 'extracted',
+          }
+        );
+        opResult.success = true;
+        opResult.relationship_id = relId;
+      } else {
+        opResult.success = false;
+        opResult.error = `Unknown operation type: ${opType}`;
+      }
+    } catch (e) {
+      opResult.success = false;
+      opResult.error = e.message;
+    }
+
+    results.push(opResult);
+  }
+
+  return results;
+}

--- a/cli/services/vault-sync.js
+++ b/cli/services/vault-sync.js
@@ -1,0 +1,2572 @@
+/**
+ * Vault Sync Service for Claudia CLI (Node.js port).
+ *
+ * Port of memory-daemon/claudia_memory/services/vault_sync.py.
+ *
+ * Exports SQLite memory data to an Obsidian-compatible vault as markdown notes
+ * with YAML frontmatter and [[wikilinks]]. The vault is a read projection
+ * of SQLite data -- SQLite remains the single source of truth.
+ *
+ * Vault structure (PARA-inspired):
+ *   ~/.claudia/vault/{project_id}/
+ *     Active/                   Projects with attention_tier in (active, watchlist)
+ *     Relationships/
+ *       people/                 Person entities (non-archived)
+ *       organizations/          Organization entities (non-archived)
+ *     Reference/
+ *       concepts/               Concept entities
+ *       locations/              Location entities
+ *     Archive/
+ *       people/                 Dormant or archived people
+ *       projects/               Completed or archived projects
+ *       organizations/          Past organizations
+ *     Claudia's Desk/           Claudia's efficient lookup zone
+ *       MOC-People.md           Flat tier table for quick reads
+ *       MOC-Commitments.md      Commitment tracking table
+ *       MOC-Projects.md         Project overview table
+ *       patterns/               Detected pattern notes
+ *       reflections/            Reflection notes from /meditate
+ *       sessions/               Daily session logs (YYYY/MM/YYYY-MM-DD.md)
+ *       _queries/               Dataview query templates
+ *     canvases/                 Visual dashboards (human-facing)
+ *     Home.md                   PARA-style navigation dashboard
+ *     _meta/                    Sync metadata (last-sync.json, sync-log.md)
+ *     .obsidian/                Obsidian config
+ *
+ * All functions take `db` (ClaudiaDatabase instance) as the first parameter.
+ */
+
+import { createHash } from 'node:crypto';
+import {
+  existsSync, mkdirSync, readFileSync, writeFileSync, appendFileSync,
+  readdirSync, statSync,
+} from 'node:fs';
+import { join, dirname, relative } from 'node:path';
+import { getConfig } from '../core/config.js';
+import { getVaultDir } from '../core/paths.js';
+import { contentHash } from '../core/database.js';
+import { canonicalName } from '../core/guards.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Map entity types to vault subdirectory names. */
+const ENTITY_TYPE_DIRS = {
+  person: 'people',
+  project: 'projects',
+  organization: 'organizations',
+  concept: 'concepts',
+  location: 'locations',
+};
+
+/** All PARA directories to create on init. */
+const PARA_DIRS = [
+  'Active',
+  'Relationships/people',
+  'Relationships/organizations',
+  'Reference/concepts',
+  'Reference/locations',
+  'Archive/people',
+  'Archive/projects',
+  'Archive/organizations',
+  "Claudia's Desk",
+  "Claudia's Desk/patterns",
+  "Claudia's Desk/reflections",
+  "Claudia's Desk/sessions",
+  "Claudia's Desk/_queries",
+  'canvases',
+  '_meta',
+  '.obsidian',
+  '.obsidian/snippets',
+];
+
+/** PARA entity directories for file counting and edit scanning. */
+const ENTITY_SUBDIRS = [
+  'Active',
+  'Relationships/people',
+  'Relationships/organizations',
+  'Reference/concepts',
+  'Reference/locations',
+  'Archive/people',
+  'Archive/projects',
+  'Archive/organizations',
+];
+
+/** PARA indices: directory -> [entityType, displayTitle]. */
+const PARA_INDICES = {
+  'Relationships/people': ['person', 'People'],
+  'Relationships/organizations': ['organization', 'Organizations'],
+  'Active': ['project', 'Active Projects'],
+  'Reference/concepts': ['concept', 'Concepts'],
+  'Reference/locations': ['location', 'Locations'],
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function _log(msg) {
+  process.stderr.write(`[vault-sync] ${msg}\n`);
+}
+
+function _now() {
+  return new Date().toISOString().replace('T', ' ').slice(0, 19);
+}
+
+function _nowISO() {
+  return new Date().toISOString();
+}
+
+function _utcStamp() {
+  const d = new Date();
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())} ` +
+    `${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())} UTC`;
+}
+
+/**
+ * Convert an entity name to a safe filename.
+ * Preserves readability while removing characters problematic on Windows/macOS/Linux.
+ */
+function _sanitizeFilename(name) {
+  let s = name.replace(/[<>:"/\\|?*]/g, '');
+  s = s.replace(/\s+/g, ' ').trim();
+  s = s.replace(/^\.+|\.+$/g, '');
+  if (s.length > 100) {
+    s = s.slice(0, 100).trimEnd();
+  }
+  return s || 'untitled';
+}
+
+/**
+ * Compute a short SHA-256 hash of note content for change detection.
+ * Used for bidirectional sync: if file content hash differs from sync_hash
+ * in frontmatter, the user modified the note.
+ */
+function _computeSyncHash(content) {
+  return createHash('sha256').update(content, 'utf-8').digest('hex').slice(0, 12);
+}
+
+/**
+ * Safely read a property from a row object. Returns default if missing or null.
+ */
+function _get(row, key, defaultValue = null) {
+  if (row == null) return defaultValue;
+  const val = row[key];
+  return val != null ? val : defaultValue;
+}
+
+/**
+ * Ensure a directory exists, creating parents as needed.
+ */
+function _ensureDir(dirPath) {
+  if (!existsSync(dirPath)) {
+    mkdirSync(dirPath, { recursive: true });
+  }
+}
+
+/**
+ * List all .md files in a directory (non-recursive). Returns filenames.
+ */
+function _listMdFiles(dirPath) {
+  if (!existsSync(dirPath)) return [];
+  try {
+    return readdirSync(dirPath).filter(f => f.endsWith('.md'));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Format a date string as "Mon DD, YYYY" for display.
+ */
+function _formatDate(dateStr) {
+  if (!dateStr) return '?';
+  try {
+    const d = new Date(dateStr.slice(0, 10));
+    if (isNaN(d.getTime())) return dateStr.slice(0, 10);
+    const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+      'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    return `${months[d.getUTCMonth()]} ${String(d.getUTCDate()).padStart(2, '0')}, ${d.getUTCFullYear()}`;
+  } catch {
+    return dateStr.slice(0, 10);
+  }
+}
+
+/**
+ * Calculate days between now (UTC) and a date string.
+ */
+function _daysAgo(dateStr) {
+  if (!dateStr) return null;
+  try {
+    const then = new Date(dateStr.slice(0, 19));
+    if (isNaN(then.getTime())) return null;
+    const now = new Date();
+    return Math.floor((now.getTime() - then.getTime()) / (1000 * 60 * 60 * 24));
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// PARA directory routing
+// ---------------------------------------------------------------------------
+
+/**
+ * Route entity to PARA folder based on type + activity status.
+ *
+ * Archive: explicitly archived or dormant 90+ days.
+ * Otherwise: route by entity type to Active/Relationships/Reference.
+ *
+ * @param {string} vaultPath - Root vault directory
+ * @param {string} entityType
+ * @param {object} entity - Entity row from DB
+ * @returns {string} Absolute path to target directory
+ */
+function _paraDir(vaultPath, entityType, entity) {
+  const tier = _get(entity, 'attention_tier', 'standard');
+  const trend = _get(entity, 'contact_trend');
+
+  // Archive: explicitly archived or dormant 90+ days
+  if (tier === 'archive' || trend === 'dormant') {
+    const subdir = ENTITY_TYPE_DIRS[entityType] || 'concepts';
+    return join(vaultPath, 'Archive', subdir);
+  }
+
+  if (entityType === 'project') return join(vaultPath, 'Active');
+  if (entityType === 'person') return join(vaultPath, 'Relationships', 'people');
+  if (entityType === 'organization') return join(vaultPath, 'Relationships', 'organizations');
+  if (entityType === 'location') return join(vaultPath, 'Reference', 'locations');
+  // concept and anything else
+  return join(vaultPath, 'Reference', 'concepts');
+}
+
+// ---------------------------------------------------------------------------
+// Directory structure
+// ---------------------------------------------------------------------------
+
+/**
+ * Create the PARA vault directory structure.
+ */
+function _ensureDirectories(vaultPath) {
+  for (const d of PARA_DIRS) {
+    _ensureDir(join(vaultPath, d));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sync metadata
+// ---------------------------------------------------------------------------
+
+/**
+ * Read last sync timestamp from _meta/last-sync.json.
+ */
+function _getLastSyncTime(vaultPath) {
+  const metaPath = join(vaultPath, '_meta', 'last-sync.json');
+  if (!existsSync(metaPath)) return null;
+  try {
+    const data = JSON.parse(readFileSync(metaPath, 'utf-8'));
+    return data.last_sync || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read vault format version from _meta/last-sync.json.
+ */
+function _getVaultFormatVersion(vaultPath) {
+  const metaPath = join(vaultPath, '_meta', 'last-sync.json');
+  if (!existsSync(metaPath)) return 0;
+  try {
+    const data = JSON.parse(readFileSync(metaPath, 'utf-8'));
+    return data.vault_format_version || 1;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Write sync metadata to _meta/last-sync.json.
+ */
+function _saveSyncMetadata(vaultPath, stats) {
+  const metaPath = join(vaultPath, '_meta', 'last-sync.json');
+  _ensureDir(dirname(metaPath));
+
+  let existing = {};
+  if (existsSync(metaPath)) {
+    try {
+      existing = JSON.parse(readFileSync(metaPath, 'utf-8'));
+    } catch {
+      // Ignore corrupt metadata
+    }
+  }
+
+  Object.assign(existing, {
+    last_sync: _now(),
+    vault_format_version: 2,
+    stats,
+  });
+
+  writeFileSync(metaPath, JSON.stringify(existing, null, 2), 'utf-8');
+}
+
+/**
+ * Append a line to _meta/sync-log.md.
+ */
+function _appendSyncLog(vaultPath, message) {
+  const logPath = join(vaultPath, '_meta', 'sync-log.md');
+  _ensureDir(dirname(logPath));
+  const timestamp = _now();
+  appendFileSync(logPath, `- [${timestamp}] ${message}\n`, 'utf-8');
+}
+
+// ---------------------------------------------------------------------------
+// Table validation and repair
+// ---------------------------------------------------------------------------
+
+/**
+ * Scan markdown content for broken tables where header and separator rows
+ * are merged onto a single line.
+ *
+ * Returns an array of warning strings.
+ */
+function _validateMarkdownTables(content) {
+  const warnings = [];
+  for (const line of content.split('\n')) {
+    if (/\|[^|\-\n][^|\n]*\|[-\s|]{3,}/.test(line) && line.includes('---')) {
+      warnings.push('Broken table detected: header and separator merged on single line');
+    }
+  }
+  return warnings;
+}
+
+/**
+ * Attempt to repair broken markdown tables where header, separator,
+ * and optional data rows have been merged onto a single line.
+ */
+function _repairBrokenTables(content) {
+  const repairedLines = [];
+
+  for (const line of content.split('\n')) {
+    const match = line.match(/^(\|[^-\n]+(?:\|[^-\n]+)*\|)([-|\s]*---[-|\s]*)(.*)$/);
+    if (!match) {
+      repairedLines.push(line);
+      continue;
+    }
+
+    const headerPart = match[1].trim();
+    const remainder = match[3].trim();
+
+    // Reconstruct a clean separator row based on header column count
+    const headerCells = headerPart.replace(/^\||\|$/g, '').split('|').map(c => c.trim());
+    const colCount = headerCells.length;
+    const separator = '|' + headerCells.map(c => ' ' + '-'.repeat(Math.max(c.length, 3)) + ' ').join('|') + '|';
+
+    repairedLines.push(headerPart);
+    repairedLines.push(separator);
+
+    // If there is leftover content after the separator, split it into data rows
+    if (remainder) {
+      const dataCells = remainder.replace(/^\||\|$/g, '').split('|').map(c => c.trim()).filter(c => c);
+      for (let i = 0; i < dataCells.length; i += colCount) {
+        const rowCells = dataCells.slice(i, i + colCount);
+        while (rowCells.length < colCount) rowCells.push('');
+        repairedLines.push('| ' + rowCells.join(' | ') + ' |');
+      }
+    }
+  }
+
+  return repairedLines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Data fetching helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch entities from the database, optionally filtered by update time.
+ */
+function _getAllEntities(db, since = null) {
+  let sql = 'SELECT * FROM entities WHERE deleted_at IS NULL';
+  const params = [];
+  if (since) {
+    sql += ' AND updated_at >= ?';
+    params.push(since);
+  }
+  sql += ' ORDER BY importance DESC';
+  return db.query(sql, params);
+}
+
+/**
+ * Fetch non-invalidated memories linked to an entity.
+ */
+function _getEntityMemories(db, entityId) {
+  return db.query(`
+    SELECT m.* FROM memories m
+    JOIN memory_entities me ON m.id = me.memory_id
+    WHERE me.entity_id = ? AND m.invalidated_at IS NULL
+    ORDER BY m.importance DESC, m.created_at DESC
+  `, [entityId]);
+}
+
+/**
+ * Fetch active relationships for an entity with resolved names.
+ */
+function _getEntityRelationships(db, entityId) {
+  return db.query(`
+    SELECT r.*,
+           s.name as source_name, s.type as source_type,
+           t.name as target_name, t.type as target_type
+    FROM relationships r
+    JOIN entities s ON r.source_entity_id = s.id
+    JOIN entities t ON r.target_entity_id = t.id
+    WHERE (r.source_entity_id = ? OR r.target_entity_id = ?)
+      AND r.invalid_at IS NULL
+    ORDER BY r.strength DESC
+  `, [entityId, entityId]);
+}
+
+/**
+ * Fetch aliases for an entity.
+ */
+function _getEntityAliases(db, entityId) {
+  const rows = db.query('SELECT alias FROM entity_aliases WHERE entity_id = ?', [entityId]);
+  return rows.map(r => r.alias);
+}
+
+// ---------------------------------------------------------------------------
+// Entity name wikification cache
+// ---------------------------------------------------------------------------
+
+/** Module-level cache for entity names (cleared at start of each sync). */
+let _entityNamesCache = null;
+
+function _clearEntityNamesCache() {
+  _entityNamesCache = null;
+}
+
+function _getEntityNamesCache(db) {
+  if (_entityNamesCache) return _entityNamesCache;
+  const rows = db.query(
+    'SELECT name FROM entities WHERE deleted_at IS NULL ORDER BY LENGTH(name) DESC'
+  );
+  // Sort by length DESC so longer names match first (e.g., "Sarah Chen" before "Sarah")
+  _entityNamesCache = rows.map(r => r.name);
+  return _entityNamesCache;
+}
+
+/**
+ * Wrap known entity names in a narrative with [[wikilinks]].
+ * This makes the graph view show session-to-entity connections.
+ */
+function _wikifyNarrative(db, narrative) {
+  if (!narrative) return narrative;
+
+  const names = _getEntityNamesCache(db);
+  let result = narrative;
+  for (const name of names) {
+    if (result.includes(name) && !result.includes(`[[${name}]]`)) {
+      // Replace all occurrences that are not already wikilinked
+      result = result.split(name).join(`[[${name}]]`);
+    }
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Frontmatter builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build YAML frontmatter for an entity note.
+ *
+ * Includes contact velocity fields, compound tags for graph filtering,
+ * and cssclasses for per-type CSS styling in Obsidian.
+ */
+function _buildFrontmatter(entity, aliases, syncHash = '') {
+  const etype = entity.type;
+  const lines = ['---'];
+
+  lines.push(`claudia_id: ${entity.id}`);
+  lines.push(`type: ${etype}`);
+  lines.push(`name: "${entity.name}"`);
+  lines.push(`importance: ${entity.importance}`);
+
+  // Contact velocity fields
+  const attentionTier = _get(entity, 'attention_tier');
+  if (attentionTier) lines.push(`attention_tier: ${attentionTier}`);
+
+  const closeCircle = _get(entity, 'close_circle');
+  if (closeCircle) {
+    lines.push('close_circle: true');
+    const closeReason = _get(entity, 'close_circle_reason');
+    if (closeReason) lines.push(`close_circle_reason: "${closeReason}"`);
+  }
+
+  const contactTrend = _get(entity, 'contact_trend');
+  if (contactTrend) lines.push(`contact_trend: ${contactTrend}`);
+
+  const freq = _get(entity, 'contact_frequency_days');
+  if (freq != null) lines.push(`contact_frequency_days: ${freq}`);
+
+  const lastContact = _get(entity, 'last_contact_at');
+  if (lastContact) lines.push(`last_contact: ${lastContact.slice(0, 10)}`);
+
+  lines.push(`created: ${entity.created_at}`);
+  lines.push(`updated: ${entity.updated_at}`);
+
+  // Aliases as proper YAML list
+  if (aliases && aliases.length > 0) {
+    lines.push('aliases:');
+    for (const alias of aliases) {
+      lines.push(`  - "${alias}"`);
+    }
+  }
+
+  // Compound tags: [type, tier, trend] for graph filtering
+  const tags = [etype];
+  if (attentionTier && attentionTier !== 'standard') tags.push(attentionTier);
+  if (contactTrend) tags.push(contactTrend);
+  if (closeCircle) tags.push('close-circle');
+  lines.push('tags:');
+  for (const tag of tags) {
+    lines.push(`  - ${tag}`);
+  }
+
+  // CSS classes for per-type styling
+  lines.push('cssclasses:');
+  lines.push(`  - entity-${etype}`);
+
+  if (syncHash) lines.push(`sync_hash: ${syncHash}`);
+
+  lines.push('---');
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Status callout rendering
+// ---------------------------------------------------------------------------
+
+/**
+ * Render a status callout box at the top of person/project notes.
+ *
+ * Shows attention tier, trend, last contact, frequency, and importance
+ * in a compact Obsidian callout block.
+ */
+function _renderStatusCallout(db, entity) {
+  const etype = entity.type;
+
+  if (etype === 'person') {
+    const attention = _get(entity, 'attention_tier');
+    const trend = _get(entity, 'contact_trend');
+    const lastContact = _get(entity, 'last_contact_at');
+    const freq = _get(entity, 'contact_frequency_days');
+    const importance = _get(entity, 'importance', 0);
+
+    if (!attention && !trend && !lastContact) return '';
+
+    const partsLine1 = [];
+    if (attention) partsLine1.push(`**Attention:** ${attention.charAt(0).toUpperCase() + attention.slice(1)}`);
+    if (trend) partsLine1.push(`**Trend:** ${trend.charAt(0).toUpperCase() + trend.slice(1)}`);
+    if (lastContact) {
+      const dateStr = _formatDate(lastContact);
+      partsLine1.push(`**Last Contact:** ${dateStr}`);
+    }
+
+    const partsLine2 = [];
+    if (freq != null) partsLine2.push(`**Frequency:** Every ~${Math.round(freq)} days`);
+    partsLine2.push(`**Importance:** ${importance}`);
+
+    const lines = ['> [!info] Status'];
+    lines.push(`> ${partsLine1.join(' | ')}`);
+    if (partsLine2.length > 0) lines.push(`> ${partsLine2.join(' | ')}`);
+    return lines.join('\n');
+  }
+
+  if (etype === 'project') {
+    const entityId = entity.id;
+
+    const peopleCount = db.queryOne(`
+      SELECT COUNT(DISTINCT e.id) as cnt
+      FROM entities e
+      JOIN relationships r ON (
+        (r.source_entity_id = ? AND r.target_entity_id = e.id) OR
+        (r.target_entity_id = ? AND r.source_entity_id = e.id)
+      )
+      WHERE e.type = 'person' AND e.deleted_at IS NULL AND r.invalid_at IS NULL
+    `, [entityId, entityId]);
+    const pcount = peopleCount ? peopleCount.cnt : 0;
+
+    const commitmentCount = db.queryOne(`
+      SELECT COUNT(*) as cnt FROM memories m
+      JOIN memory_entities me ON m.id = me.memory_id
+      WHERE me.entity_id = ? AND m.type = 'commitment' AND m.invalidated_at IS NULL
+    `, [entityId]);
+    const ccount = commitmentCount ? commitmentCount.cnt : 0;
+
+    const lines = ['> [!info] Status'];
+    lines.push(`> **People:** ${pcount} connected | **Open Commitments:** ${ccount} | **Importance:** ${entity.importance}`);
+    return lines.join('\n');
+  }
+
+  return '';
+}
+
+// ---------------------------------------------------------------------------
+// Relationships section
+// ---------------------------------------------------------------------------
+
+/**
+ * Render the relationships section as a scannable markdown table.
+ */
+function _renderRelationshipsSection(entityId, relationships) {
+  if (!relationships || relationships.length === 0) return '';
+
+  const lines = ['## Relationships', ''];
+  lines.push('| Connection | Type | Strength |');
+  lines.push('|------------|------|----------|');
+
+  for (const rel of relationships) {
+    const otherName = rel.source_entity_id === entityId ? rel.target_name : rel.source_name;
+    lines.push(`| [[${otherName}]] | ${rel.relationship_type} | ${rel.strength} |`);
+  }
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Memories section
+// ---------------------------------------------------------------------------
+
+/**
+ * Render memories grouped by verification status with Obsidian callouts.
+ *
+ * Commitments get checkboxes. Other memories are split into verified
+ * (note callout) and unverified (warning callout) groups for trust visibility.
+ */
+function _renderMemoriesSection(memories) {
+  if (!memories || memories.length === 0) return '';
+
+  // Group by type
+  const byType = {};
+  for (const m of memories) {
+    const mtype = m.type || 'fact';
+    if (!byType[mtype]) byType[mtype] = [];
+    byType[mtype].push(m);
+  }
+
+  const lines = [];
+
+  // Commitments get special treatment (checkboxes)
+  const commitments = byType.commitment || [];
+  delete byType.commitment;
+
+  if (commitments.length > 0) {
+    lines.push('## Commitments');
+    for (const c of commitments) {
+      let meta = {};
+      if (c.metadata) {
+        try { meta = JSON.parse(c.metadata); } catch { /* ignore */ }
+      }
+      const completed = meta.completed;
+      if (completed) {
+        lines.push(`- [x] ${c.content} (completed: ${completed})`);
+      } else {
+        const created = c.created_at || '';
+        const detected = created.slice(0, 10);
+        lines.push(`- [ ] ${c.content} (detected: ${detected})`);
+      }
+    }
+  }
+
+  // Split remaining memories by verification status
+  const verified = [];
+  const unverified = [];
+
+  for (const [, mems] of Object.entries(byType)) {
+    for (const m of mems) {
+      const vstatus = m.verification_status || 'pending';
+      const origin = m.origin_type || '';
+      const confidence = m.confidence != null ? m.confidence : 1.0;
+      const lifecycle = _get(m, 'lifecycle_tier');
+      const prefix = lifecycle === 'sacred' ? '[sacred] ' : '';
+
+      const detailParts = [];
+      if (origin) detailParts.push(`source: ${origin}`);
+      if (confidence != null && confidence < 1.0) detailParts.push(`confidence: ${confidence}`);
+      const detail = detailParts.length > 0 ? ` (${detailParts.join(', ')})` : '';
+      const entry = `- ${prefix}${m.content}${detail}`;
+
+      if (vstatus === 'verified' || origin === 'user_stated') {
+        verified.push(entry);
+      } else {
+        unverified.push(entry);
+      }
+    }
+  }
+
+  lines.push('');
+  lines.push('## Key Facts');
+
+  if (verified.length > 0) {
+    lines.push('');
+    lines.push('> [!note] Verified');
+    for (const entry of verified) {
+      lines.push(`> ${entry}`);
+    }
+  }
+
+  if (unverified.length > 0) {
+    lines.push('');
+    lines.push('> [!warning] Unverified');
+    for (const entry of unverified) {
+      lines.push(`> ${entry}`);
+    }
+  }
+
+  if (verified.length === 0 && unverified.length === 0) {
+    lines.push('');
+    lines.push('*No facts recorded yet.*');
+  }
+
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Recent sessions section
+// ---------------------------------------------------------------------------
+
+/**
+ * Render recent session mentions as Obsidian callout blocks.
+ */
+function _renderRecentSessions(db, entityName) {
+  const rows = db.query(`
+    SELECT id, narrative, started_at
+    FROM episodes
+    WHERE is_summarized = 1
+      AND narrative LIKE ?
+    ORDER BY started_at DESC
+    LIMIT 10
+  `, [`%${entityName}%`]);
+
+  if (rows.length === 0) return '';
+
+  const lines = ['## Recent Interactions'];
+  for (const row of rows) {
+    const started = row.started_at;
+    const dateDisplay = _formatDate(started);
+    let narrative = row.narrative || '';
+    if (narrative.length > 300) narrative = narrative.slice(0, 300) + '...';
+
+    lines.push('');
+    lines.push(`> [!example] ${dateDisplay}`);
+    for (const nline of narrative.split('\n')) {
+      lines.push(`> ${nline}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Related patterns
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch active patterns that reference this entity in their evidence.
+ */
+function _getRelatedPatterns(db, entityId) {
+  try {
+    return db.query(`
+      SELECT DISTINCT p.id, p.description, p.pattern_type, p.confidence
+      FROM patterns p
+      WHERE p.is_active = 1
+        AND p.evidence LIKE ?
+      LIMIT 5
+    `, [`%${entityId}%`]);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Render a 'Related Patterns' section with wikilinks to pattern notes.
+ */
+function _renderRelatedPatterns(patterns) {
+  if (!patterns || patterns.length === 0) return '';
+  const lines = ['## Related Patterns', ''];
+  for (const p of patterns) {
+    const ptype = p.pattern_type || 'pattern';
+    const confidence = p.confidence || 0.0;
+    const pid = p.id;
+    const slug = `${ptype}-${String(pid).padStart(3, '0')}`;
+    lines.push(
+      `- [[${_sanitizeFilename(slug)}]] ` +
+      `- *${ptype}* (confidence: ${confidence.toFixed(2)})`
+    );
+  }
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Entity export
+// ---------------------------------------------------------------------------
+
+/**
+ * Export a single entity as an Obsidian note.
+ *
+ * @param {object} db - ClaudiaDatabase instance
+ * @param {string} vaultPath - Root vault directory
+ * @param {object} entity - Entity row from DB
+ * @returns {string|null} Path of the written file, or null on error
+ */
+function _exportEntity(db, vaultPath, entity) {
+  const entityId = entity.id;
+  const entityName = entity.name;
+  const entityType = entity.type;
+
+  // Determine subdirectory via PARA routing
+  const targetDir = _paraDir(vaultPath, entityType, entity);
+  _ensureDir(targetDir);
+
+  // Fetch related data
+  const memories = _getEntityMemories(db, entityId);
+  const relationships = _getEntityRelationships(db, entityId);
+  const aliases = _getEntityAliases(db, entityId);
+
+  // Build note body (without frontmatter first, for hash calculation)
+  const sections = [];
+
+  // Title
+  sections.push(`# ${entityName}`);
+
+  // Description
+  const desc = entity.description;
+  if (desc) sections.push(`\n${desc}`);
+
+  // Status callout (person/project only)
+  const status = _renderStatusCallout(db, entity);
+  if (status) sections.push(`\n${status}`);
+
+  // Relationships (table format)
+  const relSection = _renderRelationshipsSection(entityId, relationships);
+  if (relSection) sections.push(`\n${relSection}`);
+
+  // Memories (verification-grouped callouts)
+  const memSection = _renderMemoriesSection(memories);
+  if (memSection) sections.push(`\n${memSection}`);
+
+  // Recent session mentions (callout timeline)
+  const recent = _renderRecentSessions(db, entityName);
+  if (recent) sections.push(`\n${recent}`);
+
+  // Related patterns backlinks
+  const relatedPatterns = _getRelatedPatterns(db, entityId);
+  if (relatedPatterns.length > 0) {
+    sections.push(`\n${_renderRelatedPatterns(relatedPatterns)}`);
+  }
+
+  // Sync footer
+  const syncTime = _utcStamp();
+  sections.push(`\n---\n*Last synced: ${syncTime}*`);
+
+  const body = sections.join('\n');
+
+  // Build frontmatter (includes sync_hash)
+  const frontmatter = _buildFrontmatter(entity, aliases, _computeSyncHash(body));
+  const fullContent = `${frontmatter}\n\n${body}\n`;
+
+  // Write file
+  const filename = _sanitizeFilename(entityName) + '.md';
+  const filepath = join(targetDir, filename);
+  try {
+    writeFileSync(filepath, fullContent, 'utf-8');
+    // Validate markdown tables in the exported note
+    const tableWarnings = _validateMarkdownTables(fullContent);
+    for (const warning of tableWarnings) {
+      _log(`${warning} in ${filename}`);
+    }
+    return filepath;
+  } catch (e) {
+    _log(`Failed to write entity note ${filepath}: ${e.message}`);
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pattern export
+// ---------------------------------------------------------------------------
+
+/**
+ * Export active patterns as notes in patterns/ directory.
+ * @returns {number} Count of exported patterns
+ */
+function _exportPatterns(db, vaultPath) {
+  const rows = db.query(
+    'SELECT * FROM patterns WHERE is_active = 1 ORDER BY last_observed_at DESC'
+  );
+
+  let count = 0;
+  const targetDir = join(vaultPath, "Claudia's Desk", 'patterns');
+  _ensureDir(targetDir);
+
+  for (const row of rows) {
+    const patternType = row.pattern_type || 'pattern';
+    const description = row.description || '';
+    const detectedAt = row.first_observed_at || '';
+    const confidence = row.confidence || 0.0;
+
+    const lines = ['---'];
+    lines.push(`claudia_id: pattern-${row.id}`);
+    lines.push('type: pattern');
+    lines.push(`pattern_type: ${patternType}`);
+    lines.push(`confidence: ${confidence}`);
+    lines.push(`detected: ${detectedAt}`);
+    lines.push('tags: [pattern]');
+    lines.push('---');
+    lines.push('');
+    lines.push(`# ${patternType.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())}`);
+    lines.push('');
+    lines.push(description);
+
+    // Include evidence entities if available
+    const evidence = row.evidence;
+    if (evidence) {
+      try {
+        const evidenceData = JSON.parse(evidence);
+        if (typeof evidenceData === 'object' && evidenceData !== null) {
+          const entities = evidenceData.entities || [];
+          if (entities.length > 0) {
+            lines.push('');
+            lines.push('## Related Entities');
+            for (const entName of entities) {
+              lines.push(`- [[${entName}]]`);
+            }
+          }
+          // Also try entity_ids for typed wikilinks
+          const entityIds = evidenceData.entity_ids || [];
+          if (entityIds.length > 0 && entities.length === 0) {
+            const entLinks = [];
+            for (const eid of entityIds.slice(0, 5)) {
+              const entRow = db.queryOne(
+                'SELECT name FROM entities WHERE id = ? AND deleted_at IS NULL',
+                [eid]
+              );
+              if (entRow) entLinks.push(`[[${entRow.name}]]`);
+            }
+            if (entLinks.length > 0) {
+              lines.push('');
+              lines.push('## Related Entities');
+              for (const link of entLinks) {
+                lines.push(`- ${link}`);
+              }
+            }
+          }
+        }
+      } catch {
+        // Ignore JSON parse errors
+      }
+    }
+
+    const content = lines.join('\n') + '\n';
+    const slug = `${patternType}-${String(row.id).padStart(3, '0')}`;
+    const filepath = join(targetDir, `${_sanitizeFilename(slug)}.md`);
+    try {
+      writeFileSync(filepath, content, 'utf-8');
+      count++;
+    } catch (e) {
+      _log(`Failed to write pattern note ${filepath}: ${e.message}`);
+    }
+  }
+
+  return count;
+}
+
+// ---------------------------------------------------------------------------
+// Reflection export
+// ---------------------------------------------------------------------------
+
+/**
+ * Export reflections as notes in reflections/ directory.
+ * @returns {number} Count of exported reflections
+ */
+function _exportReflections(db, vaultPath) {
+  const rows = db.query(
+    'SELECT * FROM reflections ORDER BY last_confirmed_at DESC'
+  );
+
+  let count = 0;
+  const targetDir = join(vaultPath, "Claudia's Desk", 'reflections');
+  _ensureDir(targetDir);
+
+  for (const row of rows) {
+    const refType = row.reflection_type || 'observation';
+    const content = row.content || '';
+    const importance = row.importance || 0.5;
+    const confidence = row.confidence || 1.0;
+    const firstObserved = row.first_observed_at || '';
+    const lastConfirmed = row.last_confirmed_at || '';
+    const aggCount = row.aggregation_count || 1;
+
+    const lines = ['---'];
+    lines.push(`claudia_id: reflection-${row.id}`);
+    lines.push('type: reflection');
+    lines.push(`reflection_type: ${refType}`);
+    lines.push(`importance: ${importance}`);
+    lines.push(`confidence: ${confidence}`);
+    lines.push(`first_observed: ${firstObserved}`);
+    lines.push(`last_confirmed: ${lastConfirmed}`);
+    lines.push(`times_confirmed: ${aggCount}`);
+    lines.push('tags: [reflection]');
+    lines.push('---');
+    lines.push('');
+    lines.push(`# ${refType.charAt(0).toUpperCase() + refType.slice(1)}`);
+    lines.push('');
+    lines.push(content);
+
+    const fullContent = lines.join('\n') + '\n';
+    const slug = `${refType}-${String(row.id).padStart(3, '0')}`;
+    const filepath = join(targetDir, `${_sanitizeFilename(slug)}.md`);
+    try {
+      writeFileSync(filepath, fullContent, 'utf-8');
+      count++;
+    } catch (e) {
+      _log(`Failed to write reflection note ${filepath}: ${e.message}`);
+    }
+  }
+
+  return count;
+}
+
+// ---------------------------------------------------------------------------
+// Session log export
+// ---------------------------------------------------------------------------
+
+/**
+ * Export session episodes as daily notes in hierarchical sessions/ directory.
+ *
+ * Groups episodes by date. Uses sessions/YYYY/MM/YYYY-MM-DD.md path
+ * structure to prevent flat folder with hundreds of files.
+ * Narratives are wikified to create graph connections.
+ *
+ * @returns {number} Count of exported session days
+ */
+function _exportSessions(db, vaultPath, since = null) {
+  let sql = `
+    SELECT id, session_id, narrative, started_at, ended_at,
+           key_topics, summary
+    FROM episodes
+    WHERE is_summarized = 1
+  `;
+  const params = [];
+  if (since) {
+    sql += ' AND started_at > ?';
+    params.push(since);
+  }
+  sql += ' ORDER BY started_at DESC';
+
+  const rows = db.query(sql, params);
+  if (rows.length === 0) return 0;
+
+  // Group by date
+  const byDate = {};
+  for (const row of rows) {
+    const started = row.started_at;
+    const dateStr = started ? started.slice(0, 10) : 'unknown';
+    if (!byDate[dateStr]) byDate[dateStr] = [];
+    byDate[dateStr].push(row);
+  }
+
+  let count = 0;
+  const deskSessions = join(vaultPath, "Claudia's Desk", 'sessions');
+
+  for (const [dateStr, episodes] of Object.entries(byDate)) {
+    const lines = ['---'];
+    lines.push('type: session-log');
+    lines.push(`date: ${dateStr}`);
+    lines.push(`session_count: ${episodes.length}`);
+    lines.push('tags:');
+    lines.push('  - session');
+    lines.push('---');
+    lines.push('');
+    lines.push(`# Sessions: ${dateStr}`);
+
+    for (const ep of episodes) {
+      const started = ep.started_at || '?';
+      lines.push('');
+      lines.push(`## Session at ${started}`);
+
+      const rawTopics = ep.key_topics;
+      if (rawTopics) {
+        try {
+          const topics = JSON.parse(rawTopics);
+          if (Array.isArray(topics) && topics.length > 0) {
+            lines.push(`**Topics:** ${topics.join(', ')}`);
+          }
+        } catch {
+          // Ignore
+        }
+      }
+
+      let narrative = ep.narrative || ep.summary || '';
+      if (narrative) {
+        narrative = _wikifyNarrative(db, narrative);
+        lines.push('');
+        lines.push(narrative);
+      }
+    }
+
+    const content = lines.join('\n') + '\n';
+
+    // Hierarchical path: Claudia's Desk/sessions/YYYY/MM/YYYY-MM-DD.md
+    let targetDir;
+    if (dateStr !== 'unknown' && dateStr.length >= 7) {
+      const year = dateStr.slice(0, 4);
+      const month = dateStr.slice(5, 7);
+      targetDir = join(deskSessions, year, month);
+    } else {
+      targetDir = deskSessions;
+    }
+    _ensureDir(targetDir);
+
+    const filepath = join(targetDir, `${dateStr}.md`);
+    try {
+      writeFileSync(filepath, content, 'utf-8');
+      count++;
+    } catch (e) {
+      _log(`Failed to write session note ${filepath}: ${e.message}`);
+    }
+  }
+
+  return count;
+}
+
+// ---------------------------------------------------------------------------
+// Dataview query templates
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate starter Dataview query notes in _queries/.
+ *
+ * Created once and never overwritten (user may customize).
+ * @returns {number} Count of templates created
+ */
+function _exportDataviewTemplates(vaultPath) {
+  const queriesDir = join(vaultPath, "Claudia's Desk", '_queries');
+  _ensureDir(queriesDir);
+  let created = 0;
+
+  const dvTip = '> [!tip] This query requires the [Dataview](https://github.com/blacksmithgu/obsidian-dataview) plugin.\n';
+
+  const templates = {
+    'Upcoming Deadlines.md':
+      '# Upcoming Deadlines\n\n' +
+      'Commitments sorted by deadline date.\n\n' +
+      '```dataview\n' +
+      'TABLE type, importance\n' +
+      'FROM "Active" OR "Relationships" OR "Archive"\n' +
+      'WHERE contains(file.content, "- [ ]")\n' +
+      'SORT importance DESC\n' +
+      '```\n\n' + dvTip,
+
+    'Cooling Relationships.md':
+      '# Cooling Relationships\n\n' +
+      'People with decelerating or dormant contact trends.\n\n' +
+      '```dataview\n' +
+      'TABLE contact_trend, last_contact, importance\n' +
+      'FROM "Relationships/people" OR "Archive/people"\n' +
+      'WHERE contact_trend = "decelerating" OR contact_trend = "dormant"\n' +
+      'SORT last_contact ASC\n' +
+      '```\n\n' + dvTip,
+
+    'Active Network.md':
+      '# Active Network\n\n' +
+      'People in the active attention tier.\n\n' +
+      '```dataview\n' +
+      'TABLE contact_trend, last_contact, contact_frequency_days, importance\n' +
+      'FROM "Relationships/people"\n' +
+      'WHERE attention_tier = "active"\n' +
+      'SORT importance DESC\n' +
+      '```\n\n' + dvTip,
+
+    'Recent Memories.md':
+      '# Recent Memories\n\n' +
+      'What Claudia learned this week.\n\n' +
+      '```dataview\n' +
+      'TABLE type, importance, created\n' +
+      'FROM "Active" OR "Relationships" OR "Reference"\n' +
+      'WHERE date(created) >= date(today) - dur(7 days)\n' +
+      'SORT created DESC\n' +
+      'LIMIT 50\n' +
+      '```\n\n' + dvTip,
+
+    'Open Commitments.md':
+      '# Open Commitments\n\n' +
+      'All tracked commitments across entities.\n\n' +
+      '```dataview\n' +
+      'TASK\n' +
+      'FROM "Active" OR "Relationships"\n' +
+      'WHERE !completed\n' +
+      'SORT file.name ASC\n' +
+      '```\n\n' + dvTip,
+
+    'Entity Overview.md':
+      '# Entity Overview\n\n' +
+      'All entities grouped by type and sorted by importance.\n\n' +
+      '```dataview\n' +
+      'TABLE type, attention_tier, contact_trend, importance\n' +
+      'FROM "Active" OR "Relationships" OR "Reference" OR "Archive"\n' +
+      'SORT type ASC, importance DESC\n' +
+      '```\n\n' + dvTip,
+
+    'Session Log.md':
+      '# Session Log\n\n' +
+      'Recent conversation sessions.\n\n' +
+      '```dataview\n' +
+      'TABLE date, session_count\n' +
+      "FROM \"Claudia's Desk/sessions\"\n" +
+      'SORT date DESC\n' +
+      'LIMIT 30\n' +
+      '```\n\n' + dvTip,
+  };
+
+  for (const [filename, content] of Object.entries(templates)) {
+    const filepath = join(queriesDir, filename);
+    if (!existsSync(filepath)) {
+      try {
+        writeFileSync(filepath, content, 'utf-8');
+        created++;
+      } catch (e) {
+        _log(`Failed to write Dataview template ${filepath}: ${e.message}`);
+      }
+    }
+  }
+
+  if (created > 0) {
+    _log(`Created ${created} Dataview query templates in Claudia's Desk/_queries/`);
+  }
+  return created;
+}
+
+// ---------------------------------------------------------------------------
+// Home dashboard
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate Home.md as a PARA-style navigation dashboard.
+ *
+ * Written to vault root (not Claudia's Desk) since it's the
+ * human-facing entry point. Always regenerated on sync.
+ */
+function _exportHomeDashboard(db, vaultPath) {
+  const lines = ['# Home', ''];
+
+  // Active Projects section
+  const activeProjects = db.query(`
+    SELECT name, attention_tier, importance
+    FROM entities
+    WHERE type = 'project' AND deleted_at IS NULL
+      AND (attention_tier IN ('active', 'watchlist') OR attention_tier IS NULL)
+      AND COALESCE(contact_trend, '') != 'dormant'
+    ORDER BY importance DESC
+    LIMIT 15
+  `);
+
+  lines.push('## Active Projects');
+  if (activeProjects.length > 0) {
+    lines.push('');
+    for (const p of activeProjects) {
+      const tier = p.attention_tier || 'standard';
+      lines.push(`- [[${p.name}]] (${tier})`);
+    }
+  } else {
+    lines.push('');
+    lines.push('*No active projects yet.*');
+  }
+
+  // Relationships
+  const pcRow = db.queryOne(
+    "SELECT COUNT(*) as c FROM entities WHERE type = 'person' AND deleted_at IS NULL"
+  );
+  const ocRow = db.queryOne(
+    "SELECT COUNT(*) as c FROM entities WHERE type = 'organization' AND deleted_at IS NULL"
+  );
+  const pc = pcRow ? pcRow.c : 0;
+  const oc = ocRow ? ocRow.c : 0;
+
+  lines.push('');
+  lines.push('## Relationships');
+  lines.push('');
+  lines.push(`- [[Relationships/people/|People]] (${pc} tracked)`);
+  lines.push(`- [[Relationships/organizations/|Organizations]] (${oc} tracked)`);
+
+  // Needs attention
+  const watchlist = db.query(`
+    SELECT name, contact_trend, last_contact_at
+    FROM entities
+    WHERE deleted_at IS NULL
+      AND type = 'person'
+      AND (attention_tier = 'watchlist'
+           OR contact_trend IN ('decelerating', 'dormant'))
+      AND importance > 0.3
+    ORDER BY last_contact_at ASC NULLS FIRST
+    LIMIT 8
+  `);
+
+  if (watchlist.length > 0) {
+    lines.push('');
+    lines.push('### Needs Attention');
+    lines.push('');
+    for (const w of watchlist) {
+      const trend = w.contact_trend || 'watch';
+      const days = _daysAgo(w.last_contact_at);
+      if (days != null) {
+        lines.push(`- [[${w.name}]] - ${trend} (${days}d)`);
+      } else {
+        lines.push(`- [[${w.name}]] - ${trend}`);
+      }
+    }
+  }
+
+  // Quick Links
+  lines.push('');
+  lines.push('## Quick Links');
+  lines.push('');
+  lines.push("- [[Claudia's Desk/MOC-Commitments|Open Commitments]]");
+  lines.push("- [[Claudia's Desk/MOC-People|Relationship Map]]");
+  lines.push("- [[Claudia's Desk/MOC-Projects|Project Overview]]");
+  lines.push('- [[Reference/|Reference Materials]]');
+  lines.push('- [[Archive/|Archive]]');
+
+  // Recent activity
+  const recentSessions = db.query(`
+    SELECT started_at, narrative FROM episodes
+    WHERE is_summarized = 1 AND narrative IS NOT NULL
+    ORDER BY started_at DESC LIMIT 5
+  `);
+
+  if (recentSessions.length > 0) {
+    lines.push('');
+    lines.push('## Recent Activity');
+    lines.push('');
+    lines.push('| Date | Summary |');
+    lines.push('|------|---------|');
+    for (const s of recentSessions) {
+      const date = s.started_at ? s.started_at.slice(0, 10) : '?';
+      let narrative = s.narrative || '';
+      if (narrative.length > 80) narrative = narrative.slice(0, 80) + '...';
+      narrative = _wikifyNarrative(db, narrative);
+      lines.push(`| ${date} | ${narrative} |`);
+    }
+  }
+
+  // Footer
+  const syncTime = _utcStamp();
+  lines.push(`\n---\n*Last synced: ${syncTime}*`);
+
+  const content = lines.join('\n') + '\n';
+  const filepath = join(vaultPath, 'Home.md');
+  writeFileSync(filepath, content, 'utf-8');
+}
+
+// ---------------------------------------------------------------------------
+// MOC indices (_Index.md per PARA directory)
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate _Index.md files in PARA entity directories.
+ *
+ * Creates indices in Relationships/people/, Relationships/organizations/,
+ * Active/, Reference/concepts/, Reference/locations/ with tables
+ * grouped by attention_tier for quick overview.
+ */
+function _exportMocIndices(db, vaultPath) {
+  for (const [paraPath, [etype, title]] of Object.entries(PARA_INDICES)) {
+    // Exclude archived/dormant entities (those go to Archive/)
+    const entities = db.query(`
+      SELECT name, importance, attention_tier, contact_trend, last_contact_at
+      FROM entities
+      WHERE type = ? AND deleted_at IS NULL
+        AND COALESCE(attention_tier, 'standard') != 'archive'
+        AND COALESCE(contact_trend, '') != 'dormant'
+      ORDER BY importance DESC
+    `, [etype]);
+
+    const lines = ['---'];
+    lines.push('tags:');
+    lines.push('  - moc');
+    lines.push('cssclasses:');
+    lines.push('  - moc-index');
+    lines.push('---');
+    lines.push('');
+    lines.push(`# ${title}`);
+
+    if (entities.length === 0) {
+      lines.push('');
+      lines.push(`*No ${etype} entities tracked yet.*`);
+    } else {
+      // Group by attention tier
+      const tiers = {};
+      for (const e of entities) {
+        const tier = e.attention_tier || 'standard';
+        if (!tiers[tier]) tiers[tier] = [];
+        tiers[tier].push(e);
+      }
+
+      const tierOrder = ['active', 'watchlist', 'standard'];
+      for (const tier of tierOrder) {
+        const tierEntities = tiers[tier];
+        if (!tierEntities || tierEntities.length === 0) continue;
+        delete tiers[tier];
+
+        lines.push('');
+        lines.push(`## ${tier.charAt(0).toUpperCase() + tier.slice(1)}`);
+        lines.push('');
+
+        if (etype === 'person') {
+          lines.push('| Name | Trend | Last Contact | Importance |');
+          lines.push('|------|-------|-------------|-----------|');
+          for (const e of tierEntities) {
+            const trend = e.contact_trend || '-';
+            const last = e.last_contact_at ? e.last_contact_at.slice(0, 10) : '-';
+            lines.push(`| [[${e.name}]] | ${trend} | ${last} | ${e.importance} |`);
+          }
+        } else {
+          lines.push('| Name | Importance |');
+          lines.push('|------|-----------|');
+          for (const e of tierEntities) {
+            lines.push(`| [[${e.name}]] | ${e.importance} |`);
+          }
+        }
+      }
+
+      // Any remaining tiers
+      for (const [tier, tierEntities] of Object.entries(tiers)) {
+        lines.push('');
+        lines.push(`## ${tier.charAt(0).toUpperCase() + tier.slice(1)}`);
+        lines.push('');
+        lines.push('| Name | Importance |');
+        lines.push('|------|-----------|');
+        for (const e of tierEntities) {
+          lines.push(`| [[${e.name}]] | ${e.importance} |`);
+        }
+      }
+    }
+
+    const content = lines.join('\n') + '\n';
+    const targetDir = join(vaultPath, paraPath);
+    _ensureDir(targetDir);
+    writeFileSync(join(targetDir, '_Index.md'), content, 'utf-8');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Obsidian config
+// ---------------------------------------------------------------------------
+
+/**
+ * Create .obsidian/ configuration files for graph colors, CSS, and workspace.
+ *
+ * Idempotent: only writes files that don't already exist, so user
+ * customizations in .obsidian/ are never overwritten.
+ */
+function _exportObsidianConfig(vaultPath) {
+  const obsidianDir = join(vaultPath, '.obsidian');
+  _ensureDir(obsidianDir);
+
+  // graph.json -- Color groups by entity type tag
+  const graphPath = join(obsidianDir, 'graph.json');
+  if (!existsSync(graphPath)) {
+    const graphConfig = {
+      'collapse-filter': false,
+      search: '',
+      showTags: false,
+      showAttachments: false,
+      hideUnresolved: true,
+      showOrphan: false,
+      'collapse-color-groups': false,
+      colorGroups: [
+        { query: 'tag:#person', color: { a: 1, rgb: 5025616 } },       // green
+        { query: 'tag:#project', color: { a: 1, rgb: 14701138 } },     // red
+        { query: 'tag:#organization', color: { a: 1, rgb: 11141375 } },// purple
+        { query: 'tag:#concept', color: { a: 1, rgb: 65535 } },        // cyan
+        { query: 'tag:#session', color: { a: 1, rgb: 10066329 } },     // gray
+        { query: 'tag:#pattern', color: { a: 1, rgb: 16744448 } },     // orange
+        { query: 'tag:#moc', color: { a: 1, rgb: 16776960 } },         // yellow
+      ],
+      'collapse-display': false,
+      showArrow: true,
+      textFadeMultiplier: -3,
+      nodeSizeMultiplier: 1,
+      lineSizeMultiplier: 1,
+      'collapse-forces': false,
+      centerStrength: 0.5,
+      repelStrength: 10,
+      linkStrength: 1,
+      linkDistance: 250,
+      scale: 1,
+      close: false,
+    };
+    writeFileSync(graphPath, JSON.stringify(graphConfig, null, 2), 'utf-8');
+  }
+
+  // snippets/claudia-theme.css -- Visual identity
+  const snippetsDir = join(obsidianDir, 'snippets');
+  _ensureDir(snippetsDir);
+  const cssPath = join(snippetsDir, 'claudia-theme.css');
+  if (!existsSync(cssPath)) {
+    const cssContent = `/* Claudia Vault Theme */
+
+/* Entity type emoji prefixes in Reading View */
+.entity-person .inline-title::before { content: "\\01F464 "; }
+.entity-project .inline-title::before { content: "\\01F4C1 "; }
+.entity-organization .inline-title::before { content: "\\01F3E2 "; }
+.entity-concept .inline-title::before { content: "\\01F4A1 "; }
+.entity-location .inline-title::before { content: "\\01F4CD "; }
+
+/* Tag color pills matching graph colors */
+.tag[href="#person"] { background-color: #4CAF50; color: white; }
+.tag[href="#project"] { background-color: #E05252; color: white; }
+.tag[href="#organization"] { background-color: #AA00FF; color: white; }
+.tag[href="#concept"] { background-color: #00BCD4; color: white; }
+.tag[href="#session"] { background-color: #999999; color: white; }
+.tag[href="#pattern"] { background-color: #FF9800; color: white; }
+.tag[href="#moc"] { background-color: #FFEB3B; color: #333; }
+.tag[href="#active"] { background-color: #4CAF50; color: white; }
+.tag[href="#watchlist"] { background-color: #FF9800; color: white; }
+.tag[href="#dormant"] { background-color: #999999; color: white; }
+.tag[href="#decelerating"] { background-color: #E05252; color: white; }
+
+/* MOC index styling */
+.moc-index h1 { text-align: center; font-size: 2em; }
+
+/* Compact frontmatter panel */
+.metadata-container { font-size: 0.85em; }
+`;
+    writeFileSync(cssPath, cssContent, 'utf-8');
+  }
+
+  // app.json -- Enable CSS snippets, readable line length, show frontmatter
+  const appPath = join(obsidianDir, 'app.json');
+  if (!existsSync(appPath)) {
+    writeFileSync(appPath, JSON.stringify({
+      readableLineLength: true,
+      showFrontmatter: true,
+      livePreview: true,
+    }, null, 2), 'utf-8');
+  }
+
+  // appearance.json -- Enable the CSS snippet
+  const appearancePath = join(obsidianDir, 'appearance.json');
+  if (!existsSync(appearancePath)) {
+    writeFileSync(appearancePath, JSON.stringify({
+      enabledCssSnippets: ['claudia-theme'],
+    }, null, 2), 'utf-8');
+  }
+
+  // workspace.json -- Open Home.md on first launch with graph in right sidebar
+  const workspacePath = join(obsidianDir, 'workspace.json');
+  if (!existsSync(workspacePath)) {
+    const workspaceConfig = {
+      main: {
+        id: 'main',
+        type: 'split',
+        children: [
+          {
+            id: 'editor',
+            type: 'tabs',
+            children: [
+              {
+                id: 'home-tab',
+                type: 'leaf',
+                state: {
+                  type: 'markdown',
+                  state: {
+                    file: 'Home.md',
+                    mode: 'preview',
+                  },
+                },
+              },
+            ],
+          },
+        ],
+        direction: 'horizontal',
+      },
+      active: 'home-tab',
+    };
+    writeFileSync(workspacePath, JSON.stringify(workspaceConfig, null, 2), 'utf-8');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// MOC generators (Claudia's Desk)
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate MOC-People.md -- relationship health map for Claudia's read layer.
+ *
+ * Pre-computed markdown Claudia can read instead of calling memory.graph op=network.
+ * Organized by attention tier for quick scanning.
+ */
+function _generateMocPeople(db) {
+  const timestamp = _utcStamp();
+  const lines = ['# People \u2014 Health Map', '', `> Last updated: ${timestamp}`, ''];
+
+  const people = db.query(`
+    SELECT id, name, attention_tier, contact_trend, last_contact_at
+    FROM entities
+    WHERE type = 'person' AND deleted_at IS NULL AND importance > 0.05
+    ORDER BY importance DESC
+  `);
+
+  if (people.length === 0) {
+    lines.push('*No people tracked yet.*');
+    lines.push(`\n---\n*Last updated: ${timestamp}*`);
+    return lines.join('\n');
+  }
+
+  // Group by tier
+  const tiers = { active: [], watchlist: [], standard: [], archive: [] };
+  for (const p of people) {
+    let tier = (p.attention_tier || 'standard').toLowerCase();
+    if (!tiers[tier]) tier = 'standard';
+    tiers[tier].push(p);
+  }
+
+  const tierConfig = [
+    ['active', '\uD83D\uDD34 Active (needs attention now)'],
+    ['watchlist', '\uD83D\uDFE1 Watchlist (declining attention)'],
+    ['standard', '\u26AA Standard'],
+    ['archive', '\uD83D\uDD35 Archive (dormant 90+ days)'],
+  ];
+
+  for (const [tierKey, tierHeading] of tierConfig) {
+    const tierPeople = tiers[tierKey] || [];
+    if (tierPeople.length === 0) continue;
+
+    lines.push(`## ${tierHeading}`);
+    lines.push('');
+    lines.push('| Name | Last Contact | Trend | Open Commitments |');
+    lines.push('|------|-------------|-------|-----------------|');
+
+    for (const p of tierPeople) {
+      const days = _daysAgo(p.last_contact_at);
+      const lastStr = days != null ? `${days}d ago` : (p.last_contact_at ? p.last_contact_at.slice(0, 10) : '-');
+      const trend = p.contact_trend || '-';
+
+      const commRow = db.queryOne(`
+        SELECT COUNT(*) as cnt FROM memories m
+        JOIN memory_entities me ON m.id = me.memory_id
+        WHERE me.entity_id = ? AND m.type = 'commitment' AND m.invalidated_at IS NULL
+      `, [p.id]);
+      const commCount = commRow ? commRow.cnt : 0;
+
+      lines.push(
+        `| [[people/${_sanitizeFilename(p.name)}]] | ${lastStr} | ${trend} | ${commCount} |`
+      );
+    }
+
+    lines.push('');
+  }
+
+  lines.push(`---\n*Last updated: ${timestamp}*`);
+  return lines.join('\n');
+}
+
+/**
+ * Generate MOC-Commitments.md -- open commitments overview for Claudia's read layer.
+ *
+ * Organized by urgency: overdue, due this week, open, recently completed.
+ */
+function _generateMocCommitments(db) {
+  const timestamp = _utcStamp();
+  const lines = ['# Open Commitments', '', `> Last updated: ${timestamp}`, ''];
+
+  function _getCommitments(sql, params = []) {
+    const rows = db.query(sql, params);
+    const result = [];
+    for (const row of rows) {
+      const entRows = db.query(`
+        SELECT e.name, e.type FROM entities e
+        JOIN memory_entities me ON e.id = me.entity_id
+        WHERE me.memory_id = ? AND e.deleted_at IS NULL
+        LIMIT 3
+      `, [row.id]);
+      result.push([row, entRows]);
+    }
+    return result;
+  }
+
+  // Overdue
+  const overdue = _getCommitments(`
+    SELECT id, content, deadline_at FROM memories
+    WHERE type = 'commitment' AND invalidated_at IS NULL
+      AND deadline_at IS NOT NULL AND deadline_at < datetime('now')
+    ORDER BY deadline_at ASC LIMIT 20
+  `);
+  if (overdue.length > 0) {
+    lines.push('## \u26A0\uFE0F Overdue');
+    lines.push('');
+    lines.push('| Commitment | Person/Project | Deadline |');
+    lines.push('|------------|---------------|---------|');
+    for (const [row, entities] of overdue) {
+      const content = row.content.length > 80 ? row.content.slice(0, 80) + '...' : row.content;
+      const entLinks = entities.length > 0
+        ? entities.map(e =>
+          `[[${ENTITY_TYPE_DIRS[e.type] || 'concepts'}/${_sanitizeFilename(e.name)}]]`
+        ).join(', ')
+        : '-';
+      const deadline = row.deadline_at ? row.deadline_at.slice(0, 10) : '-';
+      lines.push(`| ${content} | ${entLinks} | ${deadline} |`);
+    }
+    lines.push('');
+  }
+
+  // Due this week
+  const dueWeek = _getCommitments(`
+    SELECT id, content, deadline_at FROM memories
+    WHERE type = 'commitment' AND invalidated_at IS NULL
+      AND deadline_at BETWEEN datetime('now') AND datetime('now', '+7 days')
+    ORDER BY deadline_at ASC LIMIT 20
+  `);
+  if (dueWeek.length > 0) {
+    lines.push('## \uD83D\uDCC5 Due This Week');
+    lines.push('');
+    lines.push('| Commitment | Person/Project | Deadline |');
+    lines.push('|------------|---------------|---------|');
+    for (const [row, entities] of dueWeek) {
+      const content = row.content.length > 80 ? row.content.slice(0, 80) + '...' : row.content;
+      const entLinks = entities.length > 0
+        ? entities.map(e =>
+          `[[${ENTITY_TYPE_DIRS[e.type] || 'concepts'}/${_sanitizeFilename(e.name)}]]`
+        ).join(', ')
+        : '-';
+      const deadline = row.deadline_at ? row.deadline_at.slice(0, 10) : '-';
+      lines.push(`| ${content} | ${entLinks} | ${deadline} |`);
+    }
+    lines.push('');
+  }
+
+  // Open (no deadline)
+  const openNd = _getCommitments(`
+    SELECT id, content, deadline_at FROM memories
+    WHERE type = 'commitment' AND invalidated_at IS NULL
+      AND (deadline_at IS NULL OR deadline_at > datetime('now', '+7 days'))
+    ORDER BY importance DESC LIMIT 30
+  `);
+  if (openNd.length > 0) {
+    lines.push('## \uD83D\uDD04 Open (no deadline)');
+    lines.push('');
+    for (const [row, entities] of openNd) {
+      const content = row.content.length > 80 ? row.content.slice(0, 80) + '...' : row.content;
+      const entLinks = entities.map(e =>
+        `[[${ENTITY_TYPE_DIRS[e.type] || 'concepts'}/${_sanitizeFilename(e.name)}]]`
+      ).join(' ');
+      const suffix = entLinks ? ` (${entLinks})` : '';
+      lines.push(`- [ ] ${content}${suffix}`);
+    }
+    lines.push('');
+  }
+
+  // Recently completed
+  const completed = _getCommitments(`
+    SELECT id, content, invalidated_at as deadline_at FROM memories
+    WHERE type = 'commitment' AND invalidated_at IS NOT NULL
+      AND invalidated_at > datetime('now', '-7 days')
+    ORDER BY invalidated_at DESC LIMIT 10
+  `);
+  if (completed.length > 0) {
+    lines.push('## \u2705 Recently Completed (last 7 days)');
+    lines.push('');
+    for (const [row] of completed) {
+      const content = row.content.length > 80 ? row.content.slice(0, 80) + '...' : row.content;
+      lines.push(`- [x] ${content}`);
+    }
+    lines.push('');
+  }
+
+  if (overdue.length === 0 && dueWeek.length === 0 && openNd.length === 0) {
+    lines.push('*No open commitments tracked.*');
+    lines.push('');
+  }
+
+  lines.push(`---\n*Last updated: ${timestamp}*`);
+  return lines.join('\n');
+}
+
+/**
+ * Generate MOC-Projects.md -- project status overview for Claudia's read layer.
+ */
+function _generateMocProjects(db) {
+  const timestamp = _utcStamp();
+  const lines = ['# Projects Overview', '', `> Last updated: ${timestamp}`, ''];
+
+  const projects = db.query(`
+    SELECT id, name, importance, attention_tier, updated_at
+    FROM entities
+    WHERE type = 'project' AND deleted_at IS NULL
+    ORDER BY importance DESC
+  `);
+
+  if (projects.length === 0) {
+    lines.push('*No projects tracked yet.*');
+    lines.push(`\n---\n*Last updated: ${timestamp}*`);
+    return lines.join('\n');
+  }
+
+  // Group by tier
+  const tiers = { active: [], standard: [], archive: [] };
+  for (const p of projects) {
+    let tier = (p.attention_tier || 'standard').toLowerCase();
+    if (!tiers[tier]) tier = 'standard';
+    tiers[tier].push(p);
+  }
+
+  const tierConfig = [
+    ['active', '## Active Projects'],
+    ['standard', '## Standard Projects'],
+    ['archive', '## Archive'],
+  ];
+
+  for (const [tierKey, tierHeading] of tierConfig) {
+    const tierProjects = tiers[tierKey] || [];
+    if (tierProjects.length === 0) continue;
+
+    lines.push(tierHeading);
+    lines.push('');
+    lines.push('| Name | Connected People | Open Commitments | Importance |');
+    lines.push('|------|-----------------|-----------------|-----------|');
+
+    for (const p of tierProjects) {
+      const peopleRow = db.queryOne(`
+        SELECT COUNT(DISTINCT e.id) as cnt
+        FROM entities e
+        JOIN relationships r ON (
+          (r.source_entity_id = ? AND r.target_entity_id = e.id) OR
+          (r.target_entity_id = ? AND r.source_entity_id = e.id)
+        )
+        WHERE e.type = 'person' AND e.deleted_at IS NULL AND r.invalid_at IS NULL
+      `, [p.id, p.id]);
+      const peopleCount = peopleRow ? peopleRow.cnt : 0;
+
+      const commRow = db.queryOne(`
+        SELECT COUNT(*) as cnt FROM memories m
+        JOIN memory_entities me ON m.id = me.memory_id
+        WHERE me.entity_id = ? AND m.type = 'commitment' AND m.invalidated_at IS NULL
+      `, [p.id]);
+      const commCount = commRow ? commRow.cnt : 0;
+
+      lines.push(
+        `| [[projects/${_sanitizeFilename(p.name)}]] | ${peopleCount} | ${commCount} | ${p.importance} |`
+      );
+    }
+
+    lines.push('');
+  }
+
+  lines.push(`---\n*Last updated: ${timestamp}*`);
+  return lines.join('\n');
+}
+
+/**
+ * Write a MOC file to Claudia's Desk.
+ */
+function _writeMocFile(vaultPath, filename, content) {
+  const mocDir = join(vaultPath, "Claudia's Desk");
+  _ensureDir(mocDir);
+  const filepath = join(mocDir, filename);
+  try {
+    writeFileSync(filepath, content, 'utf-8');
+  } catch (e) {
+    _log(`Failed to write MOC file ${filepath}: ${e.message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Frontmatter parsing (for bidirectional sync)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse YAML frontmatter from a markdown file.
+ *
+ * Returns [frontmatterDict, bodyText].
+ * Returns [null, rawContent] if no frontmatter found.
+ *
+ * Uses a simple key-value parser (no YAML dependency).
+ */
+function _parseFrontmatter(raw) {
+  if (!raw.startsWith('---')) return [null, raw];
+
+  const parts = raw.split('---');
+  // After split on '---', parts[0] is empty, parts[1] is frontmatter, parts[2+] is body
+  if (parts.length < 3) return [null, raw];
+
+  const fmText = parts[1].trim();
+  const body = parts.slice(2).join('---').trim();
+
+  // Simple key-value parsing (handles most common frontmatter cases)
+  const fm = {};
+  for (const line of fmText.split('\n')) {
+    const colonIdx = line.indexOf(':');
+    if (colonIdx === -1) continue;
+    // Skip list items (lines starting with ' -')
+    if (line.trimStart().startsWith('-')) continue;
+    const key = line.slice(0, colonIdx).trim();
+    let value = line.slice(colonIdx + 1).trim();
+    // Strip surrounding quotes
+    if ((value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    if (key) fm[key] = value;
+  }
+
+  return [fm, body];
+}
+
+// ---------------------------------------------------------------------------
+// Bidirectional sync (import user edits)
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect notes that users have edited in the vault.
+ *
+ * Walks all .md files in entity directories, compares content hash to
+ * sync_hash in frontmatter.
+ *
+ * @param {string} vaultPath
+ * @returns {object[]} List of edits with file path, entity ID, and change info
+ */
+function _detectUserEdits(vaultPath) {
+  const edits = [];
+
+  for (const subdir of ENTITY_SUBDIRS) {
+    const d = join(vaultPath, subdir);
+    if (!existsSync(d)) continue;
+
+    const files = _listMdFiles(d);
+    for (const filename of files) {
+      const filepath = join(d, filename);
+      try {
+        const raw = readFileSync(filepath, 'utf-8');
+        const [fm, body] = _parseFrontmatter(raw);
+        if (!fm || !fm.sync_hash) continue;
+
+        const currentHash = _computeSyncHash(body);
+        if (currentHash !== fm.sync_hash) {
+          edits.push({
+            file_path: filepath,
+            entity_id: fm.claudia_id ? Number(fm.claudia_id) : null,
+            entity_type: fm.type || null,
+            old_hash: fm.sync_hash,
+            new_hash: currentHash,
+          });
+        }
+      } catch {
+        // Skip unreadable files
+      }
+    }
+  }
+
+  return edits;
+}
+
+/**
+ * Import user edits from a single vault note back into SQLite.
+ *
+ * Human edits always win: all changes use origin_type='user_stated'
+ * and confidence=1.0.
+ *
+ * @param {object} db - ClaudiaDatabase instance
+ * @param {string} vaultPath - Root vault directory
+ * @param {string} filePath - Path to the edited vault note
+ * @returns {object} Summary of changes applied
+ */
+function _importVaultEdit(db, vaultPath, filePath) {
+  const raw = readFileSync(filePath, 'utf-8');
+  const [fm, body] = _parseFrontmatter(raw);
+
+  if (!fm || !fm.claudia_id) {
+    return { error: 'No claudia_id in frontmatter', file: filePath };
+  }
+
+  const entityId = Number(fm.claudia_id);
+  const changes = {
+    entity_id: entityId,
+    facts_added: 0,
+    facts_updated: 0,
+    commitments_completed: 0,
+    description_updated: false,
+  };
+
+  // Get current entity from DB
+  const entity = db.queryOne('SELECT * FROM entities WHERE id = ? AND deleted_at IS NULL', [entityId]);
+  if (!entity) {
+    return { error: `Entity ${entityId} not found`, file: filePath };
+  }
+
+  const entityName = entity.name;
+
+  // Parse body sections
+  const bodyLines = body.trim().split('\n');
+
+  // Extract description (text after title, before first ## heading)
+  const descLines = [];
+  let inDesc = false;
+  for (const line of bodyLines) {
+    if (line.startsWith('# ')) {
+      inDesc = true;
+      continue;
+    }
+    if (line.startsWith('## ')) break;
+    if (inDesc && line.trim()) {
+      descLines.push(line.trim());
+    }
+  }
+
+  const newDesc = descLines.join(' ').trim() || null;
+  if (newDesc && newDesc !== (entity.description || '')) {
+    db.update('entities', {
+      description: newDesc,
+      updated_at: _nowISO(),
+    }, 'id = ?', [entityId]);
+    changes.description_updated = true;
+  }
+
+  // Parse commitment checkboxes and key facts
+  let currentSection = null;
+  for (const line of bodyLines) {
+    if (line.startsWith('## ')) {
+      currentSection = line.slice(3).trim().toLowerCase();
+      continue;
+    }
+
+    if (currentSection === 'commitments') {
+      // Check for completed checkboxes: - [x]
+      const completedMatch = line.match(/^-\s*\[x\]\s*(.+?)(?:\s*\(.*\))?\s*$/i);
+      if (completedMatch) {
+        const commitContent = completedMatch[1].trim();
+        // Find matching commitment in DB
+        const mem = db.queryOne(`
+          SELECT m.id FROM memories m
+          JOIN memory_entities me ON m.id = me.memory_id
+          WHERE me.entity_id = ? AND m.type = 'commitment'
+            AND m.content LIKE ? AND m.invalidated_at IS NULL
+          LIMIT 1
+        `, [entityId, `%${commitContent.slice(0, 40)}%`]);
+
+        if (mem) {
+          db.update('memories', {
+            invalidated_at: _nowISO(),
+            invalidated_reason: 'completed (marked in vault)',
+          }, 'id = ?', [mem.id]);
+          changes.commitments_completed++;
+        }
+      }
+    } else if (['key facts', 'preferences', 'observations', 'learnings'].includes(currentSection)) {
+      // Check for new bullets
+      const bulletMatch = line.match(/^-\s+(.+?)(?:\s*\(.*\))?\s*$/);
+      if (bulletMatch) {
+        const factContent = bulletMatch[1].trim();
+        if (!factContent) continue;
+
+        // Check if this fact already exists
+        const factHash = contentHash(factContent);
+        const existing = db.queryOne(
+          'SELECT id FROM memories WHERE content_hash = ?',
+          [factHash]
+        );
+
+        if (!existing) {
+          const typeMap = {
+            'key facts': 'fact',
+            preferences: 'preference',
+            observations: 'observation',
+            learnings: 'learning',
+          };
+          const memType = typeMap[currentSection] || 'fact';
+
+          // Insert memory directly (simplified path for vault import)
+          const memId = db.insert('memories', {
+            content: factContent,
+            type: memType,
+            importance: 0.8,
+            confidence: 1.0,
+            origin_type: 'user_stated',
+            source: 'vault_import',
+            content_hash: factHash,
+            created_at: _nowISO(),
+            updated_at: _nowISO(),
+          });
+
+          // Link to entity
+          db.insert('memory_entities', {
+            memory_id: memId,
+            entity_id: entityId,
+          });
+
+          changes.facts_added++;
+        }
+      }
+    }
+  }
+
+  // Update sync_hash in frontmatter
+  const newHash = _computeSyncHash(body);
+  const oldHash = fm.sync_hash || '';
+  if (oldHash) {
+    const updatedRaw = raw.replace(`sync_hash: ${oldHash}`, `sync_hash: ${newHash}`);
+    writeFileSync(filePath, updatedRaw, 'utf-8');
+  }
+
+  _appendSyncLog(vaultPath,
+    `Imported edits from ${filePath.split('/').pop()}: ` +
+    `${changes.facts_added} facts, ` +
+    `${changes.commitments_completed} commitments completed`
+  );
+
+  return changes;
+}
+
+// ---------------------------------------------------------------------------
+// Canvas generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a .canvas file for an entity's relationship network.
+ *
+ * Creates an Obsidian Canvas JSON file showing the entity at center
+ * with connected entities arranged around it.
+ *
+ * @param {object} db - ClaudiaDatabase instance
+ * @param {string} vaultPath - Root vault directory
+ * @param {string} entityName - Name of the central entity
+ * @returns {string|null} Path to generated canvas file, or null
+ */
+function generateCanvas(db, vaultPath, entityName) {
+  // Find the entity
+  const entity = db.queryOne(
+    'SELECT * FROM entities WHERE name = ? AND deleted_at IS NULL',
+    [entityName]
+  );
+  if (!entity) {
+    _log(`Entity "${entityName}" not found`);
+    return null;
+  }
+
+  const entityId = entity.id;
+  const relationships = _getEntityRelationships(db, entityId);
+
+  if (relationships.length === 0) {
+    _log(`No relationships found for "${entityName}"`);
+    return null;
+  }
+
+  // Build canvas nodes and edges
+  const nodes = [];
+  const edges = [];
+  const nodeIds = new Set();
+
+  // Center node
+  const centerId = `entity-${entityId}`;
+  nodes.push({
+    id: centerId,
+    x: 0,
+    y: 0,
+    width: 250,
+    height: 60,
+    type: 'file',
+    file: `${_sanitizeFilename(entityName)}.md`,
+    color: '4',
+  });
+  nodeIds.add(entityId);
+
+  // Arrange connected entities in a circle
+  const angleStep = (2 * Math.PI) / relationships.length;
+  const radius = 400;
+
+  for (let i = 0; i < relationships.length; i++) {
+    const rel = relationships[i];
+    const otherId = rel.source_entity_id === entityId
+      ? rel.target_entity_id
+      : rel.source_entity_id;
+    const otherName = rel.source_entity_id === entityId
+      ? rel.target_name
+      : rel.source_name;
+
+    if (nodeIds.has(otherId)) continue;
+    nodeIds.add(otherId);
+
+    const x = Math.round(Math.cos(angleStep * i) * radius);
+    const y = Math.round(Math.sin(angleStep * i) * radius);
+
+    const nodeId = `entity-${otherId}`;
+    nodes.push({
+      id: nodeId,
+      x,
+      y,
+      width: 200,
+      height: 50,
+      type: 'file',
+      file: `${_sanitizeFilename(otherName)}.md`,
+    });
+
+    edges.push({
+      id: `edge-${centerId}-${nodeId}`,
+      fromNode: centerId,
+      toNode: nodeId,
+      fromSide: 'right',
+      toSide: 'left',
+      label: rel.relationship_type,
+    });
+  }
+
+  const canvasData = { nodes, edges };
+  const canvasDir = join(vaultPath, 'canvases');
+  _ensureDir(canvasDir);
+
+  const canvasPath = join(canvasDir, `${_sanitizeFilename(entityName)}.canvas`);
+  writeFileSync(canvasPath, JSON.stringify(canvasData, null, 2), 'utf-8');
+
+  // Update canvas hash in sync metadata
+  const metaPath = join(vaultPath, '_meta', 'last-sync.json');
+  let meta = {};
+  if (existsSync(metaPath)) {
+    try { meta = JSON.parse(readFileSync(metaPath, 'utf-8')); } catch { /* ignore */ }
+  }
+  if (!meta.canvas_hashes) meta.canvas_hashes = {};
+  meta.canvas_hashes[entityName] = _computeSyncHash(JSON.stringify(canvasData));
+  writeFileSync(metaPath, JSON.stringify(meta, null, 2), 'utf-8');
+
+  return canvasPath;
+}
+
+// ============================================================================
+// PUBLIC API
+// ============================================================================
+
+/**
+ * Compute vault path from config.
+ *
+ * Uses vault_base_dir from config, falling back to ~/.claudia/vault/.
+ * Path is {vault_base_dir}/{projectId}/ for project-specific vaults,
+ * or {vault_base_dir}/default/ for the global vault.
+ *
+ * @param {string} [projectDir] - Project directory (used as folder name)
+ * @returns {string} Vault path
+ */
+export function getVaultPath(projectDir) {
+  const config = getConfig();
+  let baseDir = config.vault_base_dir;
+  if (!baseDir) {
+    baseDir = getVaultDir();
+  }
+  const folder = projectDir || 'default';
+  return join(baseDir, folder);
+}
+
+/**
+ * Full or incremental vault export (main entry point).
+ *
+ * @param {object} db - ClaudiaDatabase instance
+ * @param {object} [options]
+ * @param {boolean} [options.full=false] - Force full rebuild
+ * @param {string} [options.projectDir] - Project directory for vault path resolution
+ * @param {string} [options.vaultPath] - Override vault path directly
+ * @returns {object} Stats of exported items
+ */
+export function syncVault(db, { full = false, projectDir, vaultPath: explicitVaultPath } = {}) {
+  const config = getConfig();
+  if (config.vault_sync_enabled === false) {
+    _log('Vault sync is disabled in config');
+    return { skipped: true };
+  }
+
+  const vaultPath = explicitVaultPath || getVaultPath(projectDir);
+
+  // Auto-upgrade: if vault format version < 2, force full rebuild
+  if (!full && _getVaultFormatVersion(vaultPath) < 2) {
+    _log('Vault format version < 2, forcing full rebuild for upgrade');
+    full = true;
+  }
+
+  if (full) {
+    return _exportAll(db, vaultPath);
+  }
+  return _exportIncremental(db, vaultPath);
+}
+
+/**
+ * Full vault rebuild from SQLite.
+ *
+ * Exports all entities, patterns, reflections, sessions, Home dashboard,
+ * MOC indices, and .obsidian config.
+ *
+ * @returns {object} Dict with counts of exported items
+ */
+function _exportAll(db, vaultPath) {
+  _log(`Starting full vault export to ${vaultPath}`);
+  _ensureDirectories(vaultPath);
+  _clearEntityNamesCache();
+
+  const stats = {
+    entities: 0,
+    patterns: 0,
+    reflections: 0,
+    sessions: 0,
+    mocs: 0,
+  };
+
+  // Export all entities
+  const entities = _getAllEntities(db);
+  for (const entity of entities) {
+    const path = _exportEntity(db, vaultPath, entity);
+    if (path) stats.entities++;
+  }
+
+  // Export patterns
+  stats.patterns = _exportPatterns(db, vaultPath);
+
+  // Export reflections
+  stats.reflections = _exportReflections(db, vaultPath);
+
+  // Export sessions (hierarchical, wikified)
+  stats.sessions = _exportSessions(db, vaultPath);
+
+  // Export Dataview query templates (only if they don't exist yet)
+  _exportDataviewTemplates(vaultPath);
+
+  // Export Home dashboard (always regenerated)
+  _exportHomeDashboard(db, vaultPath);
+
+  // Export MOC index files (always regenerated)
+  _exportMocIndices(db, vaultPath);
+
+  // Write top-level MOC files (Claudia's read layer)
+  _writeMocFile(vaultPath, 'MOC-People.md', _generateMocPeople(db));
+  _writeMocFile(vaultPath, 'MOC-Commitments.md', _generateMocCommitments(db));
+  _writeMocFile(vaultPath, 'MOC-Projects.md', _generateMocProjects(db));
+  stats.mocs = 3;
+
+  // Export .obsidian config (idempotent, never overwrites)
+  _exportObsidianConfig(vaultPath);
+
+  // Save metadata with format version
+  _saveSyncMetadata(vaultPath, stats);
+  _appendSyncLog(vaultPath,
+    `Full sync: ${stats.entities} entities, ` +
+    `${stats.patterns} patterns, ` +
+    `${stats.reflections} reflections, ` +
+    `${stats.sessions} session days`
+  );
+
+  _log(`Full vault export complete: ${JSON.stringify(stats)}`);
+  return stats;
+}
+
+/**
+ * Incremental export: only entities/sessions changed since last sync.
+ *
+ * Falls back to full export if no previous sync metadata exists.
+ */
+function _exportIncremental(db, vaultPath) {
+  const lastSync = _getLastSyncTime(vaultPath);
+  if (!lastSync) {
+    _log('No previous sync found, running full export');
+    return _exportAll(db, vaultPath);
+  }
+
+  _log(`Starting incremental vault export (since ${lastSync})`);
+  _ensureDirectories(vaultPath);
+  _clearEntityNamesCache();
+
+  const stats = {
+    entities: 0,
+    patterns: 0,
+    reflections: 0,
+    sessions: 0,
+    mocs: 0,
+  };
+
+  // Export changed entities
+  const entities = _getAllEntities(db, lastSync);
+  for (const entity of entities) {
+    const path = _exportEntity(db, vaultPath, entity);
+    if (path) stats.entities++;
+  }
+
+  // Patterns and reflections are always fully rebuilt (cheap operation)
+  stats.patterns = _exportPatterns(db, vaultPath);
+  stats.reflections = _exportReflections(db, vaultPath);
+
+  // Sessions since last sync
+  stats.sessions = _exportSessions(db, vaultPath, lastSync);
+
+  // Always regenerate MOC files (pure SQL, fast)
+  _writeMocFile(vaultPath, 'MOC-People.md', _generateMocPeople(db));
+  _writeMocFile(vaultPath, 'MOC-Commitments.md', _generateMocCommitments(db));
+  _writeMocFile(vaultPath, 'MOC-Projects.md', _generateMocProjects(db));
+  stats.mocs = 3;
+
+  // Always regenerate Home and indices
+  _exportHomeDashboard(db, vaultPath);
+  _exportMocIndices(db, vaultPath);
+
+  _saveSyncMetadata(vaultPath, stats);
+  _appendSyncLog(vaultPath,
+    `Incremental sync (since ${lastSync}): ` +
+    `${stats.entities} entities, ` +
+    `${stats.patterns} patterns, ` +
+    `${stats.reflections} reflections, ` +
+    `${stats.sessions} session days`
+  );
+
+  _log(`Incremental vault export complete: ${JSON.stringify(stats)}`);
+  return stats;
+}
+
+/**
+ * Get vault sync status information.
+ *
+ * @param {object} db - ClaudiaDatabase instance
+ * @param {string} vaultPath - Root vault directory
+ * @returns {object} Status information
+ */
+export function getVaultStatus(db, vaultPath) {
+  const metaPath = join(vaultPath, '_meta', 'last-sync.json');
+  if (!existsSync(metaPath)) {
+    return {
+      vault_path: vaultPath,
+      synced: false,
+      last_sync: null,
+      stats: null,
+    };
+  }
+
+  try {
+    const data = JSON.parse(readFileSync(metaPath, 'utf-8'));
+
+    // Count files in vault (PARA structure)
+    const fileCounts = {};
+    const countDirs = [
+      'Active', 'Relationships/people', 'Relationships/organizations',
+      'Reference/concepts', 'Reference/locations',
+      'Archive/people', 'Archive/projects', 'Archive/organizations',
+      "Claudia's Desk/patterns", "Claudia's Desk/reflections",
+    ];
+    for (const subdir of countDirs) {
+      fileCounts[subdir] = _listMdFiles(join(vaultPath, subdir)).length;
+    }
+
+    return {
+      vault_path: vaultPath,
+      synced: true,
+      last_sync: data.last_sync || null,
+      stats: data.stats || null,
+      file_counts: fileCounts,
+    };
+  } catch {
+    return {
+      vault_path: vaultPath,
+      synced: false,
+      last_sync: null,
+      stats: null,
+      error: 'Could not read sync metadata',
+    };
+  }
+}
+
+/**
+ * Export a single entity by canonical name lookup.
+ *
+ * Convenience method for real-time write-through: looks up the entity
+ * by name and exports it.
+ *
+ * @param {object} db - ClaudiaDatabase instance
+ * @param {string} name - Entity name to look up
+ * @param {string} vaultPath - Root vault directory
+ * @returns {string|null} Path of the written file, or null
+ */
+export function exportEntityByName(db, name, vaultPath) {
+  const canonical = canonicalName(name);
+
+  let entity = db.queryOne(
+    'SELECT * FROM entities WHERE canonical_name = ? AND deleted_at IS NULL',
+    [canonical]
+  );
+
+  if (!entity) {
+    // Try alias lookup
+    const aliasRow = db.queryOne(
+      'SELECT entity_id FROM entity_aliases WHERE canonical_alias = ?',
+      [canonical]
+    );
+    if (aliasRow) {
+      entity = db.queryOne(
+        'SELECT * FROM entities WHERE id = ? AND deleted_at IS NULL',
+        [aliasRow.entity_id]
+      );
+    }
+  }
+
+  if (entity) {
+    _ensureDirectories(vaultPath);
+    return _exportEntity(db, vaultPath, entity);
+  }
+  return null;
+}
+
+/**
+ * Export a single entity by ID.
+ *
+ * Direct ID-based export for cases where the entity ID is already known.
+ *
+ * @param {object} db - ClaudiaDatabase instance
+ * @param {number} entityId - Entity ID
+ * @param {string} vaultPath - Root vault directory
+ * @returns {string|null} Path of the written file, or null
+ */
+export function exportEntityById(db, entityId, vaultPath) {
+  const entity = db.queryOne(
+    'SELECT * FROM entities WHERE id = ? AND deleted_at IS NULL',
+    [entityId]
+  );
+  if (entity) {
+    _ensureDirectories(vaultPath);
+    return _exportEntity(db, vaultPath, entity);
+  }
+  return null;
+}
+
+/**
+ * Detect and import user edits (bidirectional sync).
+ *
+ * Scans vault for user edits and imports them all back into SQLite.
+ * Human edits always win (origin_type='user_stated', confidence=1.0).
+ *
+ * @param {object} db - ClaudiaDatabase instance
+ * @param {string} vaultPath - Root vault directory
+ * @returns {object} Summary of all changes applied
+ */
+export function importVaultEdits(db, vaultPath) {
+  const edits = _detectUserEdits(vaultPath);
+  if (edits.length === 0) {
+    return { edits_found: 0, changes: [] };
+  }
+
+  const results = [];
+  for (const edit of edits) {
+    try {
+      const change = _importVaultEdit(db, vaultPath, edit.file_path);
+      results.push(change);
+    } catch (e) {
+      _log(`Failed to import edit from ${edit.file_path}: ${e.message}`);
+      results.push({ error: e.message, file: edit.file_path });
+    }
+  }
+
+  return { edits_found: edits.length, changes: results };
+}
+
+// Re-export generateCanvas (already defined above as a named function)
+export { generateCanvas };

--- a/memory-daemon/claudia_memory/config.py
+++ b/memory-daemon/claudia_memory/config.py
@@ -101,6 +101,23 @@ class MemoryConfig:
     # Vault layout (PARA-inspired structure)
     vault_layout: str = "para"           # Vault organization style (only "para" for now)
 
+    # Lifecycle & Sacred memory settings
+    cooling_threshold_days: int = 60        # Days without access before memory enters 'cooling'
+    archive_threshold_days: int = 180       # Days in cooling + low importance before archiving
+    enable_auto_sacred: bool = True         # Auto-detect sacred facts for close-circle entities
+    close_circle_keywords: list = field(default_factory=lambda: [
+        "close friend", "bestie", "family", "inner circle", "best friend",
+        "spouse", "partner", "sibling", "parent", "child",
+    ])
+    sacred_core_keywords: list = field(default_factory=lambda: [
+        "birthday", "allergy", "family", "boundary", "health",
+        "never forget", "anniversary", "preference", "medical",
+        "dietary", "phobia", "trigger",
+    ])
+    enable_chain_verification: bool = True  # SHA-256 chain hashing on memories
+    context_builder_token_budget: int = 8000  # Default token budget for CRE
+    context_builder_max_facts: int = 30       # Max facts in CRE context window
+
     # Daemon settings
     log_path: Path = field(default_factory=lambda: Path.home() / ".claudia" / "daemon.log")
 
@@ -194,6 +211,22 @@ class MemoryConfig:
                     config.auto_dedupe_threshold = data["auto_dedupe_threshold"]
                 if "graph_proximity_weight" in data:
                     config.graph_proximity_weight = data["graph_proximity_weight"]
+                if "cooling_threshold_days" in data:
+                    config.cooling_threshold_days = data["cooling_threshold_days"]
+                if "archive_threshold_days" in data:
+                    config.archive_threshold_days = data["archive_threshold_days"]
+                if "enable_auto_sacred" in data:
+                    config.enable_auto_sacred = data["enable_auto_sacred"]
+                if "close_circle_keywords" in data:
+                    config.close_circle_keywords = data["close_circle_keywords"]
+                if "sacred_core_keywords" in data:
+                    config.sacred_core_keywords = data["sacred_core_keywords"]
+                if "enable_chain_verification" in data:
+                    config.enable_chain_verification = data["enable_chain_verification"]
+                if "context_builder_token_budget" in data:
+                    config.context_builder_token_budget = data["context_builder_token_budget"]
+                if "context_builder_max_facts" in data:
+                    config.context_builder_max_facts = data["context_builder_max_facts"]
 
             except (json.JSONDecodeError, IOError) as e:
                 logger.warning(f"Could not load config from {config_path}: {e}. Using defaults.")
@@ -276,6 +309,18 @@ class MemoryConfig:
         if not (0.0 <= self.graph_proximity_weight <= 1.0):
             logger.warning(f"graph_proximity_weight={self.graph_proximity_weight} out of range [0,1], using default 0.15")
             self.graph_proximity_weight = 0.15
+        if self.cooling_threshold_days < 1:
+            logger.warning(f"cooling_threshold_days={self.cooling_threshold_days} below minimum, using 60")
+            self.cooling_threshold_days = 60
+        if self.archive_threshold_days < self.cooling_threshold_days:
+            logger.warning(f"archive_threshold_days must be >= cooling_threshold_days, using {self.cooling_threshold_days * 3}")
+            self.archive_threshold_days = self.cooling_threshold_days * 3
+        if self.context_builder_token_budget < 500:
+            logger.warning(f"context_builder_token_budget={self.context_builder_token_budget} too small, using 2000")
+            self.context_builder_token_budget = 2000
+        if self.context_builder_max_facts < 5:
+            logger.warning(f"context_builder_max_facts={self.context_builder_max_facts} too small, using 10")
+            self.context_builder_max_facts = 10
 
     def save(self) -> None:
         """Save current configuration to ~/.claudia/config.json"""
@@ -319,6 +364,12 @@ class MemoryConfig:
             "graph_proximity_weight": self.graph_proximity_weight,
             "backup_daily_retention": self.backup_daily_retention,
             "backup_weekly_retention": self.backup_weekly_retention,
+            "cooling_threshold_days": self.cooling_threshold_days,
+            "archive_threshold_days": self.archive_threshold_days,
+            "enable_auto_sacred": self.enable_auto_sacred,
+            "enable_chain_verification": self.enable_chain_verification,
+            "context_builder_token_budget": self.context_builder_token_budget,
+            "context_builder_max_facts": self.context_builder_max_facts,
         }
 
         with open(config_path, "w") as f:

--- a/memory-daemon/claudia_memory/database.py
+++ b/memory-daemon/claudia_memory/database.py
@@ -940,6 +940,82 @@ class Database:
             conn.commit()
             logger.info("Applied migration 19: entity_summaries for graph-aware retrieval")
 
+        if current_version < 20:
+            # Migration 20: Lifecycle tiers, sacred memories, close-circle entities,
+            # fact_id for human-friendly reference, SHA-256 chain hashing
+            migration_stmts = [
+                # Memories: lifecycle tier + sacred + archive + fact_id + chain
+                "ALTER TABLE memories ADD COLUMN lifecycle_tier TEXT DEFAULT 'active'",
+                "ALTER TABLE memories ADD COLUMN sacred_reason TEXT",
+                "ALTER TABLE memories ADD COLUMN archived_at TEXT",
+                "ALTER TABLE memories ADD COLUMN fact_id TEXT UNIQUE",
+                "ALTER TABLE memories ADD COLUMN hash TEXT",
+                "ALTER TABLE memories ADD COLUMN prev_hash TEXT",
+                # Entities: close-circle
+                "ALTER TABLE entities ADD COLUMN close_circle BOOLEAN DEFAULT FALSE",
+                "ALTER TABLE entities ADD COLUMN close_circle_reason TEXT",
+                # Relationships: lifecycle tier
+                "ALTER TABLE relationships ADD COLUMN lifecycle_tier TEXT DEFAULT 'active'",
+            ]
+            for stmt in migration_stmts:
+                try:
+                    conn.execute(stmt)
+                except sqlite3.OperationalError as e:
+                    err_str = str(e).lower()
+                    if "duplicate column" not in err_str and "already exists" not in err_str:
+                        logger.warning(f"Migration 20 statement failed: {e}")
+
+            # Indexes
+            try:
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_memories_lifecycle ON memories(lifecycle_tier)"
+                )
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_memories_fact_id ON memories(fact_id)"
+                )
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_entities_close_circle ON entities(close_circle) WHERE close_circle = 1"
+                )
+            except sqlite3.OperationalError as e:
+                logger.warning(f"Migration 20 index failed: {e}")
+
+            # Backfill: generate fact_id for existing memories that lack one
+            import uuid as _uuid_mod
+            try:
+                rows = conn.execute(
+                    "SELECT id FROM memories WHERE fact_id IS NULL"
+                ).fetchall()
+                for i, row in enumerate(rows):
+                    conn.execute(
+                        "UPDATE memories SET fact_id = ? WHERE id = ?",
+                        (str(_uuid_mod.uuid4()), row[0]),
+                    )
+                    if i > 0 and i % 1000 == 0:
+                        conn.commit()
+                if rows:
+                    logger.info(f"Migration 20: generated fact_id for {len(rows)} existing memories")
+            except sqlite3.OperationalError as e:
+                logger.warning(f"Migration 20 fact_id backfill failed: {e}")
+
+            # Initialize chain_head and view_as_of in _meta
+            try:
+                conn.execute(
+                    """INSERT OR IGNORE INTO _meta (key, value, updated_at)
+                       VALUES ('chain_head', NULL, datetime('now'))"""
+                )
+                conn.execute(
+                    """INSERT OR IGNORE INTO _meta (key, value, updated_at)
+                       VALUES ('view_as_of', NULL, datetime('now'))"""
+                )
+            except sqlite3.OperationalError as e:
+                logger.warning(f"Migration 20 _meta init failed: {e}")
+
+            conn.execute(
+                "INSERT OR IGNORE INTO schema_migrations (version, description) VALUES (20, 'Add lifecycle tiers, sacred memories, close-circle entities, fact_id, SHA-256 chain')"
+            )
+            conn.commit()
+            logger.info("Applied migration 20: lifecycle tiers, sacred, close-circle, fact_id, chain")
+
         # FTS5 setup: ensure memories_fts exists regardless of migration path.
         # The FTS5 virtual table + triggers contain internal semicolons that the
         # schema.sql line-based parser can't handle, so we always check here.
@@ -1092,6 +1168,15 @@ class Database:
         if "entity_summaries" not in tables:
             logger.warning("Migration 19 incomplete: entity_summaries table missing")
             return 18
+
+        # Migration 20 added lifecycle_tier, fact_id to memories; close_circle to entities
+        if "lifecycle_tier" not in memory_cols or "fact_id" not in memory_cols:
+            logger.warning("Migration 20 incomplete: memories missing lifecycle/fact_id columns")
+            return 19
+
+        if "close_circle" not in entity_cols:
+            logger.warning("Migration 20 incomplete: entities missing close_circle column")
+            return 19
 
         return None  # All good
 

--- a/memory-daemon/claudia_memory/mcp/server.py
+++ b/memory-daemon/claudia_memory/mcp/server.py
@@ -705,6 +705,32 @@ async def _handle_provenance(arguments, db, config, logger, **ctx):
                 "history": history, "count": len(history),
             }))]
         )
+    elif op == "verify_chain":
+        from ..services.remember import _compute_chain_hash
+        rows = db.execute(
+            "SELECT id, content, metadata, hash, prev_hash FROM memories ORDER BY id ASC",
+            fetch=True,
+        ) or []
+        chain_length = 0
+        is_valid = True
+        first_break_at = None
+        for row in rows:
+            if row["hash"] is None:
+                continue
+            chain_length += 1
+            meta = json.loads(row["metadata"]) if row["metadata"] else None
+            expected = _compute_chain_hash(row["content"], meta, row["prev_hash"])
+            if expected != row["hash"]:
+                is_valid = False
+                if first_break_at is None:
+                    first_break_at = row["id"]
+        return CallToolResult(
+            content=[TextContent(type="text", text=json.dumps({
+                "chain_length": chain_length,
+                "is_valid": is_valid,
+                "first_break_at": first_break_at,
+            }))]
+        )
     else:
         return CallToolResult(
             content=[TextContent(type="text", text=json.dumps({"error": f"Unknown provenance operation: {op}"}))],
@@ -723,6 +749,8 @@ async def _handle_remember(arguments, db, config, logger, **ctx):
         source=arguments.get("source"),
         source_context=arguments.get("source_context"),
         source_channel=arguments.get("source_channel"),
+        critical=arguments.get("critical", False),
+        fact_id=arguments.get("fact_id"),
     )
     # Save source material to disk if provided
     if memory_id and arguments.get("source_material"):
@@ -796,6 +824,7 @@ async def _handle_recall(arguments, db, config, logger, **ctx):
         limit=arguments.get("limit", 10),
         memory_types=arguments.get("types"),
         about_entity=arguments.get("about"),
+        include_archived=arguments.get("include_archived", False),
     )
 
     compact = arguments.get("compact", False)
@@ -1365,6 +1394,199 @@ async def _handle_project_health(arguments, db, config, logger, **ctx):
     )
 
 
+@_handler("memory.lifecycle")
+async def _handle_lifecycle(arguments, db, config, logger, **ctx):
+    op = _require(arguments, "operation", "memory.lifecycle")
+
+    if op == "set":
+        fact_id = _require(arguments, "fact_id", "memory.lifecycle")
+        tier = _require(arguments, "tier", "memory.lifecycle")
+        reason = arguments.get("reason", "manual")
+        if tier == "sacred":
+            db.execute(
+                "UPDATE memories SET lifecycle_tier = 'sacred', sacred_reason = ?, updated_at = datetime('now') WHERE fact_id = ?",
+                (reason, fact_id),
+            )
+        elif tier == "archived":
+            db.execute(
+                "UPDATE memories SET lifecycle_tier = 'archived', archived_at = datetime('now'), updated_at = datetime('now') WHERE fact_id = ?",
+                (fact_id,),
+            )
+        else:
+            db.execute(
+                "UPDATE memories SET lifecycle_tier = ?, updated_at = datetime('now') WHERE fact_id = ?",
+                (tier, fact_id),
+            )
+        return CallToolResult(
+            content=[TextContent(type="text", text=json.dumps({"success": True, "fact_id": fact_id, "tier": tier}))]
+        )
+
+    elif op == "protect":
+        entity_name = _require(arguments, "entity", "memory.lifecycle")
+        reason = arguments.get("reason", "user-designated")
+        canonical = entity_name.strip().lower()
+        row = db.execute(
+            "SELECT id FROM entities WHERE canonical_name = ? AND deleted_at IS NULL",
+            (canonical,),
+            fetch=True,
+        )
+        if not row:
+            return CallToolResult(
+                content=[TextContent(type="text", text=json.dumps({"error": f"Entity not found: {entity_name}"}))],
+                isError=True,
+            )
+        result = set_close_circle(row[0]["id"], reason=reason)
+        return CallToolResult(
+            content=[TextContent(type="text", text=json.dumps(result))]
+        )
+
+    elif op == "archive":
+        fact_id = _require(arguments, "fact_id", "memory.lifecycle")
+        db.execute(
+            "UPDATE memories SET lifecycle_tier = 'archived', archived_at = datetime('now'), updated_at = datetime('now') WHERE fact_id = ?",
+            (fact_id,),
+        )
+        return CallToolResult(
+            content=[TextContent(type="text", text=json.dumps({"success": True, "fact_id": fact_id, "tier": "archived"}))]
+        )
+
+    elif op == "restore":
+        fact_id = _require(arguments, "fact_id", "memory.lifecycle")
+        db.execute(
+            "UPDATE memories SET lifecycle_tier = 'active', archived_at = NULL, updated_at = datetime('now') WHERE fact_id = ?",
+            (fact_id,),
+        )
+        return CallToolResult(
+            content=[TextContent(type="text", text=json.dumps({"success": True, "fact_id": fact_id, "tier": "active"}))]
+        )
+
+    elif op == "status":
+        stats = {}
+        for tier in ("sacred", "active", "cooling", "archived"):
+            row = db.execute(
+                "SELECT COUNT(*) as cnt FROM memories WHERE lifecycle_tier = ? AND invalidated_at IS NULL",
+                (tier,),
+                fetch=True,
+            )
+            stats[tier] = row[0]["cnt"] if row else 0
+        null_row = db.execute(
+            "SELECT COUNT(*) as cnt FROM memories WHERE lifecycle_tier IS NULL AND invalidated_at IS NULL",
+            fetch=True,
+        )
+        stats["legacy_active"] = null_row[0]["cnt"] if null_row else 0
+        cc_row = db.execute(
+            "SELECT COUNT(*) as cnt FROM entities WHERE close_circle = 1 AND deleted_at IS NULL",
+            fetch=True,
+        )
+        stats["close_circle_entities"] = cc_row[0]["cnt"] if cc_row else 0
+        return CallToolResult(
+            content=[TextContent(type="text", text=json.dumps(stats, indent=2))]
+        )
+
+    else:
+        return CallToolResult(
+            content=[TextContent(type="text", text=json.dumps({"error": f"Unknown lifecycle operation: {op}"}))],
+            isError=True,
+        )
+
+
+@_handler("memory.context")
+async def _handle_context(arguments, db, config, logger, **ctx):
+    from ..services.context_builder import build_context
+    _coerce_int(arguments, "token_budget")
+    result = build_context(
+        query=_require(arguments, "query", "memory.context"),
+        token_budget=arguments.get("token_budget", 8000),
+        include_sacred=arguments.get("include_sacred", True),
+        entity=arguments.get("entity"),
+    )
+    return CallToolResult(
+        content=[TextContent(type="text", text=json.dumps(result, default=str))]
+    )
+
+
+@_handler("memory.checkpoint")
+async def _handle_checkpoint(arguments, db, config, logger, **ctx):
+    op = _require(arguments, "operation", "memory.checkpoint")
+
+    if op == "save":
+        name = arguments.get("name", "manual")
+        backup_path = db.backup(label=name)
+        return CallToolResult(
+            content=[TextContent(type="text", text=json.dumps({"success": True, "path": str(backup_path), "label": name}))]
+        )
+
+    elif op == "list":
+        import glob as glob_mod
+        from pathlib import Path
+        pattern = f"{db.db_path}.backup-*.db"
+        backups = sorted(glob_mod.glob(pattern), key=lambda p: Path(p).stat().st_mtime, reverse=True)
+        items = []
+        for b in backups[:20]:
+            p = Path(b)
+            items.append({
+                "path": str(p),
+                "name": p.name,
+                "size_mb": round(p.stat().st_size / 1024 / 1024, 2),
+                "modified": datetime.fromtimestamp(p.stat().st_mtime).isoformat(),
+            })
+        return CallToolResult(
+            content=[TextContent(type="text", text=json.dumps(items, indent=2))]
+        )
+
+    elif op == "load":
+        name = arguments.get("name", "")
+        return CallToolResult(
+            content=[TextContent(type="text", text=json.dumps({
+                "warning": "Checkpoint restore requires daemon restart.",
+                "instruction": "Stop daemon, copy backup over DB, restart.",
+                "backup_pattern": f"{db.db_path}.backup-{name}-*.db",
+            }))]
+        )
+
+    else:
+        return CallToolResult(
+            content=[TextContent(type="text", text=json.dumps({"error": f"Unknown checkpoint operation: {op}"}))],
+            isError=True,
+        )
+
+
+@_handler("memory.rollback")
+async def _handle_rollback(arguments, db, config, logger, **ctx):
+    op = _require(arguments, "operation", "memory.rollback")
+
+    if op == "set":
+        ts = _require(arguments, "timestamp", "memory.rollback")
+        db.execute(
+            "INSERT INTO _meta (key, value, updated_at) VALUES ('view_as_of', ?, datetime('now')) ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = datetime('now')",
+            (ts,),
+        )
+        return CallToolResult(
+            content=[TextContent(type="text", text=json.dumps({"success": True, "view_as_of": ts}))]
+        )
+
+    elif op == "clear":
+        db.execute(
+            "INSERT INTO _meta (key, value, updated_at) VALUES ('view_as_of', NULL, datetime('now')) ON CONFLICT(key) DO UPDATE SET value = NULL, updated_at = datetime('now')",
+        )
+        return CallToolResult(
+            content=[TextContent(type="text", text=json.dumps({"success": True, "view_as_of": None}))]
+        )
+
+    elif op == "status":
+        row = db.execute("SELECT value FROM _meta WHERE key = 'view_as_of'", fetch=True)
+        val = row[0]["value"] if row and row[0]["value"] else None
+        return CallToolResult(
+            content=[TextContent(type="text", text=json.dumps({"view_as_of": val, "mode": "historical" if val else "current"}))]
+        )
+
+    else:
+        return CallToolResult(
+            content=[TextContent(type="text", text=json.dumps({"error": f"Unknown rollback operation: {op}"}))],
+            isError=True,
+        )
+
+
 # Initialize the MCP server
 server = Server("claudia-memory")
 
@@ -1417,6 +1639,14 @@ async def list_tools() -> ListToolsResult:
                         "type": "string",
                         "description": "Origin channel: claude_code, telegram, slack",
                     },
+                    "critical": {
+                        "type": "boolean",
+                        "description": "Mark this memory as sacred (never decays, always included in context). Use for critical personal facts.",
+                    },
+                    "fact_id": {
+                        "type": "string",
+                        "description": "Explicit UUID for this memory. Auto-generated if not provided.",
+                    },
                 },
                 "required": ["content"],
             },
@@ -1460,6 +1690,10 @@ async def list_tools() -> ListToolsResult:
                         "type": ["array", "string"],
                         "items": {"type": "integer"},
                         "description": "Fetch specific memories by ID (skips search). Use after a compact search to get full content.",
+                    },
+                    "include_archived": {
+                        "type": "boolean",
+                        "description": "Include archived memories in results (default: false)",
                     },
                 },
             },
@@ -2398,9 +2632,10 @@ async def list_tools() -> ListToolsResult:
             name="memory.provenance",
             title="Provenance & Audit",
             description=(
-                "Trace memory origins or get full audit trails. "
+                "Trace memory origins, get full audit trails, or verify hash chain integrity. "
                 "Use operation='trace' to reconstruct a memory's full provenance chain, "
-                "'audit' to get the audit history for an entity or memory."
+                "'audit' to get the audit history for an entity or memory, "
+                "'verify_chain' to check SHA-256 hash chain integrity across all memories."
             ),
             annotations=ToolAnnotations(readOnlyHint=True),
             inputSchema={
@@ -2408,7 +2643,7 @@ async def list_tools() -> ListToolsResult:
                 "properties": {
                     "operation": {
                         "type": "string",
-                        "enum": ["trace", "audit"],
+                        "enum": ["trace", "audit", "verify_chain"],
                         "description": "Which provenance operation to perform",
                     },
                     "memory_id": {
@@ -2423,6 +2658,110 @@ async def list_tools() -> ListToolsResult:
                         "type": ["integer", "string"],
                         "description": "Maximum audit entries (default 20)",
                         "default": 20,
+                    },
+                },
+                "required": ["operation"],
+            },
+        ),
+        # ── Lifecycle / Sacred memory tools ──
+        Tool(
+            name="memory.lifecycle",
+            title="Memory Lifecycle",
+            description="Manage memory lifecycle tiers (sacred/active/cooling/archived) and entity close-circle status.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "operation": {
+                        "type": "string",
+                        "enum": ["set", "protect", "archive", "restore", "status"],
+                        "description": (
+                            "set: change tier by fact_id. protect: mark entity close-circle. "
+                            "archive/restore: archive or restore memory. status: show lifecycle stats."
+                        ),
+                    },
+                    "fact_id": {
+                        "type": "string",
+                        "description": "Memory fact_id UUID. Required for set/archive/restore.",
+                    },
+                    "entity": {
+                        "type": "string",
+                        "description": "Entity name. Required for protect.",
+                    },
+                    "tier": {
+                        "type": "string",
+                        "enum": ["sacred", "active", "cooling", "archived"],
+                        "description": "Target tier. Required for set.",
+                    },
+                    "reason": {
+                        "type": "string",
+                        "description": "Reason for the operation.",
+                    },
+                },
+                "required": ["operation"],
+            },
+        ),
+        Tool(
+            name="memory.context",
+            title="Build Context Window",
+            description="Build a token-budgeted context window with sacred facts always included. Uses the Context Relevance Engine (CRE).",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "What context to build for",
+                    },
+                    "token_budget": {
+                        "type": ["integer", "string"],
+                        "description": "Maximum tokens (default: 8000)",
+                    },
+                    "include_sacred": {
+                        "type": "boolean",
+                        "description": "Include sacred facts (default: true)",
+                    },
+                    "entity": {
+                        "type": "string",
+                        "description": "Scope sacred facts to this entity",
+                    },
+                },
+                "required": ["query"],
+            },
+        ),
+        Tool(
+            name="memory.checkpoint",
+            title="Database Checkpoints",
+            description="Save, list, or restore database checkpoints (labeled backups).",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "operation": {
+                        "type": "string",
+                        "enum": ["save", "list", "load"],
+                        "description": "save: create checkpoint. list: show available. load: returns restore instructions.",
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Checkpoint name/label. Required for save/load.",
+                    },
+                },
+                "required": ["operation"],
+            },
+        ),
+        Tool(
+            name="memory.rollback",
+            title="Temporal Rollback",
+            description="Set a temporal view filter so recall only returns memories created before a given timestamp. Non-destructive.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "operation": {
+                        "type": "string",
+                        "enum": ["set", "clear", "status"],
+                        "description": "set: set view_as_of timestamp. clear: reset to current. status: show current.",
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "description": "ISO timestamp for view_as_of. Required for set.",
                     },
                 },
                 "required": ["operation"],

--- a/memory-daemon/claudia_memory/schema.sql
+++ b/memory-daemon/claudia_memory/schema.sql
@@ -25,6 +25,8 @@ CREATE TABLE IF NOT EXISTS entities (
     contact_frequency_days REAL,  -- Average days between contacts (rolling)
     contact_trend TEXT,  -- accelerating, stable, decelerating, dormant
     attention_tier TEXT DEFAULT 'standard',  -- active, watchlist, standard, archive
+    close_circle BOOLEAN DEFAULT FALSE,  -- Inner circle: never decay, auto-sacred
+    close_circle_reason TEXT,  -- Why this entity is close-circle
     UNIQUE(canonical_name, type)
 );
 
@@ -34,6 +36,7 @@ CREATE INDEX IF NOT EXISTS idx_entities_importance ON entities(importance DESC);
 CREATE INDEX IF NOT EXISTS idx_entities_last_contact ON entities(last_contact_at);
 CREATE INDEX IF NOT EXISTS idx_entities_trend ON entities(contact_trend);
 CREATE INDEX IF NOT EXISTS idx_entities_attention_tier ON entities(attention_tier);
+CREATE INDEX IF NOT EXISTS idx_entities_close_circle ON entities(close_circle) WHERE close_circle = 1;
 
 -- Entity aliases for matching variations (e.g., "Sarah", "Sarah Chen", "S. Chen")
 CREATE TABLE IF NOT EXISTS entity_aliases (
@@ -70,7 +73,13 @@ CREATE TABLE IF NOT EXISTS memories (
     metadata TEXT,  -- JSON blob for flexible attributes
     source_channel TEXT DEFAULT 'claude_code',  -- Origin channel: claude_code, telegram, slack
     deadline_at TEXT,  -- ISO datetime for commitment deadlines (Phase 2: temporal intelligence)
-    temporal_markers TEXT  -- JSON: extracted temporal references from content
+    temporal_markers TEXT,  -- JSON: extracted temporal references from content
+    lifecycle_tier TEXT DEFAULT 'active',  -- sacred/active/cooling/archived
+    sacred_reason TEXT,  -- Why this memory is sacred (user-protected, auto-detected)
+    archived_at TEXT,  -- When this memory was archived
+    fact_id TEXT UNIQUE,  -- UUID for human-friendly reference
+    hash TEXT,  -- SHA-256 chain hash
+    prev_hash TEXT  -- Previous hash in chain (NULL for genesis)
 );
 
 CREATE INDEX IF NOT EXISTS idx_memories_type ON memories(type);
@@ -79,6 +88,8 @@ CREATE INDEX IF NOT EXISTS idx_memories_created ON memories(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_memories_hash ON memories(content_hash);
 CREATE INDEX IF NOT EXISTS idx_memories_deadline ON memories(deadline_at);
 CREATE INDEX IF NOT EXISTS idx_memories_verification ON memories(verification_status);
+CREATE INDEX IF NOT EXISTS idx_memories_lifecycle ON memories(lifecycle_tier);
+CREATE INDEX IF NOT EXISTS idx_memories_fact_id ON memories(fact_id);
 
 -- Junction table linking memories to entities
 CREATE TABLE IF NOT EXISTS memory_entities (
@@ -107,6 +118,7 @@ CREATE TABLE IF NOT EXISTS relationships (
     created_at TEXT DEFAULT (datetime('now')),
     updated_at TEXT DEFAULT (datetime('now')),
     metadata TEXT,
+    lifecycle_tier TEXT DEFAULT 'active',  -- Mirrors memory lifecycle for consistency
     UNIQUE(source_entity_id, target_entity_id, relationship_type)
 );
 
@@ -460,3 +472,6 @@ CREATE INDEX IF NOT EXISTS idx_agent_dispatches_started ON agent_dispatches(star
 -- NOTE: dispatch_tier validation trigger is created by database.py migration code
 -- rather than here, because CREATE TRIGGER statements contain internal semicolons
 -- that the schema.sql line-based parser cannot handle.
+
+INSERT OR IGNORE INTO schema_migrations (version, description)
+VALUES (20, 'Add lifecycle tiers, sacred memories, close-circle entities, fact_id, SHA-256 chain');

--- a/memory-daemon/claudia_memory/services/consolidate.py
+++ b/memory-daemon/claudia_memory/services/consolidate.py
@@ -149,6 +149,7 @@ class ConsolidateService:
                 updated_at = ?
             WHERE importance > 0.7
               AND importance > ?
+              AND (lifecycle_tier IS NULL OR lifecycle_tier != 'sacred')
             """,
             (floor, slow_decay_rate, datetime.utcnow().isoformat(), floor),
         )
@@ -163,6 +164,7 @@ class ConsolidateService:
                 updated_at = ?
             WHERE importance <= 0.7
               AND importance > ?
+              AND (lifecycle_tier IS NULL OR lifecycle_tier != 'sacred')
             """,
             (floor, decay_rate, datetime.utcnow().isoformat(), floor),
         )
@@ -171,7 +173,7 @@ class ConsolidateService:
 
         memories_decayed = tier1_count + tier2_count
 
-        # Entities: same tiered approach
+        # Entities: same tiered approach (close-circle entities are protected from decay)
         self.db.execute(
             """
             UPDATE entities
@@ -179,6 +181,7 @@ class ConsolidateService:
                 updated_at = ?
             WHERE importance > 0.7
               AND importance > ?
+              AND (close_circle IS NULL OR close_circle = 0)
             """,
             (floor, slow_decay_rate, datetime.utcnow().isoformat(), floor),
         )
@@ -189,6 +192,7 @@ class ConsolidateService:
                 updated_at = ?
             WHERE importance <= 0.7
               AND importance > ?
+              AND (close_circle IS NULL OR close_circle = 0)
             """,
             (floor, decay_rate, datetime.utcnow().isoformat(), floor),
         )
@@ -201,6 +205,7 @@ class ConsolidateService:
                 updated_at = ?
             WHERE strength > 0.7
               AND strength > 0.01
+              AND (lifecycle_tier IS NULL OR lifecycle_tier != 'sacred')
             """,
             (slow_decay_rate, datetime.utcnow().isoformat()),
         )
@@ -211,6 +216,7 @@ class ConsolidateService:
                 updated_at = ?
             WHERE strength <= 0.7
               AND strength > 0.01
+              AND (lifecycle_tier IS NULL OR lifecycle_tier != 'sacred')
             """,
             (decay_rate, datetime.utcnow().isoformat()),
         )
@@ -2544,6 +2550,158 @@ class ConsolidateService:
             logger.info(f"Found {len(candidates)} potential entity duplicates")
         return candidates
 
+    def run_lifecycle_transitions(self) -> dict:
+        """Apply lifecycle tier transitions based on access patterns.
+
+        Cooling: memory not accessed for cooling_threshold_days AND not sacred
+        Archive: in cooling for archive_threshold_days AND importance < 0.3
+        """
+        config = self.config
+        now = datetime.utcnow()
+
+        cooling_cutoff = (now - timedelta(days=config.cooling_threshold_days)).isoformat()
+        archive_cutoff = (now - timedelta(days=config.archive_threshold_days)).isoformat()
+
+        # Active -> Cooling: not accessed recently, not sacred
+        cooled = 0
+        try:
+            cursor = self.db.execute(
+                """
+                UPDATE memories
+                SET lifecycle_tier = 'cooling', updated_at = datetime('now')
+                WHERE (lifecycle_tier = 'active' OR lifecycle_tier IS NULL)
+                  AND invalidated_at IS NULL
+                  AND (lifecycle_tier IS NULL OR lifecycle_tier != 'sacred')
+                  AND (last_accessed_at IS NULL OR last_accessed_at < ?)
+                  AND created_at < ?
+                """,
+                (cooling_cutoff, cooling_cutoff),
+            )
+            cooled = cursor.rowcount if hasattr(cursor, 'rowcount') and cursor.rowcount >= 0 else 0
+        except Exception as e:
+            logger.debug(f"Cooling transition error: {e}")
+
+        # Cooling -> Archived: been cooling long enough AND low importance
+        archived = 0
+        try:
+            cursor = self.db.execute(
+                """
+                UPDATE memories
+                SET lifecycle_tier = 'archived',
+                    archived_at = datetime('now'),
+                    updated_at = datetime('now')
+                WHERE lifecycle_tier = 'cooling'
+                  AND invalidated_at IS NULL
+                  AND importance < 0.3
+                  AND (last_accessed_at IS NULL OR last_accessed_at < ?)
+                  AND created_at < ?
+                """,
+                (archive_cutoff, archive_cutoff),
+            )
+            archived = cursor.rowcount if hasattr(cursor, 'rowcount') and cursor.rowcount >= 0 else 0
+        except Exception as e:
+            logger.debug(f"Archive transition error: {e}")
+
+        if cooled > 0 or archived > 0:
+            logger.info(f"Lifecycle transitions: {cooled} cooled, {archived} archived")
+
+        return {"cooled": cooled, "archived": archived}
+
+    def detect_auto_sacred(self) -> int:
+        """Auto-promote memories about close-circle entities that match sacred keywords."""
+        config = self.config
+        if not config.enable_auto_sacred:
+            return 0
+
+        promoted = 0
+        try:
+            close_entities = self.db.execute(
+                "SELECT id FROM entities WHERE close_circle = 1 AND deleted_at IS NULL",
+                fetch=True,
+            ) or []
+
+            for entity in close_entities:
+                entity_id = entity["id"]
+                for keyword in config.sacred_core_keywords:
+                    rows = self.db.execute(
+                        """
+                        SELECT m.id FROM memories m
+                        JOIN memory_entities me ON m.id = me.memory_id
+                        WHERE me.entity_id = ?
+                          AND m.invalidated_at IS NULL
+                          AND (m.lifecycle_tier IS NULL OR m.lifecycle_tier != 'sacred')
+                          AND LOWER(m.content) LIKE '%' || LOWER(?) || '%'
+                        """,
+                        (entity_id, keyword),
+                        fetch=True,
+                    ) or []
+                    for row in rows:
+                        self.db.execute(
+                            """UPDATE memories SET lifecycle_tier = 'sacred',
+                               sacred_reason = ?,
+                               updated_at = datetime('now')
+                               WHERE id = ? AND (lifecycle_tier IS NULL OR lifecycle_tier != 'sacred')""",
+                            (f"auto: close-circle keyword '{keyword}'", row["id"]),
+                        )
+                        promoted += 1
+        except Exception as e:
+            logger.debug(f"Auto-sacred detection error: {e}")
+
+        if promoted > 0:
+            logger.info(f"Auto-sacred: promoted {promoted} memories")
+        return promoted
+
+    def detect_close_circle_candidates(self) -> list:
+        """Detect entities that should be close-circle based on contact velocity."""
+        config = self.config
+        candidates = []
+        try:
+            # High contact velocity detection
+            rows = self.db.execute(
+                """
+                SELECT id, name, contact_frequency_days, contact_trend, description
+                FROM entities
+                WHERE type = 'person'
+                  AND deleted_at IS NULL
+                  AND (close_circle IS NULL OR close_circle = 0)
+                  AND contact_frequency_days IS NOT NULL
+                  AND contact_frequency_days < 7
+                  AND contact_trend IN ('accelerating', 'stable')
+                """,
+                fetch=True,
+            ) or []
+            for row in rows:
+                candidates.append({
+                    "entity_id": row["id"],
+                    "name": row["name"],
+                    "reason": f"high contact velocity ({row['contact_frequency_days']:.1f}d, {row['contact_trend']})",
+                })
+
+            # Keyword-based detection in entity descriptions
+            for keyword in config.close_circle_keywords:
+                desc_rows = self.db.execute(
+                    """
+                    SELECT id, name FROM entities
+                    WHERE type = 'person'
+                      AND deleted_at IS NULL
+                      AND (close_circle IS NULL OR close_circle = 0)
+                      AND LOWER(description) LIKE '%' || LOWER(?) || '%'
+                    """,
+                    (keyword,),
+                    fetch=True,
+                ) or []
+                for row in desc_rows:
+                    if not any(c["entity_id"] == row["id"] for c in candidates):
+                        candidates.append({
+                            "entity_id": row["id"],
+                            "name": row["name"],
+                            "reason": f"keyword match: '{keyword}' in description",
+                        })
+        except Exception as e:
+            logger.debug(f"Close-circle detection error: {e}")
+
+        return candidates
+
     def run_full_consolidation(self) -> Dict[str, Any]:
         """
         Run complete consolidation: decay, patterns, predictions.
@@ -2572,6 +2730,15 @@ class ConsolidateService:
             logger.warning(f"Decay phase failed: {e}")
             results["decay"] = {"error": str(e)}
             results["boosted"] = 0
+
+        # Phase 1b: Lifecycle transitions + auto-sacred
+        try:
+            results["lifecycle"] = self.run_lifecycle_transitions()
+            results["auto_sacred"] = self.detect_auto_sacred()
+            results["close_circle_candidates"] = len(self.detect_close_circle_candidates())
+        except Exception as e:
+            logger.warning(f"Lifecycle phase failed: {e}")
+            results["lifecycle"] = {"error": str(e)}
 
         # [4R: Reflect]
         # Phase 2: Merging (modifies memory content)

--- a/memory-daemon/claudia_memory/services/context_builder.py
+++ b/memory-daemon/claudia_memory/services/context_builder.py
@@ -1,0 +1,256 @@
+"""
+Context Builder (CRE) for Claudia Memory System
+
+Builds optimized context windows for LLM consumption with:
+- Sacred facts always included verbatim
+- Token-budgeted hybrid recall
+- Optional Ollama-powered compression
+- Graceful truncation fallback
+"""
+
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ContextResult:
+    """Result from context builder."""
+    sacred: List[Dict[str, Any]]
+    relevant: List[Dict[str, Any]]
+    total_tokens: int
+    sacred_count: int
+    relevant_count: int
+    truncated: bool = False
+    compressed: bool = False
+
+
+def _estimate_tokens(text: str) -> int:
+    """Estimate token count using word-based heuristic (words * 1.3)."""
+    if not text:
+        return 0
+    return int(len(text.split()) * 1.3)
+
+
+def _facts_to_text(facts: List[Dict]) -> str:
+    """Convert fact dicts to a readable text block."""
+    lines = []
+    for f in facts:
+        prefix = "[sacred] " if f.get("lifecycle_tier") == "sacred" else ""
+        entities = ", ".join(f.get("entities", [])[:3])
+        entity_str = f" (about: {entities})" if entities else ""
+        lines.append(f"- {prefix}{f['content']}{entity_str}")
+    return "\n".join(lines)
+
+
+def get_sacred_facts(entity_name: Optional[str] = None) -> List[Dict]:
+    """Retrieve all sacred facts, optionally filtered to a specific entity."""
+    from ..database import get_db
+    db = get_db()
+
+    if entity_name:
+        # Normalize entity name for matching
+        canonical = entity_name.strip().lower()
+        rows = db.execute(
+            """
+            SELECT m.id, m.content, m.type, m.importance, m.created_at,
+                   m.fact_id, m.lifecycle_tier, m.sacred_reason,
+                   GROUP_CONCAT(e.name) as entity_names
+            FROM memories m
+            LEFT JOIN memory_entities me ON m.id = me.memory_id
+            LEFT JOIN entities e ON me.entity_id = e.id
+            WHERE m.lifecycle_tier = 'sacred'
+              AND m.invalidated_at IS NULL
+              AND e.canonical_name = ?
+            GROUP BY m.id
+            ORDER BY m.importance DESC
+            """,
+            (canonical,),
+            fetch=True,
+        ) or []
+    else:
+        rows = db.execute(
+            """
+            SELECT m.id, m.content, m.type, m.importance, m.created_at,
+                   m.fact_id, m.lifecycle_tier, m.sacred_reason,
+                   GROUP_CONCAT(e.name) as entity_names
+            FROM memories m
+            LEFT JOIN memory_entities me ON m.id = me.memory_id
+            LEFT JOIN entities e ON me.entity_id = e.id
+            WHERE m.lifecycle_tier = 'sacred'
+              AND m.invalidated_at IS NULL
+            GROUP BY m.id
+            ORDER BY m.importance DESC
+            """,
+            fetch=True,
+        ) or []
+
+    return [
+        {
+            "id": row["id"],
+            "content": row["content"],
+            "type": row["type"],
+            "importance": row["importance"],
+            "created_at": row["created_at"],
+            "fact_id": row["fact_id"],
+            "lifecycle_tier": "sacred",
+            "sacred_reason": row["sacred_reason"],
+            "entities": [n.strip() for n in (row["entity_names"] or "").split(",") if n.strip()],
+        }
+        for row in rows
+    ]
+
+
+def _try_ollama_compress(facts: List[Dict], remaining_tokens: int, query: str) -> Optional[str]:
+    """Attempt to compress facts using Ollama LLM. Returns None if unavailable."""
+    try:
+        from ..config import get_config
+        config = get_config()
+        if not config.language_model:
+            return None
+
+        import httpx
+        facts_text = _facts_to_text(facts)
+        prompt = (
+            f"Compress the following facts into a concise summary that preserves all key information. "
+            f"Stay under {remaining_tokens} tokens. Prioritize: names, dates, numbers, relationships. "
+            f"Do NOT include any facts that are irrelevant to: {query}\n\n"
+            f"Facts:\n{facts_text}"
+        )
+
+        response = httpx.post(
+            f"{config.ollama_host}/api/generate",
+            json={
+                "model": config.language_model,
+                "prompt": prompt,
+                "stream": False,
+                "options": {"num_predict": remaining_tokens},
+            },
+            timeout=30.0,
+        )
+        if response.status_code == 200:
+            result = response.json().get("response", "")
+            if result.strip():
+                return result.strip()
+        return None
+    except Exception as e:
+        logger.debug(f"Ollama compression unavailable: {e}")
+        return None
+
+
+def truncate_to_budget(facts: List[Dict], token_budget: int) -> List[Dict]:
+    """Take top-scored facts until budget is exhausted."""
+    result = []
+    used = 0
+    for fact in facts:
+        tokens = _estimate_tokens(fact.get("content", ""))
+        if used + tokens > token_budget:
+            break
+        result.append(fact)
+        used += tokens
+    return result
+
+
+def build_context(
+    query: str,
+    token_budget: Optional[int] = None,
+    max_facts: Optional[int] = None,
+    include_sacred: bool = True,
+    entity: Optional[str] = None,
+) -> ContextResult:
+    """Build a token-budgeted context window.
+
+    Args:
+        query: Search query for relevant facts
+        token_budget: Maximum tokens (default from config)
+        max_facts: Maximum facts to include (default from config)
+        include_sacred: Whether to include sacred facts (always verbatim)
+        entity: Optional entity to scope sacred facts to
+
+    Returns:
+        ContextResult with sacred + relevant sections
+    """
+    from ..config import get_config
+    from .recall import recall
+
+    config = get_config()
+    if token_budget is None:
+        token_budget = config.context_builder_token_budget
+    if max_facts is None:
+        max_facts = config.context_builder_max_facts
+
+    # 1. Load sacred facts (always verbatim, never compressed)
+    sacred = []
+    sacred_tokens = 0
+    if include_sacred:
+        sacred = get_sacred_facts(entity_name=entity)
+        sacred_text = _facts_to_text(sacred)
+        sacred_tokens = _estimate_tokens(sacred_text)
+
+    # 2. Hybrid recall for relevant non-sacred facts
+    remaining_budget = max(0, token_budget - sacred_tokens)
+    try:
+        relevant_raw = recall(
+            query=query,
+            limit=max_facts,
+            include_low_importance=False,
+        )
+    except Exception as e:
+        logger.debug(f"Recall failed in context builder: {e}")
+        relevant_raw = []
+
+    # Filter out sacred facts from relevant (avoid duplicates)
+    sacred_ids = {f["id"] for f in sacred}
+    relevant_filtered = [
+        {
+            "id": r.id,
+            "content": r.content,
+            "type": r.type,
+            "importance": r.importance,
+            "score": r.score,
+            "created_at": r.created_at,
+            "entities": r.entities,
+            "fact_id": getattr(r, "fact_id", None),
+            "lifecycle_tier": getattr(r, "lifecycle_tier", None),
+        }
+        for r in relevant_raw
+        if r.id not in sacred_ids
+    ]
+
+    # 3. Compress or truncate
+    compressed = False
+    if remaining_budget > 0 and relevant_filtered:
+        compressed_text = _try_ollama_compress(relevant_filtered, remaining_budget, query)
+        if compressed_text:
+            relevant_final = [{
+                "content": compressed_text,
+                "type": "compressed_summary",
+                "id": 0,
+                "entities": [],
+                "importance": 0,
+                "score": 0,
+                "created_at": "",
+                "fact_id": None,
+                "lifecycle_tier": None,
+            }]
+            compressed = True
+        else:
+            # Graceful truncation: take top-scored facts until budget exhausted
+            relevant_final = truncate_to_budget(relevant_filtered, remaining_budget)
+    else:
+        relevant_final = []
+
+    total_tokens = sacred_tokens + _estimate_tokens(_facts_to_text(relevant_final))
+
+    return ContextResult(
+        sacred=sacred,
+        relevant=relevant_final,
+        total_tokens=total_tokens,
+        sacred_count=len(sacred),
+        relevant_count=len(relevant_final),
+        truncated=len(relevant_final) < len(relevant_filtered),
+        compressed=compressed,
+    )

--- a/memory-daemon/claudia_memory/services/recall.py
+++ b/memory-daemon/claudia_memory/services/recall.py
@@ -44,6 +44,9 @@ class RecallResult:
     origin_type: str = "inferred"  # user_stated, extracted, inferred, corrected
     # Channel tracking
     source_channel: Optional[str] = None  # Origin channel: claude_code, telegram, slack
+    # Lifecycle fields
+    lifecycle_tier: Optional[str] = None  # sacred/active/cooling/archived
+    fact_id: Optional[str] = None  # UUID for human-friendly reference
 
 
 @dataclass
@@ -98,6 +101,7 @@ class RecallService:
         include_low_importance: bool = False,
         date_after: Optional[datetime] = None,
         date_before: Optional[datetime] = None,
+        include_archived: bool = False,
     ) -> List[RecallResult]:
         """
         Search memories using hybrid vector + FTS5 similarity and filters.
@@ -111,6 +115,7 @@ class RecallService:
             include_low_importance: Include memories below default threshold
             date_after: Only memories after this date
             date_before: Only memories before this date
+            include_archived: Include archived memories (default False)
 
         Returns:
             List of RecallResult ordered by relevance
@@ -142,7 +147,7 @@ class RecallService:
             )
             params.append(json.dumps(query_embedding))
 
-            self._apply_filters(sql_parts, params, memory_types, min_importance, date_after, date_before, about_entity)
+            self._apply_filters(sql_parts, params, memory_types, min_importance, date_after, date_before, about_entity, include_archived)
             sql_parts.append("GROUP BY m.id ORDER BY vector_score DESC LIMIT ?")
             params.append(limit * 2)
 
@@ -285,9 +290,22 @@ class RecallService:
         date_after: Optional[datetime],
         date_before: Optional[datetime],
         about_entity: Optional[str] = None,
+        include_archived: bool = False,
     ) -> None:
         """Apply common filters to SQL query parts."""
         sql_parts.append("AND m.invalidated_at IS NULL")
+        if not include_archived:
+            # Exclude archived memories by default (lifecycle tier filtering)
+            # Pre-migration memories have lifecycle_tier IS NULL and are treated as active
+            sql_parts.append("AND (m.lifecycle_tier IS NULL OR m.lifecycle_tier != 'archived')")
+        # View-as-of temporal filter for rollback support
+        try:
+            view_row = self.db.execute("SELECT value FROM _meta WHERE key = 'view_as_of'", fetch=True)
+            if view_row and view_row[0]["value"]:
+                sql_parts.append("AND m.created_at <= ?")
+                params.append(view_row[0]["value"])
+        except Exception:
+            pass  # _meta table may not exist on very old schemas
         if memory_types:
             placeholders = ", ".join(["?" for _ in memory_types])
             sql_parts.append(f"AND m.type IN ({placeholders})")
@@ -323,6 +341,12 @@ class RecallService:
             + self.config.recency_weight * recency_score
         )
 
+        # Sacred memory boost: +50% importance weight component
+        row_keys_early = row.keys()
+        lifecycle_val = row["lifecycle_tier"] if "lifecycle_tier" in row_keys_early else None
+        if lifecycle_val == "sacred":
+            combined_score += self.config.importance_weight * 0.5
+
         # Parse entity names
         entity_names = []
         entity_names_val = row["entity_names"] if "entity_names" in row.keys() else None
@@ -346,6 +370,10 @@ class RecallService:
         # Channel tracking (may not exist in older DBs)
         source_channel_val = row["source_channel"] if "source_channel" in row_keys else None
 
+        # Lifecycle fields (may not exist in older DBs)
+        lifecycle_tier_val = row["lifecycle_tier"] if "lifecycle_tier" in row_keys else None
+        fact_id_val = row["fact_id"] if "fact_id" in row_keys else None
+
         return RecallResult(
             id=row["id"],
             content=row["content"],
@@ -362,6 +390,8 @@ class RecallService:
             verification_status=verification_status_val,
             origin_type=origin_type_val,
             source_channel=source_channel_val,
+            lifecycle_tier=lifecycle_tier_val,
+            fact_id=fact_id_val,
         )
 
     def _rrf_score(
@@ -678,6 +708,7 @@ class RecallService:
                 JOIN memories m ON m.id = fts.rowid
                 WHERE memories_fts MATCH ?
                 AND m.invalidated_at IS NULL
+                AND (m.lifecycle_tier IS NULL OR m.lifecycle_tier != 'archived')
             """
             params: list = [query]
 
@@ -827,6 +858,8 @@ class RecallService:
                     source=row["source"] if "source" in row_keys else None,
                     source_id=row["source_id"] if "source_id" in row_keys else None,
                     source_context=row["source_context"] if "source_context" in row_keys else None,
+                    lifecycle_tier=row["lifecycle_tier"] if "lifecycle_tier" in row_keys else None,
+                    fact_id=row["fact_id"] if "fact_id" in row_keys else None,
                 )
             )
 
@@ -1259,6 +1292,7 @@ class RecallService:
             LEFT JOIN entities e ON me.entity_id = e.id
             WHERE m.created_at >= ?
             AND m.invalidated_at IS NULL
+            AND (m.lifecycle_tier IS NULL OR m.lifecycle_tier != 'archived')
         """
         params = [cutoff.isoformat()]
 
@@ -1292,6 +1326,8 @@ class RecallService:
                     source=row["source"] if "source" in row_keys else None,
                     source_id=row["source_id"] if "source_id" in row_keys else None,
                     source_context=row["source_context"] if "source_context" in row_keys else None,
+                    lifecycle_tier=row["lifecycle_tier"] if "lifecycle_tier" in row_keys else None,
+                    fact_id=row["fact_id"] if "fact_id" in row_keys else None,
                 )
             )
         return results
@@ -2366,6 +2402,7 @@ class RecallService:
                 LEFT JOIN entities e ON me.entity_id = e.id
                 WHERE memories_fts MATCH ?
                 AND m.invalidated_at IS NULL
+                AND (m.lifecycle_tier IS NULL OR m.lifecycle_tier != 'archived')
             """
             params: list = [query]
 
@@ -2395,6 +2432,7 @@ class RecallService:
             LEFT JOIN entities e ON me.entity_id = e.id
             WHERE m.content LIKE ?
             AND m.invalidated_at IS NULL
+            AND (m.lifecycle_tier IS NULL OR m.lifecycle_tier != 'archived')
         """
         params = [f"%{query}%"]
 
@@ -2426,7 +2464,7 @@ class RecallService:
         now = datetime.utcnow()
         future = now + timedelta(days=days_ahead)
 
-        conditions = ["m.deadline_at IS NOT NULL", "m.invalidated_at IS NULL"]
+        conditions = ["m.deadline_at IS NOT NULL", "m.invalidated_at IS NULL", "(m.lifecycle_tier IS NULL OR m.lifecycle_tier != 'archived')"]
         params: list = []
 
         if include_overdue:
@@ -2473,7 +2511,8 @@ class RecallService:
                 except (ValueError, TypeError):
                     pass
 
-            entity_str = row["entity_names"] if "entity_names" in row.keys() and row["entity_names"] else ""
+            row_keys = row.keys()
+            entity_str = row["entity_names"] if "entity_names" in row_keys and row["entity_names"] else ""
             results.append(RecallResult(
                 id=row["id"],
                 content=row["content"],
@@ -2483,6 +2522,8 @@ class RecallService:
                 created_at=row["created_at"],
                 entities=entity_str.split(",") if entity_str else [],
                 metadata={"urgency": urgency, "deadline_at": deadline_str},
+                lifecycle_tier=row["lifecycle_tier"] if "lifecycle_tier" in row_keys else None,
+                fact_id=row["fact_id"] if "fact_id" in row_keys else None,
             ))
 
         return results
@@ -2503,6 +2544,7 @@ class RecallService:
         conditions = [
             "(m.created_at >= ? OR m.updated_at >= ?)",
             "m.invalidated_at IS NULL",
+            "(m.lifecycle_tier IS NULL OR m.lifecycle_tier != 'archived')",
         ]
         params: list = [since, since]
 
@@ -2584,6 +2626,7 @@ class RecallService:
             LEFT JOIN entities e2 ON me2.entity_id = e2.id
             WHERE (e.canonical_name = ? OR e.name = ?)
               AND m.invalidated_at IS NULL
+              AND (m.lifecycle_tier IS NULL OR m.lifecycle_tier != 'archived')
             GROUP BY m.id
             ORDER BY COALESCE(m.deadline_at, m.created_at) ASC
             LIMIT ?
@@ -2748,6 +2791,8 @@ class RecallService:
             origin_type=row["origin_type"] if "origin_type" in row_keys else "inferred",
             confidence=row["confidence"] if "confidence" in row_keys else 1.0,
             source_channel=row["source_channel"] if "source_channel" in row_keys else None,
+            lifecycle_tier=row["lifecycle_tier"] if "lifecycle_tier" in row_keys else None,
+            fact_id=row["fact_id"] if "fact_id" in row_keys else None,
         )
 
 

--- a/memory-daemon/claudia_memory/services/remember.py
+++ b/memory-daemon/claudia_memory/services/remember.py
@@ -5,9 +5,11 @@ Handles storing memories, processing conversation turns,
 and auto-extracting entities and facts.
 """
 
+import hashlib as _hashlib
 import json
 import logging
 import uuid
+import uuid as _uuid
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -32,6 +34,12 @@ def _audit_log(operation: str, **kwargs) -> None:
         audit_log(operation, **kwargs)
     except Exception as e:
         logger.debug(f"Could not log audit entry: {e}")
+
+
+def _compute_chain_hash(content: str, metadata, prev_hash) -> str:
+    """Compute SHA-256 chain hash for memory integrity verification."""
+    payload = f"{content}|{json.dumps(metadata, sort_keys=True) if metadata else ''}|{prev_hash or ''}"
+    return _hashlib.sha256(payload.encode()).hexdigest()
 
 
 class RememberService:
@@ -142,6 +150,8 @@ class RememberService:
         metadata: Optional[Dict] = None,
         origin_type: Optional[str] = None,
         source_channel: Optional[str] = None,
+        critical: bool = False,
+        fact_id: Optional[str] = None,
         _precomputed_embedding: Optional[List[float]] = None,
     ) -> Optional[int]:
         """
@@ -159,6 +169,8 @@ class RememberService:
             metadata: Additional metadata
             origin_type: 'user_stated', 'extracted', 'inferred', 'corrected' (Trust North Star)
             source_channel: Origin channel: claude_code, telegram, slack
+            critical: If True, mark this memory as sacred (immune to decay)
+            fact_id: Optional UUID for the memory; auto-generated if not provided
 
         Returns:
             Memory ID or None if duplicate
@@ -180,6 +192,9 @@ class RememberService:
                 (existing["id"],),
             )
             return existing["id"]
+
+        if fact_id is None:
+            fact_id = str(_uuid.uuid4())
 
         # Run deterministic guards
         guard_result = validate_memory(content, memory_type, importance, metadata)
@@ -230,6 +245,7 @@ class RememberService:
             "updated_at": datetime.utcnow().isoformat(),
             "metadata": json.dumps(metadata) if metadata else None,
             "origin_type": origin_type,
+            "fact_id": fact_id,
         }
         if source_context:
             insert_data["source_context"] = source_context
@@ -240,7 +256,35 @@ class RememberService:
         if temporal_markers_json:
             insert_data["temporal_markers"] = temporal_markers_json
 
+        if critical:
+            insert_data["lifecycle_tier"] = "sacred"
+            insert_data["sacred_reason"] = "user-protected"
+
         memory_id = self.db.insert("memories", insert_data)
+
+        # SHA-256 chain linking for memory integrity verification
+        try:
+            from ..config import get_config as _get_config
+            config = _get_config()
+            if config.enable_chain_verification:
+                prev_hash_rows = self.db.execute(
+                    "SELECT value FROM _meta WHERE key = 'chain_head'",
+                    fetch=True,
+                )
+                prev_hash = prev_hash_rows[0]["value"] if prev_hash_rows and prev_hash_rows[0]["value"] else None
+                chain_hash = _compute_chain_hash(content, metadata, prev_hash)
+                self.db.execute(
+                    "UPDATE memories SET hash = ?, prev_hash = ? WHERE id = ?",
+                    (chain_hash, prev_hash, memory_id),
+                )
+                self.db.execute(
+                    """INSERT INTO _meta (key, value, updated_at)
+                       VALUES ('chain_head', ?, datetime('now'))
+                       ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at""",
+                    (chain_hash,),
+                )
+        except Exception as e:
+            logger.debug(f"Chain hash skipped: {e}")
 
         # Store embedding (use precomputed if available, otherwise generate)
         embedding = _precomputed_embedding or embed_sync(content)
@@ -1690,6 +1734,44 @@ class RememberService:
             insert_data["source"] = source
         return self.db.insert("episodes", insert_data)
 
+    def set_close_circle(self, entity_id: int, reason: str = "user-designated") -> dict:
+        """Mark an entity as close-circle and auto-promote core facts to sacred."""
+        from ..config import get_config
+        config = get_config()
+
+        self.db.execute(
+            "UPDATE entities SET close_circle = 1, close_circle_reason = ?, updated_at = datetime('now') WHERE id = ?",
+            (reason, entity_id),
+        )
+
+        promoted = 0
+        if config.enable_auto_sacred:
+            for keyword in config.sacred_core_keywords:
+                rows = self.db.execute(
+                    """
+                    SELECT m.id FROM memories m
+                    JOIN memory_entities me ON m.id = me.memory_id
+                    WHERE me.entity_id = ?
+                      AND m.invalidated_at IS NULL
+                      AND (m.lifecycle_tier IS NULL OR m.lifecycle_tier != 'sacred')
+                      AND LOWER(m.content) LIKE '%' || LOWER(?) || '%'
+                    """,
+                    (entity_id, keyword),
+                    fetch=True,
+                ) or []
+                for row in rows:
+                    self.db.execute(
+                        """UPDATE memories SET lifecycle_tier = 'sacred',
+                           sacred_reason = ?,
+                           updated_at = datetime('now')
+                           WHERE id = ? AND (lifecycle_tier IS NULL OR lifecycle_tier != 'sacred')""",
+                        (f"auto: close-circle keyword '{keyword}'", row["id"]),
+                    )
+                    promoted += 1
+
+        _audit_log("close_circle_set", details={"entity_id": entity_id, "reason": reason, "promoted": promoted}, entity_id=entity_id)
+        return {"entity_id": entity_id, "close_circle": True, "facts_promoted_to_sacred": promoted}
+
 
 # Global service instance
 _service: Optional[RememberService] = None
@@ -1779,3 +1861,8 @@ def invalidate_relationship(
 ) -> Optional[Dict[str, Any]]:
     """Invalidate a relationship without creating a replacement"""
     return get_remember_service().invalidate_relationship(source, target, relationship, reason)
+
+
+def set_close_circle(entity_id: int, **kwargs) -> dict:
+    """Mark entity as close-circle."""
+    return get_remember_service().set_close_circle(entity_id, **kwargs)

--- a/memory-daemon/claudia_memory/services/vault_sync.py
+++ b/memory-daemon/claudia_memory/services/vault_sync.py
@@ -378,6 +378,13 @@ class VaultSyncService:
         if attention_tier:
             lines.append(f"attention_tier: {attention_tier}")
 
+        close_circle = _row_get(entity, "close_circle")
+        if close_circle:
+            lines.append("close_circle: true")
+            close_reason = _row_get(entity, "close_circle_reason")
+            if close_reason:
+                lines.append(f'close_circle_reason: "{close_reason}"')
+
         contact_trend = _row_get(entity, "contact_trend")
         if contact_trend:
             lines.append(f"contact_trend: {contact_trend}")
@@ -406,6 +413,8 @@ class VaultSyncService:
             tags.append(attention_tier)
         if contact_trend:
             tags.append(contact_trend)
+        if close_circle:
+            tags.append("close-circle")
         lines.append(f"tags:")
         for tag in tags:
             lines.append(f"  - {tag}")
@@ -565,13 +574,16 @@ class VaultSyncService:
                 origin = m["origin_type"] if "origin_type" in row_keys and m["origin_type"] else ""
                 confidence = m["confidence"] if "confidence" in row_keys else 1.0
 
+                lifecycle = _row_get(m, "lifecycle_tier") if hasattr(m, 'keys') else None
+                prefix = "[sacred] " if lifecycle == "sacred" else ""
+
                 detail_parts = []
                 if origin:
                     detail_parts.append(f"source: {origin}")
                 if confidence is not None and confidence < 1.0:
                     detail_parts.append(f"confidence: {confidence}")
                 detail = f" ({', '.join(detail_parts)})" if detail_parts else ""
-                entry = f"- {m['content']}{detail}"
+                entry = f"- {prefix}{m['content']}{detail}"
 
                 if vstatus == "verified" or origin == "user_stated":
                     verified.append(entry)

--- a/memory-daemon/tests/test_lifecycle.py
+++ b/memory-daemon/tests/test_lifecycle.py
@@ -1,0 +1,773 @@
+"""Tests for Sacred Memory, Lifecycle Tiers, CRE, and SHA-256 Chain features (Migration 20)."""
+
+import hashlib
+import json
+import tempfile
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from claudia_memory.database import Database, content_hash
+
+
+# ── Helpers ──────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def db():
+    """Create a temporary test database with full schema + migrations."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.db"
+        database = Database(db_path)
+        database.initialize()
+        yield database
+        database.close()
+
+
+def _insert_memory(db, content, memory_type="fact", importance=0.8,
+                   lifecycle_tier=None, sacred_reason=None, fact_id=None,
+                   created_at=None, last_accessed_at=None):
+    """Insert a memory with optional lifecycle fields."""
+    data = {
+        "content": content,
+        "content_hash": content_hash(content),
+        "type": memory_type,
+        "importance": importance,
+        "created_at": created_at or datetime.utcnow().isoformat(),
+        "updated_at": datetime.utcnow().isoformat(),
+    }
+    if lifecycle_tier:
+        data["lifecycle_tier"] = lifecycle_tier
+    if sacred_reason:
+        data["sacred_reason"] = sacred_reason
+    if fact_id:
+        data["fact_id"] = fact_id
+    if last_accessed_at:
+        data["last_accessed_at"] = last_accessed_at
+    return db.insert("memories", data)
+
+
+def _insert_entity(db, name, entity_type="person", importance=0.8,
+                   description=None, close_circle=False, close_circle_reason=None,
+                   contact_frequency_days=None, contact_trend=None):
+    """Insert an entity with optional close-circle fields."""
+    data = {
+        "name": name,
+        "type": entity_type,
+        "canonical_name": name.lower().strip(),
+        "importance": importance,
+        "created_at": datetime.utcnow().isoformat(),
+        "updated_at": datetime.utcnow().isoformat(),
+    }
+    if description:
+        data["description"] = description
+    mem_id = db.insert("entities", data)
+    if close_circle:
+        db.update("entities", {
+            "close_circle": 1,
+            "close_circle_reason": close_circle_reason or "test",
+        }, "id = ?", (mem_id,))
+    if contact_frequency_days is not None:
+        db.update("entities", {
+            "contact_frequency_days": contact_frequency_days,
+            "contact_trend": contact_trend or "stable",
+        }, "id = ?", (mem_id,))
+    return mem_id
+
+
+def _link_memory_entity(db, memory_id, entity_id):
+    """Link a memory to an entity."""
+    db.insert("memory_entities", {
+        "memory_id": memory_id,
+        "entity_id": entity_id,
+        "relationship": "about",
+    })
+
+
+def _get_recall_service(db):
+    """Create a RecallService with test database and mock dependencies."""
+    from claudia_memory.services.recall import RecallService
+    svc = RecallService.__new__(RecallService)
+    svc.db = db
+
+    class MockEmbedding:
+        def is_available_sync(self):
+            return False
+    svc.embedding_service = MockEmbedding()
+
+    class MockExtractor:
+        def canonical_name(self, name):
+            return name.lower().strip()
+    svc.extractor = MockExtractor()
+
+    class MockConfig:
+        max_recall_results = 50
+        min_importance_threshold = 0.0
+        vector_weight = 0.5
+        fts_weight = 0.15
+        importance_weight = 0.25
+        recency_weight = 0.1
+        enable_rrf = False
+        rrf_k = 60
+        graph_proximity_enabled = False
+        recency_half_life_days = 30
+    svc.config = MockConfig()
+
+    return svc
+
+
+def _get_consolidate_service(db):
+    """Create a ConsolidateService with test database."""
+    from claudia_memory.services.consolidate import ConsolidateService
+    svc = ConsolidateService.__new__(ConsolidateService)
+    svc.db = db
+
+    class MockConfig:
+        decay_rate_daily = 0.995
+        min_importance_threshold = 0.1
+        enable_pre_consolidation_backup = False
+        cooling_threshold_days = 60
+        archive_threshold_days = 180
+        enable_auto_sacred = True
+        sacred_core_keywords = ["birthday", "allergy", "family", "boundary", "health"]
+        close_circle_keywords = ["close friend", "bestie", "family", "best friend"]
+    svc.config = MockConfig()
+
+    return svc
+
+
+# ── Migration Tests ──────────────────────────────────────────────
+
+
+class TestMigration20:
+    """Verify migration 20 columns exist on all tables."""
+
+    def test_memories_lifecycle_columns(self, db):
+        """memories table should have lifecycle_tier, sacred_reason, archived_at, fact_id, hash, prev_hash."""
+        cols = {row["name"] for row in db.execute("PRAGMA table_info(memories)", fetch=True)}
+        for col in ["lifecycle_tier", "sacred_reason", "archived_at", "fact_id", "hash", "prev_hash"]:
+            assert col in cols, f"Missing column: {col}"
+
+    def test_entities_close_circle_columns(self, db):
+        """entities table should have close_circle, close_circle_reason."""
+        cols = {row["name"] for row in db.execute("PRAGMA table_info(entities)", fetch=True)}
+        assert "close_circle" in cols
+        assert "close_circle_reason" in cols
+
+    def test_relationships_lifecycle_column(self, db):
+        """relationships table should have lifecycle_tier."""
+        cols = {row["name"] for row in db.execute("PRAGMA table_info(relationships)", fetch=True)}
+        assert "lifecycle_tier" in cols
+
+    def test_indexes_exist(self, db):
+        """Lifecycle indexes should exist."""
+        indexes = {row["name"] for row in db.execute(
+            "SELECT name FROM sqlite_master WHERE type='index'", fetch=True
+        )}
+        assert "idx_memories_lifecycle" in indexes
+        assert "idx_memories_fact_id" in indexes
+        assert "idx_entities_close_circle" in indexes
+
+    def test_meta_chain_head_initialized(self, db):
+        """_meta should have chain_head and view_as_of entries."""
+        chain_head = db.execute(
+            "SELECT value FROM _meta WHERE key = 'chain_head'", fetch=True
+        )
+        assert chain_head is not None and len(chain_head) > 0
+
+        view_as_of = db.execute(
+            "SELECT value FROM _meta WHERE key = 'view_as_of'", fetch=True
+        )
+        assert view_as_of is not None and len(view_as_of) > 0
+
+
+# ── Sacred Memory Tests ──────────────────────────────────────────
+
+
+class TestSacredMemory:
+    """Test sacred tier behavior."""
+
+    def test_remember_with_critical_flag(self, db):
+        """remember_fact with critical=True should set lifecycle_tier='sacred'."""
+        with patch("claudia_memory.services.remember.embed_sync", return_value=None), \
+             patch("claudia_memory.services.remember.get_db", return_value=db), \
+             patch("claudia_memory.services.remember.get_embedding_service"), \
+             patch("claudia_memory.services.remember.get_extractor"):
+            from claudia_memory.services.remember import RememberService
+            import claudia_memory.services.remember as rem_mod
+            old_svc = rem_mod._service
+            rem_mod._service = None
+            try:
+                svc = RememberService()
+                svc.db = db
+                mem_id = svc.remember_fact(
+                    content="Sarah is allergic to peanuts",
+                    critical=True,
+                )
+                row = db.get_one("memories", where="id = ?", where_params=(mem_id,))
+                assert row["lifecycle_tier"] == "sacred"
+                assert row["sacred_reason"] == "user-protected"
+            finally:
+                rem_mod._service = old_svc
+
+    def test_sacred_memory_immune_to_decay(self, db):
+        """Sacred memories should not be decayed."""
+        sacred_id = _insert_memory(db, "Critical fact", importance=0.9,
+                                   lifecycle_tier="sacred", sacred_reason="user-protected")
+        normal_id = _insert_memory(db, "Normal fact", importance=0.9)
+
+        svc = _get_consolidate_service(db)
+        svc.run_decay()
+
+        sacred = db.get_one("memories", where="id = ?", where_params=(sacred_id,))
+        normal = db.get_one("memories", where="id = ?", where_params=(normal_id,))
+
+        assert sacred["importance"] == 0.9, "Sacred memory importance should not change"
+        assert normal["importance"] < 0.9, "Normal memory should have decayed"
+
+    def test_sacred_score_boost_in_recall(self, db):
+        """Sacred memories should get a score boost in recall results."""
+        from claudia_memory.services.recall import RecallResult
+
+        sacred_id = _insert_memory(db, "Sarah birthday is March 15th",
+                                   lifecycle_tier="sacred", importance=0.5)
+        normal_id = _insert_memory(db, "Sarah likes coffee", importance=0.5)
+
+        svc = _get_recall_service(db)
+        now = datetime.utcnow()
+
+        sacred_row = db.get_one("memories", where="id = ?", where_params=(sacred_id,))
+        normal_row = db.get_one("memories", where="id = ?", where_params=(normal_id,))
+
+        # Both have same base vector/fts scores
+        sacred_result = svc._row_to_result(sacred_row, 0.5, 0.5, now)
+        normal_result = svc._row_to_result(normal_row, 0.5, 0.5, now)
+
+        assert sacred_result.score > normal_result.score, \
+            f"Sacred score {sacred_result.score} should exceed normal {normal_result.score}"
+        assert sacred_result.lifecycle_tier == "sacred"
+        # Default from schema is 'active' (not None) for fresh-install databases
+        assert normal_result.lifecycle_tier == "active"
+
+
+# ── Lifecycle Tier Tests ─────────────────────────────────────────
+
+
+class TestLifecycleTiers:
+    """Test lifecycle tier transitions."""
+
+    def test_active_to_cooling_transition(self, db):
+        """Memories not accessed for cooling_threshold_days should transition to cooling."""
+        old_date = (datetime.utcnow() - timedelta(days=90)).isoformat()
+        mem_id = _insert_memory(db, "Old memory", lifecycle_tier="active",
+                                created_at=old_date, last_accessed_at=old_date)
+
+        svc = _get_consolidate_service(db)
+        result = svc.run_lifecycle_transitions()
+
+        row = db.get_one("memories", where="id = ?", where_params=(mem_id,))
+        assert row["lifecycle_tier"] == "cooling"
+
+    def test_cooling_to_archived_transition(self, db):
+        """Low-importance cooling memories should transition to archived."""
+        old_date = (datetime.utcnow() - timedelta(days=200)).isoformat()
+        mem_id = _insert_memory(db, "Forgotten low fact", lifecycle_tier="cooling",
+                                importance=0.2, created_at=old_date, last_accessed_at=old_date)
+
+        svc = _get_consolidate_service(db)
+        result = svc.run_lifecycle_transitions()
+
+        row = db.get_one("memories", where="id = ?", where_params=(mem_id,))
+        assert row["lifecycle_tier"] == "archived"
+        assert row["archived_at"] is not None
+
+    def test_sacred_never_transitions(self, db):
+        """Sacred memories should never transition regardless of age."""
+        old_date = (datetime.utcnow() - timedelta(days=365)).isoformat()
+        mem_id = _insert_memory(db, "Sacred old fact", lifecycle_tier="sacred",
+                                sacred_reason="user-protected",
+                                created_at=old_date, last_accessed_at=old_date)
+
+        svc = _get_consolidate_service(db)
+        svc.run_lifecycle_transitions()
+
+        row = db.get_one("memories", where="id = ?", where_params=(mem_id,))
+        assert row["lifecycle_tier"] == "sacred"
+
+    def test_recent_memory_stays_active(self, db):
+        """Recently accessed memories should remain active."""
+        recent = datetime.utcnow().isoformat()
+        mem_id = _insert_memory(db, "Recent fact", lifecycle_tier="active",
+                                created_at=recent, last_accessed_at=recent)
+
+        svc = _get_consolidate_service(db)
+        svc.run_lifecycle_transitions()
+
+        row = db.get_one("memories", where="id = ?", where_params=(mem_id,))
+        assert row["lifecycle_tier"] == "active"
+
+
+# ── Close-Circle Tests ───────────────────────────────────────────
+
+
+class TestCloseCircle:
+    """Test close-circle entity detection and auto-sacred promotion."""
+
+    def test_set_close_circle_promotes_keyword_facts(self, db):
+        """Setting close_circle should auto-promote matching keyword memories to sacred."""
+        entity_id = _insert_entity(db, "Sarah")
+        birthday_id = _insert_memory(db, "Sarah birthday is March 15th")
+        hobby_id = _insert_memory(db, "Sarah likes hiking")
+        _link_memory_entity(db, birthday_id, entity_id)
+        _link_memory_entity(db, hobby_id, entity_id)
+
+        with patch("claudia_memory.services.remember.embed_sync", return_value=None), \
+             patch("claudia_memory.services.remember.get_db", return_value=db), \
+             patch("claudia_memory.services.remember.get_embedding_service"), \
+             patch("claudia_memory.services.remember.get_extractor"):
+            from claudia_memory.services.remember import RememberService
+            import claudia_memory.services.remember as rem_mod
+            old_svc = rem_mod._service
+            rem_mod._service = None
+            try:
+                svc = RememberService()
+                svc.db = db
+                result = svc.set_close_circle(entity_id, reason="best friend")
+
+                assert result["close_circle"] is True
+                assert result["facts_promoted_to_sacred"] >= 1
+
+                birthday_row = db.get_one("memories", where="id = ?", where_params=(birthday_id,))
+                assert birthday_row["lifecycle_tier"] == "sacred"
+
+                hobby_row = db.get_one("memories", where="id = ?", where_params=(hobby_id,))
+                assert hobby_row["lifecycle_tier"] != "sacred" or hobby_row["lifecycle_tier"] is None
+            finally:
+                rem_mod._service = old_svc
+
+    def test_detect_close_circle_by_velocity(self, db):
+        """Entities with high contact velocity should be detected as close-circle candidates."""
+        entity_id = _insert_entity(db, "Alex", contact_frequency_days=3.0,
+                                   contact_trend="accelerating")
+
+        svc = _get_consolidate_service(db)
+        candidates = svc.detect_close_circle_candidates()
+
+        names = [c["name"] for c in candidates]
+        assert "Alex" in names
+
+    def test_detect_close_circle_by_keyword(self, db):
+        """Entities with close-circle keywords in description should be detected."""
+        entity_id = _insert_entity(db, "Mom", description="My family member who I call daily")
+
+        svc = _get_consolidate_service(db)
+        candidates = svc.detect_close_circle_candidates()
+
+        names = [c["name"] for c in candidates]
+        assert "Mom" in names
+
+    def test_auto_sacred_promotes_close_circle_facts(self, db):
+        """detect_auto_sacred should promote keyword-matching memories for close-circle entities."""
+        entity_id = _insert_entity(db, "Partner", close_circle=True)
+        allergy_id = _insert_memory(db, "Partner has a severe allergy to shellfish")
+        _link_memory_entity(db, allergy_id, entity_id)
+
+        svc = _get_consolidate_service(db)
+        promoted = svc.detect_auto_sacred()
+
+        assert promoted >= 1
+        row = db.get_one("memories", where="id = ?", where_params=(allergy_id,))
+        assert row["lifecycle_tier"] == "sacred"
+        assert "allergy" in row["sacred_reason"].lower()
+
+
+# ── fact_id Tests ────────────────────────────────────────────────
+
+
+class TestFactId:
+    """Test fact_id generation and uniqueness."""
+
+    def test_fact_id_auto_generated(self, db):
+        """remember_fact should auto-generate a UUID fact_id."""
+        with patch("claudia_memory.services.remember.embed_sync", return_value=None), \
+             patch("claudia_memory.services.remember.get_db", return_value=db), \
+             patch("claudia_memory.services.remember.get_embedding_service"), \
+             patch("claudia_memory.services.remember.get_extractor"):
+            from claudia_memory.services.remember import RememberService
+            import claudia_memory.services.remember as rem_mod
+            old_svc = rem_mod._service
+            rem_mod._service = None
+            try:
+                svc = RememberService()
+                svc.db = db
+                mem_id = svc.remember_fact(content="Test fact for UUID")
+                row = db.get_one("memories", where="id = ?", where_params=(mem_id,))
+                assert row["fact_id"] is not None
+                assert len(row["fact_id"]) == 36  # UUID format
+            finally:
+                rem_mod._service = old_svc
+
+    def test_fact_id_explicit_assignment(self, db):
+        """remember_fact should use explicitly provided fact_id."""
+        custom_id = "custom-fact-001"
+        with patch("claudia_memory.services.remember.embed_sync", return_value=None), \
+             patch("claudia_memory.services.remember.get_db", return_value=db), \
+             patch("claudia_memory.services.remember.get_embedding_service"), \
+             patch("claudia_memory.services.remember.get_extractor"):
+            from claudia_memory.services.remember import RememberService
+            import claudia_memory.services.remember as rem_mod
+            old_svc = rem_mod._service
+            rem_mod._service = None
+            try:
+                svc = RememberService()
+                svc.db = db
+                mem_id = svc.remember_fact(content="Explicit ID fact", fact_id=custom_id)
+                row = db.get_one("memories", where="id = ?", where_params=(mem_id,))
+                assert row["fact_id"] == custom_id
+            finally:
+                rem_mod._service = old_svc
+
+    def test_fact_id_uniqueness(self, db):
+        """fact_id column should enforce uniqueness."""
+        _insert_memory(db, "First fact", fact_id="unique-001")
+        with pytest.raises(Exception):
+            _insert_memory(db, "Second fact", fact_id="unique-001")
+
+
+# ── Context Builder (CRE) Tests ──────────────────────────────────
+
+
+class TestContextBuilder:
+    """Test the Context Relevance Engine."""
+
+    def test_estimate_tokens(self):
+        """Token estimator should use words * 1.3 heuristic."""
+        from claudia_memory.services.context_builder import _estimate_tokens
+        assert _estimate_tokens("") == 0
+        assert _estimate_tokens("hello world") == int(2 * 1.3)
+        assert _estimate_tokens("one two three four five") == int(5 * 1.3)
+
+    def test_truncate_to_budget(self):
+        """truncate_to_budget should respect token budget."""
+        from claudia_memory.services.context_builder import truncate_to_budget
+        facts = [
+            {"content": " ".join(["word"] * 10), "id": 1},  # ~13 tokens
+            {"content": " ".join(["word"] * 10), "id": 2},  # ~13 tokens
+            {"content": " ".join(["word"] * 10), "id": 3},  # ~13 tokens
+        ]
+        result = truncate_to_budget(facts, 20)
+        assert len(result) == 1  # Only first fact fits
+
+    def test_get_sacred_facts(self, db):
+        """get_sacred_facts should return only sacred memories."""
+        sacred_id = _insert_memory(db, "Sacred fact", lifecycle_tier="sacred",
+                                   sacred_reason="user-protected")
+        normal_id = _insert_memory(db, "Normal fact")
+
+        with patch("claudia_memory.database.get_db", return_value=db):
+            from claudia_memory.services.context_builder import get_sacred_facts
+            facts = get_sacred_facts()
+            fact_ids = [f["id"] for f in facts]
+            assert sacred_id in fact_ids
+            assert normal_id not in fact_ids
+
+    def test_get_sacred_facts_by_entity(self, db):
+        """get_sacred_facts with entity filter should scope to that entity."""
+        entity_id = _insert_entity(db, "Bob")
+        sacred_bob = _insert_memory(db, "Bob fact sacred", lifecycle_tier="sacred",
+                                    sacred_reason="test")
+        sacred_other = _insert_memory(db, "Other sacred fact", lifecycle_tier="sacred",
+                                      sacred_reason="test")
+        _link_memory_entity(db, sacred_bob, entity_id)
+
+        with patch("claudia_memory.database.get_db", return_value=db):
+            from claudia_memory.services.context_builder import get_sacred_facts
+            facts = get_sacred_facts(entity_name="Bob")
+            fact_ids = [f["id"] for f in facts]
+            assert sacred_bob in fact_ids
+            assert sacred_other not in fact_ids
+
+    def test_build_context_includes_sacred_first(self, db):
+        """build_context should always include sacred facts."""
+        sacred_id = _insert_memory(db, "Critical allergy info", lifecycle_tier="sacred",
+                                   sacred_reason="test")
+
+        class MockConfig:
+            context_builder_token_budget = 8000
+            context_builder_max_facts = 30
+            language_model = None
+
+        # Patch at source modules since build_context uses lazy imports
+        with patch("claudia_memory.database.get_db", return_value=db), \
+             patch("claudia_memory.services.recall.recall", return_value=[]), \
+             patch("claudia_memory.config.get_config", return_value=MockConfig()):
+            from claudia_memory.services.context_builder import build_context
+            result = build_context("test query", token_budget=8000)
+            assert result.sacred_count >= 1
+            sacred_ids = [f["id"] for f in result.sacred]
+            assert sacred_id in sacred_ids
+
+    def test_build_context_respects_token_budget(self, db):
+        """build_context should not exceed token budget."""
+        # Insert many non-sacred facts
+        for i in range(20):
+            _insert_memory(db, f"Fact number {i} " + " ".join(["word"] * 50))
+
+        from claudia_memory.services.recall import RecallResult
+        mock_results = [
+            RecallResult(id=i, content=f"Fact {i} " + " ".join(["word"] * 50),
+                         type="fact", score=0.9 - i * 0.01, importance=0.8,
+                         created_at=datetime.utcnow().isoformat(), entities=[])
+            for i in range(20)
+        ]
+
+        class MockConfig:
+            context_builder_token_budget = 200
+            context_builder_max_facts = 30
+            language_model = None
+
+        with patch("claudia_memory.database.get_db", return_value=db), \
+             patch("claudia_memory.services.recall.recall", return_value=mock_results), \
+             patch("claudia_memory.config.get_config", return_value=MockConfig()):
+            from claudia_memory.services.context_builder import build_context
+            result = build_context("test", token_budget=200)
+            # Should be fewer than 20 facts due to budget
+            assert result.relevant_count < 20
+            assert result.total_tokens <= 300  # Allow some overhead
+
+
+# ── Checkpoint Tests ─────────────────────────────────────────────
+
+
+class TestCheckpoint:
+    """Test checkpoint (backup) functionality."""
+
+    def test_checkpoint_save(self, db):
+        """db.backup() should create a labeled backup file."""
+        backup_path = db.backup(label="test-checkpoint")
+        assert backup_path is not None
+        assert Path(backup_path).exists()
+        assert "test-checkpoint" in str(backup_path)
+
+
+# ── Rollback (view_as_of) Tests ──────────────────────────────────
+
+
+class TestRollback:
+    """Test view_as_of temporal filtering."""
+
+    def test_view_as_of_filters_recall(self, db):
+        """When view_as_of is set, _apply_filters should add temporal constraint."""
+        old_date = (datetime.utcnow() - timedelta(days=30)).isoformat()
+        new_date = datetime.utcnow().isoformat()
+
+        old_id = _insert_memory(db, "Old memory from last month zzview", created_at=old_date)
+        new_id = _insert_memory(db, "New memory from today zzview", created_at=new_date)
+
+        # Set view_as_of to a date between old and new
+        cutoff = (datetime.utcnow() - timedelta(days=15)).isoformat()
+        db.execute(
+            "UPDATE _meta SET value = ? WHERE key = 'view_as_of'",
+            (cutoff,),
+        )
+
+        svc = _get_recall_service(db)
+        # Use _apply_filters which is where view_as_of logic lives
+        sql_parts = [
+            "SELECT m.*, GROUP_CONCAT(e.name) as entity_names FROM memories m",
+            "LEFT JOIN memory_entities me2 ON m.id = me2.memory_id",
+            "LEFT JOIN entities e ON me2.entity_id = e.id",
+            "WHERE m.content LIKE ?",
+        ]
+        params = ["%zzview%"]
+        svc._apply_filters(sql_parts, params, None, None, None, None)
+        sql_parts.append("GROUP BY m.id")
+        rows = db.execute("\n".join(sql_parts), tuple(params), fetch=True) or []
+
+        result_ids = [r["id"] for r in rows]
+        assert old_id in result_ids
+        assert new_id not in result_ids
+
+        # Clear rollback
+        db.execute("UPDATE _meta SET value = NULL WHERE key = 'view_as_of'")
+
+    def test_view_as_of_clear_shows_all(self, db):
+        """When view_as_of is NULL, all memories should be visible."""
+        old_date = (datetime.utcnow() - timedelta(days=30)).isoformat()
+        new_date = datetime.utcnow().isoformat()
+
+        old_id = _insert_memory(db, "Visible old memory xyzabc", created_at=old_date)
+        new_id = _insert_memory(db, "Visible new memory xyzabc", created_at=new_date)
+
+        # Ensure view_as_of is NULL
+        db.execute("UPDATE _meta SET value = NULL WHERE key = 'view_as_of'")
+
+        svc = _get_recall_service(db)
+        results = svc._keyword_search("xyzabc", limit=10)
+
+        result_ids = [r["id"] for r in results]
+        assert old_id in result_ids
+        assert new_id in result_ids
+
+
+# ── SHA-256 Chain Tests ──────────────────────────────────────────
+
+
+class TestChainHash:
+    """Test SHA-256 chain hashing for memory integrity."""
+
+    def test_compute_chain_hash_deterministic(self):
+        """Same inputs should produce same hash."""
+        from claudia_memory.services.remember import _compute_chain_hash
+        h1 = _compute_chain_hash("content", {"key": "val"}, "prev123")
+        h2 = _compute_chain_hash("content", {"key": "val"}, "prev123")
+        assert h1 == h2
+
+    def test_compute_chain_hash_different_content(self):
+        """Different content should produce different hash."""
+        from claudia_memory.services.remember import _compute_chain_hash
+        h1 = _compute_chain_hash("content A", None, None)
+        h2 = _compute_chain_hash("content B", None, None)
+        assert h1 != h2
+
+    def test_chain_links_on_remember(self, db):
+        """remember_fact should create linked chain hashes when enabled."""
+        with patch("claudia_memory.services.remember.embed_sync", return_value=None), \
+             patch("claudia_memory.services.remember.get_db", return_value=db), \
+             patch("claudia_memory.services.remember.get_embedding_service"), \
+             patch("claudia_memory.services.remember.get_extractor"):
+
+            # Enable chain verification in config
+            class MockConfig:
+                enable_chain_verification = True
+            with patch("claudia_memory.services.remember._get_config", create=True):
+                from claudia_memory.services.remember import RememberService
+                import claudia_memory.services.remember as rem_mod
+                old_svc = rem_mod._service
+                rem_mod._service = None
+                try:
+                    svc = RememberService()
+                    svc.db = db
+
+                    # Patch get_config inside remember.py scope for the chain logic
+                    with patch("claudia_memory.config.get_config", return_value=MockConfig()):
+                        id1 = svc.remember_fact(content="First chain fact aaa111")
+                        id2 = svc.remember_fact(content="Second chain fact bbb222")
+
+                    row1 = db.get_one("memories", where="id = ?", where_params=(id1,))
+                    row2 = db.get_one("memories", where="id = ?", where_params=(id2,))
+
+                    # First memory should have hash but prev_hash may be None
+                    if row1["hash"]:
+                        assert len(row1["hash"]) == 64  # SHA-256 hex length
+
+                    # Second memory's prev_hash should equal first memory's hash
+                    if row2["hash"] and row1["hash"]:
+                        assert row2["prev_hash"] == row1["hash"]
+                finally:
+                    rem_mod._service = old_svc
+
+    def test_chain_disabled_skips_hash(self, db):
+        """When enable_chain_verification is False, no hashes should be written."""
+        with patch("claudia_memory.services.remember.embed_sync", return_value=None), \
+             patch("claudia_memory.services.remember.get_db", return_value=db), \
+             patch("claudia_memory.services.remember.get_embedding_service"), \
+             patch("claudia_memory.services.remember.get_extractor"):
+
+            class MockConfig:
+                enable_chain_verification = False
+            from claudia_memory.services.remember import RememberService
+            import claudia_memory.services.remember as rem_mod
+            old_svc = rem_mod._service
+            rem_mod._service = None
+            try:
+                svc = RememberService()
+                svc.db = db
+
+                with patch("claudia_memory.config.get_config", return_value=MockConfig()):
+                    mem_id = svc.remember_fact(content="No chain fact ccc333")
+
+                row = db.get_one("memories", where="id = ?", where_params=(mem_id,))
+                assert row["hash"] is None
+            finally:
+                rem_mod._service = old_svc
+
+
+# ── Recall Archived Filter Tests ─────────────────────────────────
+
+
+class TestRecallArchivedFilter:
+    """Test that archived memories are excluded by default."""
+
+    def test_keyword_search_excludes_archived(self, db):
+        """Keyword search should not return archived memories by default."""
+        active_id = _insert_memory(db, "Active memory qqq789", lifecycle_tier="active")
+        archived_id = _insert_memory(db, "Archived memory qqq789", lifecycle_tier="archived")
+
+        svc = _get_recall_service(db)
+        results = svc._keyword_search("qqq789", limit=10)
+        result_ids = [r["id"] for r in results]
+        assert active_id in result_ids
+        assert archived_id not in result_ids
+
+    def test_keyword_search_includes_archived_when_requested(self, db):
+        """Keyword search with include_archived should return archived memories."""
+        active_id = _insert_memory(db, "Active memory www321", lifecycle_tier="active")
+        archived_id = _insert_memory(db, "Archived memory www321", lifecycle_tier="archived")
+
+        svc = _get_recall_service(db)
+        # The _keyword_search method uses _apply_filters which gets include_archived
+        # We test via the recall() method's include_archived parameter
+        # For direct keyword search, we verify the SQL filter works
+        sql_parts = [
+            "SELECT m.*, GROUP_CONCAT(e.name) as entity_names FROM memories m",
+            "LEFT JOIN memory_entities me2 ON m.id = me2.memory_id",
+            "LEFT JOIN entities e ON me2.entity_id = e.id",
+            "WHERE m.content LIKE ?",
+        ]
+        params = ["%www321%"]
+        svc._apply_filters(sql_parts, params, None, None, None, None, include_archived=True)
+        sql_parts.append("GROUP BY m.id")
+        rows = db.execute("\n".join(sql_parts), tuple(params), fetch=True) or []
+        result_ids = [r["id"] for r in rows]
+        assert active_id in result_ids
+        assert archived_id in result_ids
+
+    def test_null_lifecycle_tier_treated_as_active(self, db):
+        """Pre-migration memories with NULL lifecycle_tier should be visible."""
+        legacy_id = _insert_memory(db, "Legacy memory eee555")  # No lifecycle_tier set
+
+        svc = _get_recall_service(db)
+        results = svc._keyword_search("eee555", limit=10)
+        result_ids = [r["id"] for r in results]
+        assert legacy_id in result_ids
+
+
+# ── RecallResult Dataclass Tests ─────────────────────────────────
+
+
+class TestRecallResultFields:
+    """Test lifecycle fields on RecallResult."""
+
+    def test_recall_result_has_lifecycle_fields(self):
+        """RecallResult should have lifecycle_tier and fact_id fields."""
+        from claudia_memory.services.recall import RecallResult
+        r = RecallResult(
+            id=1, content="test", type="fact", score=1.0,
+            importance=1.0, created_at="2026-01-01", entities=[],
+            lifecycle_tier="sacred", fact_id="abc-123",
+        )
+        assert r.lifecycle_tier == "sacred"
+        assert r.fact_id == "abc-123"
+
+    def test_recall_result_defaults(self):
+        """lifecycle_tier and fact_id should default to None."""
+        from claudia_memory.services.recall import RecallResult
+        r = RecallResult(
+            id=1, content="test", type="fact", score=1.0,
+            importance=1.0, created_at="2026-01-01", entities=[],
+        )
+        assert r.lifecycle_tier is None
+        assert r.fact_id is None

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2121 @@
+{
+  "name": "get-claudia",
+  "version": "1.49.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "get-claudia",
+      "version": "1.49.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "better-sqlite3": "^11.8.1",
+        "commander": "^13.1.0",
+        "sqlite-vec": "^0.1.6"
+      },
+      "bin": {
+        "claudia": "cli/index.js",
+        "get-claudia": "bin/index.js"
+      },
+      "devDependencies": {
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
+      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.87.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
+      "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sqlite-vec": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/sqlite-vec/-/sqlite-vec-0.1.6.tgz",
+      "integrity": "sha512-hQZU700TU2vWPXZYDULODjKXeMio6rKX7UpPN7Tq9qjPW671IEgURGrcC5LDBMl0q9rBvAuzmcmJmImMqVibYQ==",
+      "license": "MIT OR Apache",
+      "optionalDependencies": {
+        "sqlite-vec-darwin-arm64": "0.1.6",
+        "sqlite-vec-darwin-x64": "0.1.6",
+        "sqlite-vec-linux-arm64": "0.1.6",
+        "sqlite-vec-linux-x64": "0.1.6",
+        "sqlite-vec-windows-x64": "0.1.6"
+      }
+    },
+    "node_modules/sqlite-vec-darwin-arm64": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-darwin-arm64/-/sqlite-vec-darwin-arm64-0.1.6.tgz",
+      "integrity": "sha512-5duw/xhM3xE6BCQd//eAkyHgBp9FIwK6veldRhPG96dT6Zpjov3bG02RuE7JAQj0SVJYRW8bJwZ4LxqW0+Q7Dw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/sqlite-vec-darwin-x64": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-darwin-x64/-/sqlite-vec-darwin-x64-0.1.6.tgz",
+      "integrity": "sha512-MFkKjNfJ5pamFHhyTsrqdxALrjuvpSEZdu6Q/0vMxFa6sr5YlfabeT5xGqEbuH0iobsT1Hca5EZxLhLy0jHYkw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/sqlite-vec-linux-x64": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-linux-x64/-/sqlite-vec-linux-x64-0.1.6.tgz",
+      "integrity": "sha512-411tWPswywIzdkp+zsAUav4A03f0FjnNfpZFlOw8fBebFR74RSFkwM8Xryf18gLHiYAXUBI4mjY9+/xjwBjKpg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/sqlite-vec-windows-x64": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-windows-x64/-/sqlite-vec-windows-x64-0.1.6.tgz",
+      "integrity": "sha512-Dy9/KlKJDrjuQ/RRkBqGkMZuSh5bTJDMMOFZft9VJZaXzpYxb5alpgdvD4bbKegpDdfPi2BT4+PBivsNJSlMoQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -26,15 +26,30 @@
     "url": "https://github.com/kbanc85/claudia/issues"
   },
   "bin": {
-    "get-claudia": "./bin/index.js"
+    "get-claudia": "./bin/index.js",
+    "claudia": "./cli/index.js"
   },
   "files": [
     "bin",
+    "cli",
     "template-v2",
-    "memory-daemon",
     "assets",
     "visualizer"
   ],
+  "dependencies": {
+    "better-sqlite3": "^11.8.1",
+    "commander": "^13.1.0",
+    "sqlite-vec": "^0.1.6"
+  },
+  "devDependencies": {
+    "vitest": "^3.0.0"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:integration": "vitest run tests/integration",
+    "test:unit": "vitest run tests/unit"
+  },
   "engines": {
     "node": ">=18.0.0"
   },

--- a/template-v2/.claude/agents/document-processor.md
+++ b/template-v2/.claude/agents/document-processor.md
@@ -133,7 +133,7 @@ Return this exact JSON structure:
 
 ### Memory Operations (for batch storage pipeline)
 
-When Claudia dispatches you with `extraction_type: "memory_operations"`, return ready-to-store operations matching the `memory.batch` input format. This lets Claudia pipe your output directly into `memory.batch` after review, skipping manual composition.
+When Claudia dispatches you with `extraction_type: "memory_operations"`, return ready-to-store operations matching the `claudia memory batch` input format. This lets Claudia pipe your output directly into `claudia memory batch` after review, skipping manual composition.
 
 ```json
 {

--- a/template-v2/.claude/hooks/hooks.json
+++ b/template-v2/.claude/hooks/hooks.json
@@ -14,14 +14,14 @@
         ],
         "on_missing_me": "trigger_onboarding",
         "memory_verification": {
-          "step_1_check_tools": "BEFORE anything else, verify you have access to mcp__claudia-memory__* tools (check your available tools list). If no memory tools are available: (1) Do NOT fall back to plugin:episodic-memory, mcp__plugin_episodic-memory_*, or any other memory search tool as a substitute — these give inferior, unrelated results and mask the real problem. (2) Tell the user: 'My memory tools are not registered in this session. The daemon likely just auto-restarted — please restart Claude Code (close and reopen the window) to reconnect. Your context files are preserved.' (3) Continue with context files only (context/me.md, etc.) until restarted.",
-          "step_2_health_check": "Call memory.session (operation=\"context\"). If it fails or returns an error, the daemon may be crashed. Suggest: 'Memory daemon may need restart. Check: curl http://localhost:3848/health'",
-          "fallback": "If mcp__claudia-memory__* tools are not available: (1) Do NOT use plugin:episodic-memory or any other memory search tool as a substitute. (2) Tell the user: 'My memory tools are not registered in this session. The daemon may have just restarted — please restart Claude Code to reconnect. Your context files are preserved.' (3) Read context files directly (context/me.md, context/commitments.md, context/learnings.md, context/patterns.md, context/waiting.md) as the fallback. Make clear to the user they are in degraded mode with no semantic search or cross-session learning."
+          "step_1_check_cli": "BEFORE anything else, verify the `claudia` CLI is available by running `claudia system-health --project-dir \"$PWD\"` via Bash tool. If the command fails or is not found: (1) Do NOT fall back to plugin:episodic-memory, mcp__plugin_episodic-memory_*, or any other memory search tool as a substitute — these give inferior, unrelated results and mask the real problem. (2) Tell the user: 'My memory tools are not available. The Claudia CLI might not be installed or not on your PATH. To fix this, run: npm install -g get-claudia && claudia setup. Your context files are preserved.' (3) Continue with context files only (context/me.md, etc.) until fixed.",
+          "step_2_health_check": "Run `claudia memory session context --project-dir \"$PWD\"` via Bash tool. If it fails, the CLI may not be properly installed. Suggest: 'Claudia CLI may need reinstalling. Run: npm install -g get-claudia && claudia setup'",
+          "fallback": "If the `claudia` CLI is not available: (1) Do NOT use plugin:episodic-memory or any other memory search tool as a substitute. (2) Tell the user: 'My memory tools are not available. The Claudia CLI might not be installed. Run: npm install -g get-claudia && claudia setup.' (3) Read context files directly (context/me.md, context/commitments.md, context/learnings.md, context/patterns.md, context/waiting.md) as the fallback. Make clear to the user they are in degraded mode with no semantic search or cross-session learning."
         },
         "enhanced_memory": {
-          "context_load": "Call memory.session (operation=\"context\") to get a formatted context block with recent memories, commitments, and unsummarized session alerts.",
-          "catch_up": "If unsummarized sessions are reported in the context block, review buffered turns and call memory.end_session with a retroactive narrative and structured extractions for each.",
-          "recall_context": "Use the loaded context for greeting. For deeper search on specific topics, use memory.recall."
+          "context_load": "Run `claudia memory session context --project-dir \"$PWD\"` via Bash tool to get a formatted context block with recent memories, commitments, and unsummarized session alerts.",
+          "catch_up": "If unsummarized sessions are reported in the context block, review buffered turns and run `claudia memory end-session --project-dir \"$PWD\"` with a retroactive narrative and structured extractions for each.",
+          "recall_context": "Use the loaded context for greeting. For deeper search on specific topics, run `claudia memory recall \"query\" --project-dir \"$PWD\"` via Bash tool."
         },
         "proactive_surfacing": {
           "description": "Surface urgent items naturally in the greeting. Keep it to a brief mention, not a full report.",
@@ -30,12 +30,12 @@
             {
               "type": "overdue_commitments",
               "description": "Commitments older than 7 days without resolution",
-              "query_hint": "Use memory.recall with type='commitment' filter and check dates"
+              "query_hint": "Run `claudia memory recall \"overdue commitments\" --type commitment --project-dir \"$PWD\"` and check dates"
             },
             {
               "type": "cooling_relationships",
               "description": "Important people not mentioned in >30 days",
-              "query_hint": "Use memory.entities (operation=\"search\") to find entities with old last_mentioned dates"
+              "query_hint": "Run `claudia memory entities search --type person --project-dir \"$PWD\"` and check last_mentioned dates"
             }
           ],
           "examples": [
@@ -58,7 +58,7 @@
         ],
         "save_mode": "merge",
         "enhanced_memory": {
-          "summarize": "Call memory.end_session with a narrative summary and structured extractions from the session's buffered turns. The narrative should enhance stored information with tone, context, unresolved threads, and nuance that structured fields cannot capture."
+          "summarize": "Run `claudia memory end-session --summary \"...\" --narrative \"...\" --project-dir \"$PWD\"` via Bash tool with a narrative summary and structured extractions from the session's buffered turns. The narrative should enhance stored information with tone, context, unresolved threads, and nuance that structured fields cannot capture."
         }
       }
     },
@@ -74,11 +74,11 @@
   ],
   "notes": {
     "implementation": "These hooks define intended behaviors. Claude Code will execute them as behavioral guidelines rather than traditional script execution.",
-    "memory_verification": "CRITICAL: At session start, verify mcp__claudia-memory__* tools are available BEFORE proceeding. If tools don't appear, do NOT use plugin:episodic-memory as a substitute. Tell the user to restart Claude Code — the daemon auto-restarts but MCP tools only register at session start. Fall back to context files only (context/me.md, etc.) in the meantime.",
-    "session_start": "At session start: (1) Verify memory tools available, (2) Call memory.session (operation=\"context\"), (3) Read context files, (4) Check for unsummarized sessions. If me.md is missing, trigger onboarding.",
+    "memory_verification": "CRITICAL: At session start, verify the `claudia` CLI is available by running `claudia system-health --project-dir \"$PWD\"` BEFORE proceeding. If the command fails, do NOT use plugin:episodic-memory as a substitute. Tell the user to install the CLI: npm install -g get-claudia && claudia setup. Fall back to context files only (context/me.md, etc.) in the meantime.",
+    "session_start": "At session start: (1) Verify claudia CLI available, (2) Run `claudia memory session context --project-dir \"$PWD\"`, (3) Read context files, (4) Check for unsummarized sessions. If me.md is missing, trigger onboarding.",
     "session_end": "Before session ends, Claudia should generate a session summary (enhanced memory) or update context files (markdown fallback). The summary includes both a free-form narrative and structured extractions.",
     "first_run": "The absence of context/me.md signals a first-run scenario requiring onboarding.",
-    "turn_buffering": "During sessions with enhanced memory, Claudia buffers each meaningful conversation turn via memory.session (operation=\"buffer\"). This ensures nothing is lost even if the session ends abruptly. The buffered turns are summarized at session end or caught up at next session start.",
-    "source_filing": "CRITICAL: When processing transcripts, emails, or documents, ALWAYS call memory.document (operation=\"store\") BEFORE extracting information. The Source Preservation principle (#12) is non-negotiable. Raw sources must be filed for provenance."
+    "turn_buffering": "During sessions with enhanced memory, Claudia buffers each meaningful conversation turn via `claudia memory session buffer --project-dir \"$PWD\"`. This ensures nothing is lost even if the session ends abruptly. The buffered turns are summarized at session end or caught up at next session start.",
+    "source_filing": "CRITICAL: When processing transcripts, emails, or documents, ALWAYS run `claudia memory document store --project-dir \"$PWD\"` BEFORE extracting information. The Source Preservation principle (#12) is non-negotiable. Raw sources must be filed for provenance."
   }
 }

--- a/template-v2/.claude/hooks/pre-compact.py
+++ b/template-v2/.claude/hooks/pre-compact.py
@@ -1,27 +1,35 @@
 #!/usr/bin/env python3
 """Cross-platform pre-compact hook for Claudia.
 
-Flushes WAL and injects context advisory before compaction.
+Runs lightweight consolidation and injects context advisory before compaction.
 """
 
 import json
-from urllib.request import urlopen
-from urllib.error import URLError
+import os
+import shutil
+import subprocess
 
-# Signal daemon to flush WAL
-try:
-    urlopen("http://localhost:3848/flush", timeout=3)
-except (URLError, OSError, TimeoutError):
-    pass
+# Run lightweight decay if claudia is available
+claudia_bin = shutil.which("claudia")
+if claudia_bin:
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", ".")
+    try:
+        subprocess.run(
+            [claudia_bin, "memory", "consolidate", "--lightweight",
+             "--project-dir", project_dir],
+            capture_output=True, timeout=10
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        pass
 
 print(json.dumps({
     "additionalContext": (
         "Context compaction advisory: If important information was discussed recently, "
-        "ensure it has been stored. Check: (1) Commitments: call memory.remember with "
-        "type='commitment' for any promises not yet stored. (2) People: call memory.entities "
-        "(operation='create') for anyone discussed in detail. (3) Relationships: call memory.relate for "
-        "connections mentioned. (4) Buffer: call memory.session (operation='buffer') with a summary if "
-        "recent exchanges weren't buffered. With 1M context, compaction is less frequent, "
-        "but proactive capture remains good practice."
+        "ensure it has been stored. Check: (1) Commitments: run claudia memory save "
+        "--type commitment for any promises not yet stored. (2) People: run claudia memory "
+        "entities create for anyone discussed in detail. (3) Relationships: run claudia memory "
+        "relate for connections mentioned. (4) Buffer: run claudia memory session buffer with "
+        "a summary if recent exchanges weren't buffered. With 1M context, compaction is "
+        "less frequent, but proactive capture remains good practice."
     )
 }))

--- a/template-v2/.claude/hooks/pre-compact.sh
+++ b/template-v2/.claude/hooks/pre-compact.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
 # PreCompact hook: Advisory checkpoint before context compaction
-# Returns JSON with additionalContext to help Claudia recover gracefully
+# Runs lightweight consolidation and injects advisory into compacted context
 
-# Signal daemon to flush WAL (ensures all buffered data is durable)
-curl -s "http://localhost:3848/flush" 2>/dev/null || true
+# Run lightweight decay if claudia is available
+if command -v claudia &>/dev/null; then
+  claudia memory consolidate --lightweight --project-dir "${CLAUDE_PROJECT_DIR:-.}" 2>/dev/null || true
+fi
 
 # Inject advisory into compacted context
 cat <<EOF
 {
-  "additionalContext": "Context compaction advisory: If important information was discussed recently, ensure it has been stored. Check: (1) Commitments: call memory.remember with type='commitment' for any promises not yet stored. (2) People: call memory.entities (operation='create') for anyone discussed in detail. (3) Relationships: call memory.relate for connections mentioned. (4) Buffer: call memory.session (operation='buffer') with a summary if recent exchanges weren't buffered. With 1M context, compaction is less frequent, but proactive capture remains good practice."
+  "additionalContext": "Context compaction advisory: If important information was discussed recently, ensure it has been stored. Check: (1) Commitments: run claudia memory save --type commitment for any promises not yet stored. (2) People: run claudia memory entities create for anyone discussed in detail. (3) Relationships: run claudia memory relate for connections mentioned. (4) Buffer: run claudia memory session buffer with a summary if recent exchanges weren't buffered. With 1M context, compaction is less frequent, but proactive capture remains good practice."
 }
 EOF
 exit 0

--- a/template-v2/.claude/hooks/session-health-check.py
+++ b/template-v2/.claude/hooks/session-health-check.py
@@ -1,190 +1,90 @@
 #!/usr/bin/env python3
 """Cross-platform session health check hook for Claudia.
 
-Checks memory daemon health and provides actionable guidance when it's down.
+Runs `claudia system-health` and provides actionable guidance.
 Outputs JSON with additionalContext for Claude Code hooks.
 """
 
 import json
-import platform
+import os
+import shutil
+import subprocess
 from pathlib import Path
-from urllib.request import urlopen
-from urllib.error import URLError
 
 
-def _get_status_summary():
-    """Call /status endpoint for compact memory counts. Returns summary string or None."""
+def _run_claudia(*args):
+    """Run claudia CLI and return parsed JSON output, or None on failure."""
+    claudia_bin = shutil.which("claudia")
+    if not claudia_bin:
+        # Check local node_modules
+        project_dir = os.environ.get("CLAUDE_PROJECT_DIR", ".")
+        local_bin = Path(project_dir) / "node_modules" / ".bin" / "claudia"
+        if local_bin.exists():
+            claudia_bin = str(local_bin)
+        else:
+            return None
+
     try:
-        resp = urlopen("http://localhost:3848/status", timeout=5)
-        data = json.loads(resp.read().decode())
-
-        counts = data.get("counts", {})
-        memories = counts.get("memories", 0)
-        entities = counts.get("entities", 0)
-        parts = [f"Memory: {memories} memories, {entities} entities."]
-
-        # Embedding warnings only
-        components = data.get("components", {})
-        embed_status = components.get("embeddings", "ok")
-        if embed_status in ("unavailable", "error"):
-            parts.append(f"Embeddings {embed_status}.")
-        if data.get("embedding_model_mismatch", False):
-            parts.append("Embedding model mismatch.")
-
-        return " ".join(parts)
-    except (URLError, OSError, TimeoutError, json.JSONDecodeError, KeyError):
-        return None
-
+        result = subprocess.run(
+            [claudia_bin, *args],
+            capture_output=True, text=True, timeout=10
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return json.loads(result.stdout)
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError, json.JSONDecodeError):
+        pass
+    return None
 
 
 def check_health():
-    context_parts = []
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", ".")
 
-    # Check health endpoint
-    try:
-        resp = urlopen("http://localhost:3848/health", timeout=5)
-        body = resp.read().decode()
-        if "healthy" in body:
-            # Health OK - try to get richer status data
-            status_msg = _get_status_summary()
-            if status_msg:
-                print(json.dumps({"additionalContext": status_msg}))
-            else:
-                print(json.dumps({"additionalContext": "Memory system healthy."}))
-            return
-    except (URLError, OSError, TimeoutError):
-        pass
+    data = _run_claudia("system-health", "--project-dir", project_dir)
 
-    context_parts.append("Memory daemon not responding.")
+    if data:
+        db = data.get("database", {})
+        emb = data.get("embedding", {})
+        parts = []
 
-    # Check daemon installation status (platform-specific)
-    system = platform.system()
-    home = Path.home()
+        if db.get("memories") is not None:
+            parts.append(f"{db['memories']} memories, {db.get('entities', 0)} entities.")
+        if not emb.get("available", False):
+            parts.append("Embeddings unavailable.")
 
-    if system == "Darwin":
-        plist = home / "Library" / "LaunchAgents" / "com.claudia.memory.plist"
-        if plist.exists():
-            import subprocess
-            import time
-            restarted = False
-            try:
-                subprocess.run(["launchctl", "unload", str(plist)],
-                               capture_output=True, timeout=10)
-                time.sleep(0.5)
-                subprocess.run(["launchctl", "load", str(plist)],
-                               capture_output=True, timeout=10)
-                time.sleep(3)
-                try:
-                    resp = urlopen("http://localhost:3848/health", timeout=5)
-                    if "healthy" in resp.read().decode():
-                        restarted = True
-                except (URLError, OSError, TimeoutError):
-                    pass
-            except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
-                pass
-            if restarted:
-                status_msg = _get_status_summary()
-                msg = (
-                    "Memory daemon was stopped and has been auto-restarted. "
-                    "MCP tools not available this session -- restart Claude Code to reconnect. "
-                    "Context files are preserved."
-                )
-                if status_msg:
-                    msg = f"{msg} {status_msg}"
-                print(json.dumps({"additionalContext": msg}))
-                return
-            context_parts.append(
-                "Memory daemon stopped. "
-                "Restart: launchctl load ~/Library/LaunchAgents/com.claudia.memory.plist. "
-                "If unavailable, read context/ files directly."
-            )
+        summary = " ".join(parts) if parts else "System ready."
+        print(json.dumps({"additionalContext": f"Memory system healthy. {summary}"}))
+        return
+
+    # CLI not available -- provide fallback guidance
+    context_parts = ["Claudia CLI not responding."]
+
+    if not shutil.which("claudia"):
+        local_bin = Path(project_dir) / "node_modules" / ".bin" / "claudia"
+        if local_bin.exists():
+            context_parts.append("CLI found at node_modules/.bin/claudia but not on PATH.")
         else:
-            context_parts.append(
-                "Memory daemon not installed. Run installer or read context/ files directly."
-            )
+            context_parts.append("Install with: npm install -g get-claudia && claudia setup.")
 
-    elif system == "Linux":
-        service = home / ".config" / "systemd" / "user" / "claudia-memory.service"
-        if service.exists():
-            import subprocess
-            import time
-            restarted = False
-            try:
-                subprocess.run(["systemctl", "--user", "restart", "claudia-memory"],
-                               capture_output=True, timeout=15)
-                time.sleep(3)
-                try:
-                    resp = urlopen("http://localhost:3848/health", timeout=5)
-                    if "healthy" in resp.read().decode():
-                        restarted = True
-                except (URLError, OSError, TimeoutError):
-                    pass
-            except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
-                pass
-            if restarted:
-                status_msg = _get_status_summary()
-                msg = (
-                    "Memory daemon was stopped and has been auto-restarted. "
-                    "MCP tools not available this session -- restart Claude Code to reconnect. "
-                    "Context files are preserved."
-                )
-                if status_msg:
-                    msg = f"{msg} {status_msg}"
-                print(json.dumps({"additionalContext": msg}))
-                return
-            context_parts.append(
-                "Memory daemon stopped. "
-                "Restart: systemctl --user restart claudia-memory. "
-                "If unavailable, read context/ files directly."
-            )
-        else:
-            context_parts.append(
-                "Memory daemon not installed. Run installer or read context/ files directly."
-            )
+    context_parts.append("Reading context/ files as fallback.")
 
-    elif system == "Windows":
-        # Check Task Scheduler for ClaudiaMemoryDaemon
-        task_status = None
+    # Attach user profile if available
+    profile_path = Path(project_dir) / "context" / "me.md"
+    profile = ""
+    if profile_path.exists():
         try:
-            import subprocess
-            result = subprocess.run(
-                ["powershell", "-Command",
-                 "(Get-ScheduledTask -TaskName 'ClaudiaMemoryDaemon' -ErrorAction SilentlyContinue).State"],
-                capture_output=True, text=True, timeout=5
-            )
-            task_status = result.stdout.strip()
-        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
-            pass
-
-        if task_status:
-            context_parts.append(
-                f"Memory daemon installed (Task Scheduler, state: {task_status}) but not responding. "
-                "Restart via Task Scheduler. If unavailable, read context/ files directly."
-            )
-        else:
-            context_parts.append(
-                "Memory daemon not installed. Run installer or read context/ files directly."
-            )
-
-    # Check for recent crash logs
-    log_path = home / ".claudia" / "daemon-stderr.log"
-    if log_path.exists():
-        try:
-            lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
-            last_lines = lines[-5:-2] if len(lines) > 5 else lines[-3:]
-            if last_lines:
-                log_snippet = " ".join(line.strip() for line in last_lines)
-                context_parts.append(f"Recent daemon log: {log_snippet}")
+            profile = profile_path.read_text(encoding="utf-8")[:2000]
         except OSError:
             pass
 
-    output = " ".join(context_parts)
-    print(json.dumps({"additionalContext": output}))
+    msg = " ".join(context_parts)
+    if profile:
+        msg += f"\n\nUser profile (from context/me.md):\n{profile}"
+
+    print(json.dumps({"additionalContext": msg}))
 
 
 if __name__ == "__main__":
     try:
         check_health()
     except Exception:
-        # Never let the hook crash Claude Code startup
         print(json.dumps({"additionalContext": "Health check encountered an error."}))

--- a/template-v2/.claude/hooks/session-health-check.sh
+++ b/template-v2/.claude/hooks/session-health-check.sh
@@ -1,56 +1,48 @@
 #!/bin/bash
 # Quick health check at session start
-# Returns JSON with additionalContext to inform Claudia of memory system status
-# Provides actionable guidance when daemon is down
+# Runs `claudia system-health` and returns JSON with additionalContext
+# Falls back gracefully if claudia CLI is not installed
 
-# Try curl first, fall back to PowerShell for Windows environments without curl
-HEALTH_OK=false
-if curl -s "http://localhost:3848/health" 2>/dev/null | grep -q "healthy"; then
-  HEALTH_OK=true
-elif command -v powershell.exe &>/dev/null && \
-     powershell.exe -Command "(Invoke-WebRequest -Uri 'http://localhost:3848/health' -UseBasicParsing -TimeoutSec 5).Content" 2>/dev/null | grep -q "healthy"; then
-  HEALTH_OK=true
-fi
+# Try claudia CLI first
+if command -v claudia &>/dev/null; then
+  HEALTH_JSON=$(claudia system-health --project-dir "${CLAUDE_PROJECT_DIR:-.}" 2>/dev/null)
+  EXIT_CODE=$?
 
-if [ "$HEALTH_OK" = true ]; then
-  # Health OK - try to get richer status data from /status endpoint
-  STATUS_JSON=""
-  if command -v curl &>/dev/null; then
-    STATUS_JSON=$(curl -s "http://localhost:3848/status" 2>/dev/null)
-  elif command -v powershell.exe &>/dev/null; then
-    STATUS_JSON=$(powershell.exe -Command "(Invoke-WebRequest -Uri 'http://localhost:3848/status' -UseBasicParsing -TimeoutSec 5).Content" 2>/dev/null)
-  fi
-
-  if [ -n "$STATUS_JSON" ] && command -v python3 &>/dev/null; then
-    STATUS_SUMMARY=$(python3 -c "
+  if [ $EXIT_CODE -eq 0 ] && [ -n "$HEALTH_JSON" ]; then
+    # Parse status summary from system-health JSON output
+    if command -v python3 &>/dev/null; then
+      SUMMARY=$(python3 -c "
 import json, sys
 try:
     d = json.loads(sys.stdin.read())
-    c = d.get('counts', {})
-    parts = [f\"{c.get('memories',0)} memories, {c.get('entities',0)} entities, {c.get('patterns',0)} active patterns.\"]
-    comp = d.get('components', {})
-    es = comp.get('embeddings', 'ok')
-    if es in ('unavailable', 'error'):
-        parts.append(f\"WARNING: Embeddings component is '{es}'. Semantic search may not work.\")
-    if d.get('embedding_model_mismatch', False):
-        parts.append('WARNING: Embedding model mismatch detected. Consider running /diagnose.')
-    print(' '.join(parts))
+    db = d.get('database', {})
+    emb = d.get('embedding', {})
+    parts = []
+    if db.get('memories') is not None:
+        parts.append(f\"{db['memories']} memories, {db.get('entities', 0)} entities.\")
+    if not emb.get('available', False):
+        parts.append('WARNING: Embeddings unavailable. Semantic search will not work.')
+    if parts:
+        print(' '.join(parts))
+    else:
+        print('System ready.')
 except Exception:
-    pass
-" <<< "$STATUS_JSON" 2>/dev/null)
+    print('System ready.')
+" <<< "$HEALTH_JSON" 2>/dev/null)
+      if [ -n "$SUMMARY" ]; then
+        SUMMARY_ESC=$(echo "$SUMMARY" | sed 's/"/\\"/g')
+        echo "{\"additionalContext\": \"Memory system healthy. $SUMMARY_ESC\"}"
+      else
+        echo '{"additionalContext": "Memory system healthy."}'
+      fi
+    else
+      echo '{"additionalContext": "Memory system healthy."}'
+    fi
+    exit 0
   fi
-
-  if [ -n "$STATUS_SUMMARY" ]; then
-    # Escape for JSON
-    STATUS_SUMMARY_ESC=$(echo "$STATUS_SUMMARY" | sed 's/"/\\"/g')
-    echo "{\"additionalContext\": \"Memory system healthy. $STATUS_SUMMARY_ESC\"}"
-  else
-    echo '{"additionalContext": "Memory system healthy."}'
-  fi
-  exit 0
 fi
 
-# Helper: emit JSON for unhealthy-daemon states, appending context/me.md if available
+# claudia CLI not available or failed -- provide guidance
 emit_with_profile() {
   local MSG="$1"
   local PROFILE=""
@@ -71,102 +63,16 @@ print(json.dumps({'additionalContext': msg}))"
   fi
 }
 
-# Daemon is NOT healthy. Figure out why and provide actionable guidance.
-CONTEXT="IMPORTANT: Memory daemon is NOT running. Without it, you lose semantic search, pattern detection, cross-session learning, and proactive predictions. You MUST surface this to the user and offer to help fix it."
-
-# Check if daemon is installed
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  PLIST="$HOME/Library/LaunchAgents/com.claudia.memory.plist"
-  if [ -f "$PLIST" ]; then
-    # Attempt silent auto-restart before falling through to manual suggestion
-    RESTARTED=false
-    if launchctl unload "$PLIST" 2>/dev/null; sleep 0.5; launchctl load "$PLIST" 2>/dev/null; then
-      sleep 3
-      if curl -s "http://localhost:3848/health" 2>/dev/null | grep -q "healthy"; then
-        RESTARTED=true
-      fi
-    fi
-    if [ "$RESTARTED" = true ]; then
-      STATUS_JSON=$(curl -s "http://localhost:3848/status" 2>/dev/null)
-      STATUS_SUMMARY=""
-      if [ -n "$STATUS_JSON" ] && command -v python3 &>/dev/null; then
-        STATUS_SUMMARY=$(python3 -c "
-import json, sys
-try:
-    d = json.loads(sys.stdin.read())
-    c = d.get('counts', {})
-    print(f\"{c.get('memories',0)} memories, {c.get('entities',0)} entities, {c.get('patterns',0)} active patterns.\")
-except Exception:
-    pass
-" <<< "$STATUS_JSON" 2>/dev/null)
-      fi
-      MSG="IMPORTANT: Memory daemon was stopped and has been auto-restarted. However, the memory MCP tools (mcp__claudia-memory__*) are NOT available in this session because MCP tools connect at session start, before the restart happened. Tell the user: 'The memory daemon was just restarted. Please restart Claude Code (close and reopen the window) to reconnect your memory tools. Your context files are preserved.' Do NOT use plugin:episodic-memory as a substitute."
-      if [ -n "$STATUS_SUMMARY" ]; then
-        MSG="$MSG Daemon status: $STATUS_SUMMARY"
-      fi
-      emit_with_profile "$MSG"
-      exit 0
-    fi
-    CONTEXT="$CONTEXT Daemon is installed (LaunchAgent exists) but could not be auto-restarted. Suggest: 'Your memory daemon is stopped. Please run: launchctl load ~/Library/LaunchAgents/com.claudia.memory.plist'"
+# Check if claudia is installed at all
+if ! command -v claudia &>/dev/null; then
+  # Check if it's a local install (npx get-claudia puts it in node_modules/.bin)
+  if [ -f "${CLAUDE_PROJECT_DIR:-}/node_modules/.bin/claudia" ]; then
+    emit_with_profile "Memory CLI found at node_modules/.bin/claudia but not on PATH. Run: export PATH=\"\$PWD/node_modules/.bin:\$PATH\" or use npx claudia."
   else
-    CONTEXT="$CONTEXT Daemon is NOT installed. Suggest: 'The memory daemon hasn\u0027t been set up yet. Want me to install it? I can run the installer for you.'"
+    emit_with_profile "Claudia CLI not found. Memory system unavailable. Install with: npm install -g get-claudia && claudia setup. Reading context/ files as fallback."
   fi
-elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
-  SERVICE="$HOME/.config/systemd/user/claudia-memory.service"
-  if [ -f "$SERVICE" ]; then
-    # Attempt silent auto-restart before falling through to manual suggestion
-    RESTARTED=false
-    if systemctl --user restart claudia-memory 2>/dev/null; then
-      sleep 3
-      if curl -s "http://localhost:3848/health" 2>/dev/null | grep -q "healthy"; then
-        RESTARTED=true
-      fi
-    fi
-    if [ "$RESTARTED" = true ]; then
-      STATUS_JSON=$(curl -s "http://localhost:3848/status" 2>/dev/null)
-      STATUS_SUMMARY=""
-      if [ -n "$STATUS_JSON" ] && command -v python3 &>/dev/null; then
-        STATUS_SUMMARY=$(python3 -c "
-import json, sys
-try:
-    d = json.loads(sys.stdin.read())
-    c = d.get('counts', {})
-    print(f\"{c.get('memories',0)} memories, {c.get('entities',0)} entities, {c.get('patterns',0)} active patterns.\")
-except Exception:
-    pass
-" <<< "$STATUS_JSON" 2>/dev/null)
-      fi
-      MSG="IMPORTANT: Memory daemon was stopped and has been auto-restarted. However, the memory MCP tools (mcp__claudia-memory__*) are NOT available in this session because MCP tools connect at session start, before the restart happened. Tell the user: 'The memory daemon was just restarted. Please restart Claude Code (close and reopen the window) to reconnect your memory tools. Your context files are preserved.' Do NOT use plugin:episodic-memory as a substitute."
-      if [ -n "$STATUS_SUMMARY" ]; then
-        MSG="$MSG Daemon status: $STATUS_SUMMARY"
-      fi
-      emit_with_profile "$MSG"
-      exit 0
-    fi
-    CONTEXT="$CONTEXT Daemon is installed (systemd service exists) but could not be auto-restarted. Suggest: 'Your memory daemon is stopped. Please run: systemctl --user restart claudia-memory'"
-  else
-    CONTEXT="$CONTEXT Daemon is NOT installed. Suggest: 'The memory daemon hasn\u0027t been set up yet. Want me to install it? I can run the installer for you.'"
-  fi
-elif [[ "$OSTYPE" == msys* ]] || [[ "$OSTYPE" == cygwin* ]] || [[ "$OSTYPE" == MINGW* ]]; then
-  # Windows via Git Bash
-  TASK_STATUS=""
-  if command -v powershell.exe &>/dev/null; then
-    TASK_STATUS=$(powershell.exe -Command "(Get-ScheduledTask -TaskName 'ClaudiaMemoryDaemon' -ErrorAction SilentlyContinue).State" 2>/dev/null)
-  fi
-  if [ -n "$TASK_STATUS" ]; then
-    CONTEXT="$CONTEXT Daemon is installed (Task Scheduler, state: $TASK_STATUS). Suggest: 'Your memory daemon is installed but not responding. Want me to check the logs and try restarting it?'"
-  else
-    CONTEXT="$CONTEXT Daemon is NOT installed as a scheduled task. Suggest: 'The memory daemon hasn\u0027t been set up yet. Want me to install it? I can run the installer for you.'"
-  fi
+else
+  emit_with_profile "Claudia CLI found but system-health check failed. Try: claudia setup --project-dir \"${CLAUDE_PROJECT_DIR:-.}\" to diagnose. Reading context/ files as fallback."
 fi
 
-# Check for recent crash logs
-if [ -f "$HOME/.claudia/daemon-stderr.log" ]; then
-  LAST_ERROR=$(tail -5 "$HOME/.claudia/daemon-stderr.log" 2>/dev/null | head -3)
-  if [ -n "$LAST_ERROR" ]; then
-    CONTEXT="$CONTEXT Recent daemon log: $LAST_ERROR"
-  fi
-fi
-
-emit_with_profile "$CONTEXT"
 exit 0

--- a/template-v2/.claude/rules/claudia-principles.md
+++ b/template-v2/.claude/rules/claudia-principles.md
@@ -191,7 +191,7 @@ Each significant action gets confirmed individually. "Go ahead with everything" 
 
 **I always file raw source material before extracting from it.**
 
-When someone shares a transcript, email, document, or any substantive source, I file the original via `memory.document` (operation: "store") before extracting memories. This creates a provenance chain: every fact traces back to where I learned it.
+When someone shares a transcript, email, document, or any substantive source, I file the original via `claudia memory document store` before extracting memories. This creates a provenance chain: every fact traces back to where I learned it.
 
 | Source Type | source_type |
 |-------------|-------------|
@@ -228,7 +228,7 @@ For formal multi-source processing, use `/ingest-sources`. Even without the comm
 - Make moral judgments about users
 - Share information inappropriately
 - Use em dashes (the hallmark of lazy AI writing)
-- Reference internal implementation details in conversation: skill files, rule files, hook names, MCP tool IDs (like `mcp__claudia-memory__*`), or internal system names. These are part of who I am - I follow them silently without narrating them.
+- Reference internal implementation details in conversation: skill files, rule files, hook names, CLI command internals, or internal system names. These are part of who I am - I follow them silently without narrating them.
 
 ---
 

--- a/template-v2/.claude/rules/memory-availability.md
+++ b/template-v2/.claude/rules/memory-availability.md
@@ -4,23 +4,35 @@ This rule is always active and applies to every session. Follow it silently - do
 
 ---
 
-## When Memory Tools Are Missing
+## How Memory Works
 
-If `mcp__claudia-memory__*` tools are **not listed in your available tools**, follow these rules strictly:
+Claudia's memory operates via the `claudia` CLI. All memory operations are invoked through the Bash tool:
+
+```bash
+claudia memory recall "query" --project-dir "$PWD"
+claudia memory save "fact" --project-dir "$PWD"
+claudia memory about "entity name" --project-dir "$PWD"
+```
+
+The CLI outputs JSON that you parse to use in conversation.
+
+## When the CLI Is Not Available
+
+If `claudia` is not on PATH or commands fail:
 
 ### Do NOT substitute with other memory tools
 
-Do not use any of the following as a replacement for missing memory tools:
+Do not use any of the following as a replacement:
 - `plugin:episodic-memory` / `mcp__plugin_episodic-memory_*`
-- Any other cross-session memory or search tool not in the `mcp__claudia-memory__*` family
+- Any other cross-session memory or search tool
 
-These tools access a different, unrelated memory system. Using them gives the user the wrong memories, masks the real connectivity problem, and creates confusion about what Claudia actually knows.
+These tools access a different, unrelated memory system. Using them gives the user the wrong memories, masks the real problem, and creates confusion about what Claudia actually knows.
 
 ### Do tell the user clearly
 
 Say something like:
 
-> "My memory tools aren't connected in this session. The daemon is likely running but the MCP connection isn't registered yet. To fix this, restart Claude Code (close and reopen the window). Your context files are preserved and I can work from those in the meantime."
+> "My memory tools aren't available in this session. The Claudia CLI might not be installed or not on your PATH. To fix this, run: `npm install -g get-claudia && claudia setup`. Your context files are preserved and I can work from those in the meantime."
 
 ### Do fall back to context files only
 
@@ -33,14 +45,21 @@ Read the following files directly as the fallback:
 
 Make clear to the user they are in degraded mode: no semantic search, no pattern detection, no cross-session learning. This is the honest and correct behavior.
 
-### The fix is one action
+### The fix
 
-The user only needs to do one thing: **restart Claude Code**. The daemon auto-restarts via launchctl/systemctl. There is no command to type. Just close and reopen the Claude Code window.
+The user needs to ensure the Claudia CLI is installed and on their PATH:
+
+```bash
+npm install -g get-claudia
+claudia setup
+```
+
+If it's installed but not on PATH (common with npx installs), they can use the full path or add `node_modules/.bin` to their PATH.
 
 ---
 
 ## Background (for context only, not to be surfaced verbatim)
 
-The most common cause of missing memory tools is a registration timing issue, not a crashed daemon. MCP tools register at session initialization. If the daemon restarted after the session started, the tools simply aren't registered yet - the daemon is up, but a Claude Code restart is the only fix.
+The Claudia CLI is a Node.js binary that talks directly to the local SQLite database. There is no daemon process, no HTTP server, no port to check. If the `claudia` command works, memory is available. If it doesn't, the fix is installation, not restarting a process.
 
-Substituting with another memory plugin gives the wrong data from a different system and hides the real problem from the user. The honest answer is always to acknowledge the degraded state and point to the one action that fixes it.
+Substituting with another memory plugin gives the wrong data from a different system and hides the real problem from the user. The honest answer is always to acknowledge the degraded state and point to the installation fix.

--- a/template-v2/.claude/settings.local.json
+++ b/template-v2/.claude/settings.local.json
@@ -23,7 +23,7 @@
           {
             "type": "command",
             "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/pre-compact.py\" 2>/dev/null || python \"$CLAUDE_PROJECT_DIR/.claude/hooks/pre-compact.py\" 2>/dev/null || bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/pre-compact.sh\" 2>/dev/null || echo {\"additionalContext\":\"Pre-compact hook skipped.\"}",
-            "timeout": 5000,
+            "timeout": 10000,
             "statusMessage": "Preserving context..."
           }
         ]

--- a/template-v2/.claude/skills/README.md
+++ b/template-v2/.claude/skills/README.md
@@ -170,7 +170,7 @@ argument-hint: [arg]
 | `follow-up-draft/` | Post-meeting thank-you |
 | `file-document/` | Save documents with provenance |
 | `new-person/` | Create relationship file |
-| `diagnose/` | Check memory daemon health |
+| `diagnose/` | Check Claudia CLI health |
 
 ## Effort Levels
 

--- a/template-v2/.claude/skills/agent-dispatcher.md
+++ b/template-v2/.claude/skills/agent-dispatcher.md
@@ -79,7 +79,7 @@ When multiple skills or agents could handle the same input:
 | User Input | Primary Skill | Why |
 |-----------|--------------|-----|
 | "Research X" | Research Scout (Tier 2) | Needs web search, external data |
-| "What do you know about X?" | `memory.about` directly | Memory lookup, no research needed |
+| "What do you know about X?" | `claudia memory about` directly | Memory lookup, no research needed |
 | "Deep dive on X" | `/deep-context` | Full memory analysis, no web needed |
 | "What am I missing?" | `/what-am-i-missing` | Risk/blind-spot surface, not research |
 

--- a/template-v2/.claude/skills/brain-monitor/SKILL.md
+++ b/template-v2/.claude/skills/brain-monitor/SKILL.md
@@ -17,13 +17,13 @@ Launch the Brain Monitor, a live terminal dashboard showing real-time memory act
 Run this command:
 
 ```bash
-~/.claudia/daemon/venv/bin/python -m claudia_memory --tui
+claudia system-health --project-dir "$PWD" --pretty
 ```
 
-Launch it using the Bash tool with `run_in_background: true` so the Claude session stays responsive.
+This shows a comprehensive system health report. For continuous monitoring, use the Brain Visualizer instead (see `/brain` skill).
 
-If the venv doesn't exist, the memory daemon isn't installed. Tell the user:
-`bash ~/.claudia/daemon/scripts/install.sh`
+If the `claudia` CLI is not found, it's not installed. Tell the user:
+`npm install -g get-claudia && claudia setup`
 
 ---
 
@@ -32,15 +32,12 @@ If the venv doesn't exist, the memory daemon isn't installed. Tell the user:
 ```
 **Brain Monitor** launched.
 
-Live panels updating in real-time:
-- **Neural Pulse** - write/read/link activity (updates every 3s)
-- **Identity** - daemon health + memory stats (updates every 3s)
-- **Constellation** - entity dot grid by type (updates every 10s)
-- **Landscape** - importance distribution + memory types (updates every 10s)
+Showing:
+- **System Health** - CLI status, database stats, embedding model
+- **Memory Stats** - total memories, entities, relationships
+- **Recent Activity** - latest memory operations
 
-**Keys:** Q quit | R refresh | T toggle theme
-
-Changes to your memory system show up as they happen.
+For the full 3D interactive brain visualization, use `/brain`.
 ```
 
 ---

--- a/template-v2/.claude/skills/capture-meeting/SKILL.md
+++ b/template-v2/.claude/skills/capture-meeting/SKILL.md
@@ -31,13 +31,15 @@ User provides one of:
 **Always file the raw transcript/notes FIRST.** This is not optional. Source preservation creates provenance: every extracted fact can trace back to where it came from.
 
 ```
-Call memory.document with operation="store":
-├── content: The FULL raw transcript/notes text (do not summarize)
-├── filename: YYYY-MM-DD-[person]-[topic].md
-├── source_type: "transcript"
-├── summary: Brief 1-line summary of the meeting
-├── about: [list of participant entity names]
+claudia memory document store \
+  --filename "YYYY-MM-DD-[person]-[topic].md" \
+  --source-type "transcript" \
+  --summary "Brief 1-line summary of the meeting" \
+  --about "participant1,participant2" \
+  --project-dir "$PWD" \
+  < content.md
 ```
+(Pipe the FULL raw transcript/notes text via stdin; do not summarize)
 
 The file is automatically routed to the right folder:
 - `people/sarah-chen/transcripts/2026-02-04-kickoff.md`
@@ -73,7 +75,7 @@ The file is automatically routed to the right folder:
    - Confirm entity names match existing entities
    - Adjust or remove any questionable extractions
 
-4. Call memory.batch with the reviewed operations
+4. Call `claudia memory batch --project-dir "$PWD"` with the reviewed operations (via stdin JSON)
 ```
 
 **Fallback: Manual extraction** (use when agent is unavailable or for very short notes)
@@ -103,11 +105,11 @@ The file is automatically routed to the right folder:
 
 ### 4. Link Provenance
 
-After extracting memories (facts, commitments) via memory.batch or memory.remember:
+After extracting memories (facts, commitments) via `claudia memory batch` or `claudia memory save`:
 ```
-Call memory.document again with memory_ids=[...] to link the stored transcript
-to the memories extracted from it. This creates the provenance chain:
-memory -> document -> file on disk.
+Run claudia memory document store --memory-ids "id1,id2,..." --project-dir "$PWD"
+to link the stored transcript to the memories extracted from it. This creates
+the provenance chain: memory -> document -> file on disk.
 ```
 
 Now the user can ask "where did you learn that Sarah prefers async communication?" and you can point to the exact transcript.
@@ -184,7 +186,7 @@ Ask for confirmation on:
 
 ## Quality Checklist
 
-- [ ] **Raw transcript/notes filed** (memory.document called with full content)
+- [ ] **Raw transcript/notes filed** (`claudia memory document store` called with full content)
 - [ ] Memories linked to source document (provenance chain complete)
 - [ ] Every action item has an owner
 - [ ] Every commitment has a deadline (even approximate)

--- a/template-v2/.claude/skills/commitment-detector.md
+++ b/template-v2/.claude/skills/commitment-detector.md
@@ -16,8 +16,8 @@ inputs:
     description: The conversation content containing potential commitment language
 outputs:
   - name: commitment
-    type: memory_ops
-    description: Tracked commitment stored via memory.remember with type 'commitment'
+    type: cli_command
+    description: Tracked commitment stored via `claudia memory save` with type 'commitment'
   - name: context_update
     type: file
     description: Update to context/commitments.md or context/waiting.md
@@ -87,12 +87,17 @@ outputs:
    - Due: Deadline
    - Context: Any relevant notes
 
-3. **Persist to memory immediately** - Call `memory.remember` with:
+3. **Persist to memory immediately** - Run `claudia memory save --project-dir "$PWD"` with:
    - `content`: The commitment text (e.g., "Send proposal to Sarah by Friday")
    - `type`: "commitment"
    - `about`: [person name if applicable]
    - `importance`: 0.9
    - `source`: "conversation"
+
+   Example:
+   ```bash
+   claudia memory save "Send proposal to Sarah by Friday" --type commitment --about "Sarah Chen" --importance 0.9 --project-dir "$PWD"
+   ```
 
    This ensures the commitment survives context compaction and can be recalled semantically. Do not skip this step.
 
@@ -231,7 +236,7 @@ When detecting commitments, identify any explicit or implicit deadlines:
 
 ### How It Works
 
-The memory system automatically extracts and indexes deadlines when storing commitments. When calling `memory.remember` with `type: "commitment"`, include the full commitment text with the deadline language. The system will:
+The memory system automatically extracts and indexes deadlines when storing commitments. When calling `claudia memory save` with `--type commitment`, include the full commitment text with the deadline language. The system will:
 
 1. Parse temporal references from the content
 2. Resolve relative dates to absolute ISO dates

--- a/template-v2/.claude/skills/concierge.md
+++ b/template-v2/.claude/skills/concierge.md
@@ -54,7 +54,7 @@ Before reaching for the web, check what Claudia already knows:
 
 ```
 Research request received:
-├── memory.recall(topic) - Do we already have relevant facts?
+├── claudia memory recall "[topic]" --project-dir "$PWD" - Do we already have relevant facts?
 │   ├── Fresh results (< 7 days) → Use them, offer to refresh
 │   ├── Stale results (> 7 days) → Mention staleness, offer to update
 │   └── No results → Proceed to web research
@@ -106,15 +106,14 @@ After completing research, do two things:
 
 **Report findings** using the format below.
 
-**Store key facts** in memory (if memory tools are available):
+**Store key facts** in memory (if the Claudia CLI is available):
 ```
-memory.remember({
-  content: "[key finding]",
-  type: "fact",
-  source: "web:[URL]",
-  about: ["[relevant entities]"],
-  importance: [0.5-0.8 based on relevance]
-})
+claudia memory save "[key finding]" \
+  --type "fact" \
+  --source "web:[URL]" \
+  --about "[relevant entities]" \
+  --importance 0.7 \
+  --project-dir "$PWD"
 ```
 
 Store facts, not entire pages. Focus on:
@@ -230,7 +229,7 @@ Never silently fail. Never guess what a page says. If the fetch didn't work, say
 ## Integration with Other Skills
 
 ### With Memory Manager
-- Research findings stored via `memory.remember` with `source:web:` prefix
+- Research findings stored via `claudia memory save` with `source:web:` prefix
 - Entity information updated when research reveals new details about known people/companies
 - Relationships updated when research reveals organizational changes
 

--- a/template-v2/.claude/skills/databases/SKILL.md
+++ b/template-v2/.claude/skills/databases/SKILL.md
@@ -44,7 +44,7 @@ ls -la ~/.claudia/demo/*.db 2>/dev/null || echo "NO_DEMO_DBS"
 
 ### Step 2: Get current database
 
-The currently active database is determined by the memory daemon's configuration. Check the MCP config or environment:
+The currently active database is determined by the workspace directory. The CLI hashes the project path to find the right database:
 
 ```bash
 # Check current working directory to compute expected hash
@@ -115,7 +115,7 @@ Format "Last Active" as relative time (e.g., "2h ago", "3d ago", "14d ago").
 
 ## Use
 
-Switch to a different database by modifying the MCP configuration.
+Switch to a different database by setting the `CLAUDIA_DB_OVERRIDE` environment variable.
 
 ### Step 1: Verify database exists
 
@@ -147,7 +147,7 @@ You're about to switch from:
 To:
   **Target:** [target workspace path] ([target hash])
 
-This will modify your `.mcp.json` to set `CLAUDIA_DB_OVERRIDE`.
+This will set `CLAUDIA_DB_OVERRIDE` in your environment.
 **You'll need to restart Claude Code for the change to take effect.**
 
 Proceed? (yes/no)
@@ -155,26 +155,20 @@ Proceed? (yes/no)
 
 ### Step 4: Modify .mcp.json
 
-If confirmed, update the `.mcp.json` file to add `CLAUDIA_DB_OVERRIDE` environment variable:
+If confirmed, update the `.claude/settings.local.json` file to add `CLAUDIA_DB_OVERRIDE` environment variable:
 
-Read the current .mcp.json, then add or update the environment variable for the claudia-memory server:
+Read the current settings, then add or update the environment variable:
 
 ```bash
-# Check if .mcp.json exists
-cat .mcp.json 2>/dev/null || echo "NO_MCP_JSON"
+# Check if settings exist
+cat .claude/settings.local.json 2>/dev/null || echo "NO_SETTINGS"
 ```
 
 Then edit the file to add:
 ```json
 {
-  "mcpServers": {
-    "claudia-memory": {
-      "command": "...",
-      "args": ["..."],
-      "env": {
-        "CLAUDIA_DB_OVERRIDE": "/Users/kamil/.claudia/memory/<hash>.db"
-      }
-    }
+  "env": {
+    "CLAUDIA_DB_OVERRIDE": "/Users/kamil/.claudia/memory/<hash>.db"
   }
 }
 ```
@@ -389,7 +383,7 @@ No Claudia databases found.
 
 This could mean:
 - Claudia hasn't been set up yet (run `npx get-claudia`)
-- The memory daemon hasn't been used yet
+- The Claudia CLI hasn't been used yet
 - Databases are in a non-standard location
 
 Expected locations:

--- a/template-v2/.claude/skills/deep-context/SKILL.md
+++ b/template-v2/.claude/skills/deep-context/SKILL.md
@@ -23,18 +23,18 @@ Execute these memory queries to build a comprehensive picture:
 ### Step 1: Entity Core (limit=50)
 
 ```
-memory.about(entity=[target], limit=50)
+claudia memory about "[target]" --limit 50 --project-dir "$PWD"
 ```
 
-Get everything known about the primary entity: memories, relationships, metadata, recent sessions.
+Get everything known about the primary entity (JSON output): memories, relationships, metadata, recent sessions.
 
 ### Step 2: Semantic Recall (limit=50)
 
 ```
-memory.recall(query=[target + context], limit=50)
+claudia memory recall "[target + context]" --limit 50 --project-dir "$PWD"
 ```
 
-Broad semantic search to catch memories that reference the entity indirectly or discuss related topics.
+Broad semantic search (JSON output) to catch memories that reference the entity indirectly or discuss related topics.
 
 ### Step 3: Connected Entities (limit=10 each, top 3 connections)
 
@@ -42,7 +42,7 @@ From the relationships returned in Step 1, identify the top 3 connected entities
 
 ```
 For each of top 3 related entities:
-  memory.about(entity=[connected], limit=10)
+  claudia memory about "[connected]" --limit 10 --project-dir "$PWD"
 ```
 
 This surfaces the network around the target: who they work with, what those people are doing, shared context.
@@ -50,7 +50,7 @@ This surfaces the network around the target: who they work with, what those peop
 ### Step 4: Temporal Sweep (limit=30)
 
 ```
-memory.recall(query=[target], limit=30, types=["observation", "learning", "commitment"])
+claudia memory recall "[target]" --limit 30 --types "observation,learning,commitment" --project-dir "$PWD"
 ```
 
 Pull time-sensitive items: observations that reveal trends, learnings that inform approach, commitments that need tracking.
@@ -58,7 +58,7 @@ Pull time-sensitive items: observations that reveal trends, learnings that infor
 ### Step 5: Episode Context
 
 ```
-memory.recall(query="session with [target]", limit=20)
+claudia memory recall "session with [target]" --limit 20 --project-dir "$PWD"
 ```
 
 Find session narratives that mention the target to understand the arc of the relationship over time.
@@ -71,7 +71,7 @@ Deduplicate results by memory ID across all steps before synthesis. If a memory 
 
 - **Entity not found**: If Step 1 returns 0 results, return early: "No memories about [entity]. Try a different name or spelling."
 - **Sparse connections**: If fewer than 3 connections exist, pull all available. Skip Step 3 entirely if 0 connections.
-- **Daemon unavailable**: Fall back to reading `context/` files and `people/*.md` directly. Note degraded mode in output.
+- **CLI unavailable**: Fall back to reading `context/` files and `people/*.md` directly. Note degraded mode in output.
 - **Contradictions**: When Step 1 and Step 2 return conflicting data, include both with `origin_type` labels so the user can resolve.
 
 ## Synthesis Format
@@ -124,4 +124,4 @@ After gathering all data, synthesize into this structure:
 
 ## Performance Notes
 
-This skill makes 6-8 memory calls (Steps 1-5 plus up to 3 connected entity lookups). Total memory budget: ~180 max (50+50+30+30+20). Designed for the 1M context window where pulling this many memories is practical without compaction risk. For quick lookups, use `memory.about` directly. Reserve `/deep-context` for when you need the full picture.
+This skill makes 6-8 CLI calls (Steps 1-5 plus up to 3 connected entity lookups). Total memory budget: ~180 max (50+50+30+30+20). Designed for the 1M context window where pulling this many memories is practical without compaction risk. For quick lookups, use `claudia memory about` directly. Reserve `/deep-context` for when you need the full picture.

--- a/template-v2/.claude/skills/diagnose/SKILL.md
+++ b/template-v2/.claude/skills/diagnose/SKILL.md
@@ -1,56 +1,43 @@
 ---
 name: diagnose
-description: Check memory daemon health and troubleshoot connectivity issues. Use when memory tools aren't working, at session start if something seems wrong, or when user asks about memory status.
+description: Check memory system health and troubleshoot connectivity issues. Use when memory commands aren't working, at session start if something seems wrong, or when user asks about memory status.
 effort-level: low
 ---
 
 # Diagnose
 
 System health check for Claudia's memory infrastructure. Run this when:
-- Memory tools seem unavailable
+- Memory commands seem unavailable
 - Session context isn't loading
 - User asks "is my memory working?"
 - Something feels off with persistence
 
 ## Process
 
-### Step 1: Check MCP Tool Availability
+### Step 1: Check CLI Availability
 
-First, verify what memory tools are available:
+First, verify the `claudia` CLI is available:
 
+```bash
+which claudia 2>/dev/null || echo "claudia CLI not found on PATH"
+claudia --version 2>/dev/null || echo "claudia CLI not responding"
 ```
-List your available tools that start with "memory."
-```
 
-**Expected tools:**
-- `memory.session`
-- `memory.remember`
-- `memory.recall`
-- `memory.about`
-- `memory.entities`
-- `memory.relate`
-- `memory.document`
-- `memory.batch`
-- `memory.end_session`
-- `memory.reflections`
-- `memory.consolidate`
-- `memory.system_health`
-
-If NO memory tools appear, the daemon isn't connected via MCP.
+If the `claudia` command is not found, the CLI is not installed or not on PATH.
 
 ### Step 2: Test Memory Connection
 
-If tools are available, try a simple operation:
+If the CLI is available, try a simple operation:
 
-```
-Call memory.session with operation="context" and no other arguments
+```bash
+claudia system-health --project-dir "$PWD"
 ```
 
 **Possible outcomes:**
-- Success with context: Memory system fully operational
+- Success with health data: Memory system fully operational
 - Success but empty: Working but no data yet (new install)
-- Error/timeout: Daemon running but unhealthy
-- Tool not found: MCP connection broken
+- Error/timeout: CLI installed but database or system unhealthy
+- Command not found: CLI not installed
 
 ### Step 2.5: Detect Platform
 
@@ -58,50 +45,39 @@ Run: `uname -s 2>/dev/null || echo Windows`
 
 Use the appropriate command set below (macOS/Linux or Windows).
 
-### Step 3: Check Daemon Process
+### Step 3: Check System Components
 
 **macOS/Linux:**
 
 ```bash
-# Check if daemon process is running (and whether in standalone mode)
-ps aux | grep claudia_memory | grep -v grep
+# Check if claudia CLI is on PATH
+which claudia
 
-# Check health endpoint
-curl -s http://localhost:3848/health || echo "Health endpoint not responding"
-
-# Check recent daemon logs
-tail -20 ~/.claudia/daemon-stderr.log 2>/dev/null || echo "No daemon log found"
+# Check system health
+claudia system-health --project-dir "$PWD"
 
 # Check database exists and has data
 ls -la ~/.claudia/memory/*.db 2>/dev/null || echo "No database found"
 sqlite3 ~/.claudia/memory/claudia.db "SELECT COUNT(*) as memories FROM memories; SELECT COUNT(*) as entities FROM entities;" 2>/dev/null || echo "Cannot query database"
 
-# Check for standalone/MCP conflict (pre-v1.36 issue)
-# If you see a process with --standalone AND no MCP tools, this is the cause
-STANDALONE_RUNNING=$(ps aux | grep "claudia_memory.*standalone" | grep -v grep | wc -l | tr -d ' ')
-echo "Standalone daemon processes: $STANDALONE_RUNNING"
+# Check for embedding model
+ollama list 2>/dev/null | grep minilm || echo "Embedding model not found"
 ```
 
 **Windows (PowerShell):**
 
 ```powershell
-# Check if daemon process is running
-Get-Process python* | Where-Object { $_.CommandLine -like '*claudia_memory*' } 2>$null
-# Fallback if CommandLine isn't available:
-tasklist /FI "IMAGENAME eq python.exe" /V 2>$null | findstr claudia
+# Check if claudia CLI is available
+Get-Command claudia -ErrorAction SilentlyContinue
 
-# Check health endpoint
-try { (Invoke-WebRequest -Uri 'http://localhost:3848/health' -UseBasicParsing -TimeoutSec 5).Content } catch { "Health endpoint not responding" }
-
-# Check recent daemon logs
-Get-Content -Tail 20 "$env:USERPROFILE\.claudia\daemon-stderr.log" 2>$null
+# Check system health
+claudia system-health --project-dir "$PWD"
 
 # Check database exists and has data
 dir "$env:USERPROFILE\.claudia\memory\*.db" 2>$null
-& "$env:USERPROFILE\.claudia\daemon\venv\Scripts\python.exe" -c "import sqlite3; conn = sqlite3.connect('$env:USERPROFILE\.claudia\memory\claudia.db'); print('memories:', conn.execute('SELECT COUNT(*) FROM memories').fetchone()[0]); print('entities:', conn.execute('SELECT COUNT(*) FROM entities').fetchone()[0])"
 
-# Check Task Scheduler status
-Get-ScheduledTask -TaskName 'ClaudiaMemoryDaemon' -ErrorAction SilentlyContinue | Select-Object State
+# Check for embedding model
+ollama list 2>$null | Select-String minilm
 ```
 
 ### Step 4: Report Results
@@ -114,11 +90,10 @@ Format the diagnosis as:
 
 | Component | Status | Details |
 |-----------|--------|---------|
-| MCP Tools | ✅/❌ | [count] tools available |
-| Daemon Process | ✅/❌ | [PID or "not running"] |
-| Health Endpoint | ✅/❌ | [response or error] |
+| Claudia CLI | ✅/❌ | [version or "not found"] |
 | Database | ✅/❌ | [path, size, record counts] |
-| Session Context | ✅/❌ | [loaded or error] |
+| System Health | ✅/❌ | [response or error] |
+| Embedding Model | ✅/❌ | [model name or "not found"] |
 
 **Overall:** [Healthy / Degraded / Not Connected]
 
@@ -128,48 +103,17 @@ Format the diagnosis as:
 
 ## Common Issues and Fixes
 
-### Issue: No memory tools available
+### Issue: Claudia CLI not found
 
-**Cause:** MCP server not configured or not started
+**Cause:** CLI not installed or not on PATH
 
 **Fix:**
-1. Check `.mcp.json` exists and has claudia_memory configured
-2. Restart Claude Code to reload MCP configuration
-3. Check `~/.claudia/daemon-stderr.log` for startup errors
-
-### Issue: Daemon not running
-
-**Cause:** Daemon crashed or was never started
-
-**Fix (macOS/Linux):**
 ```bash
-# Start the daemon manually
-cd ~/.claudia/daemon && source venv/bin/activate
-python -m claudia_memory &
-
-# Or reinstall
-cd [claudia-install-dir] && ./memory-daemon/scripts/install.sh
+npm install -g get-claudia
+claudia setup
 ```
 
-**Fix (Windows PowerShell):**
-```powershell
-# Start the daemon manually
-& "$env:USERPROFILE\.claudia\daemon\venv\Scripts\Activate.ps1"
-python -m claudia_memory
-
-# Or reinstall
-cd [claudia-install-dir]
-powershell -ExecutionPolicy Bypass -File memory-daemon\scripts\install.ps1
-```
-
-### Issue: Health endpoint not responding
-
-**Cause:** Python 3.14 compatibility issue (fixed in v1.21.1+) or daemon crashed after startup
-
-**Fix:**
-1. Check daemon logs: `tail -50 ~/.claudia/daemon-stderr.log`
-2. Look for "RuntimeError" or "event loop" errors
-3. Update to latest Claudia version: `npx get-claudia .`
+If installed via npx but not globally, the binary may not be on PATH. Either install globally or use the full path.
 
 ### Issue: Database empty or missing
 
@@ -179,74 +123,38 @@ powershell -ExecutionPolicy Bypass -File memory-daemon\scripts\install.ps1
 1. If fresh install: Normal, database populates as you use Claudia
 2. If was working before: Check for database file, may need to restore from backup
 
-### Issue: MCP tools available but calls fail
+### Issue: CLI installed but commands fail
 
-**Cause:** Daemon process exists but is unhealthy
+**Cause:** Database corruption, missing dependencies, or version mismatch
 
-**Fix (macOS/Linux):**
-1. Kill the old process: `pkill -f claudia_memory`
-2. Restart Claude Code (this restarts the MCP server)
-3. Check logs for specific errors
+**Fix:**
+1. Update to latest Claudia version: `npm install -g get-claudia`
+2. Run setup again: `claudia setup`
+3. Check Node.js version is 18+: `node --version`
 
-**Fix (Windows):**
-1. Kill the old process: `taskkill /F /FI "IMAGENAME eq python.exe"` (or use Task Manager)
-2. Restart Claude Code (this restarts the MCP server)
-3. Check logs: `Get-Content -Tail 50 "$env:USERPROFILE\.claudia\daemon-stderr.log"`
+### Issue: Embedding model not available
 
-### Issue: Standalone daemon running but MCP tools not registered (pre-v1.36)
+**Cause:** Ollama not installed or model not pulled
 
-**Symptoms:** Daemon process running with `--standalone`, health endpoint healthy, 0 memory tools in Claude Code
-
-**Cause (pre-v1.36):** The LaunchAgent/systemd service starts the daemon with `--standalone`, which acquires a singleton lock. When Claude Code spawns the MCP server, it hits the same lock, sees another daemon running, and exits immediately (exit code 0). Claude Code sees the clean exit and thinks the MCP server started, but no tools register.
-
-**Fix:** Upgrade Claudia to v1.36+ where this conflict is resolved:
+**Fix:**
 ```bash
-npx get-claudia .
-```
-After upgrading, restart Claude Code. The MCP server no longer competes with the standalone daemon's lock.
+# Install Ollama (if not installed)
+# See https://ollama.ai for installation
 
-**If upgrade isn't possible:** Restart Claude Code. If tools still don't register, stop the standalone daemon temporarily:
+# Pull the embedding model
+ollama pull all-minilm:l6-v2
+```
+
+Note: Memory still works without Ollama, but semantic search and vector-based recall will be unavailable. Basic keyword search and explicit lookups still function.
+
+### Issue: Wrong project directory
+
+**Cause:** CLI is using a different project hash than expected
+
+**Fix:**
+Ensure you're passing the correct project directory:
 ```bash
-launchctl unload ~/Library/LaunchAgents/com.claudia.memory.plist
-```
-Then restart Claude Code (which will spawn the MCP server cleanly). Note: background jobs won't run until you reload the LaunchAgent.
-
-### Issue: .mcp.json uses wrong entry point
-
-**Detection:** Check the `args` array in `.mcp.json` for the `claudia-memory` server. If it says `claudia_memory.mcp.server` instead of `claudia_memory`, it bypasses project isolation, the health server, and background scheduling.
-
-**Fix:** Update the args in `.mcp.json` to:
-```json
-"args": ["-m", "claudia_memory", "--project-dir", "${workspaceFolder}"]
-```
-Then restart Claude Code.
-
-## Automatic Recovery
-
-If the daemon needs restart and user confirms:
-
-**macOS/Linux:**
-```bash
-# Kill any existing daemon
-pkill -f claudia_memory 2>/dev/null
-
-# Wait for cleanup
-sleep 2
-
-# Verify it's stopped
-ps aux | grep claudia_memory | grep -v grep && echo "Still running, may need manual kill"
+claudia system-health --project-dir "$PWD"
 ```
 
-**Windows (PowerShell):**
-```powershell
-# Kill any existing daemon
-Get-Process python* -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -like '*claudia_memory*' } | Stop-Process -Force
-
-# Wait for cleanup
-Start-Sleep -Seconds 2
-
-# Verify it's stopped
-Get-Process python* -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -like '*claudia_memory*' }
-```
-
-Then instruct user to restart Claude Code, which will spawn a fresh daemon via MCP.
+The CLI uses the project directory to determine which database to use. Each project gets its own isolated database based on a hash of the directory path.

--- a/template-v2/.claude/skills/file-document/SKILL.md
+++ b/template-v2/.claude/skills/file-document/SKILL.md
@@ -48,13 +48,15 @@ Determine:
 ### 3. File It
 
 ```
-Call memory.document with operation="store":
-├── content: The FULL raw text (never summarize)
-├── filename: Descriptive name
-├── source_type: gmail | transcript | upload | capture
-├── summary: Brief description
-├── about: [entity names]
+claudia memory document store \
+  --filename "Descriptive name" \
+  --source-type "gmail|transcript|upload|capture" \
+  --summary "Brief description" \
+  --about "entity1,entity2" \
+  --project-dir "$PWD" \
+  < content.md
 ```
+(Pipe the FULL raw text via stdin; never summarize)
 
 ### 4. Confirm
 
@@ -70,7 +72,7 @@ The document is now searchable and linked to [entities].
 You can find it later with:
 - "Show me documents about [entity]"
 - "Find the email from [person]"
-- memory.document(operation="search", entity="[name]")
+- claudia memory document search --entity "[name]" --project-dir "$PWD"
 ```
 
 ## Source Types
@@ -107,12 +109,12 @@ If no entity linked:
 ```
 User: "Here's an email from Jim about the partnership terms. Save it."
 
-Call memory.document (operation="store"):
-- content: [full email text]
-- filename: "2026-02-04-jim-ferry-partnership.md"
-- source_type: "gmail"
-- summary: "Jim Ferry re: partnership terms and next steps"
-- about: ["Jim Ferry"]
+claudia memory document store \
+  --filename "2026-02-04-jim-ferry-partnership.md" \
+  --source-type "gmail" \
+  --summary "Jim Ferry re: partnership terms and next steps" \
+  --about "Jim Ferry" \
+  --project-dir "$PWD" < email.md
 
 Response:
 "Filed Jim's email about partnership terms.
@@ -124,12 +126,11 @@ You can find it later by asking about Jim's documents."
 ```
 User: "Here's some info I found about competitor pricing. Keep this."
 
-Call memory.document (operation="store"):
-- content: [research text]
-- filename: "2026-02-04-competitor-pricing-research.md"
-- source_type: "capture"
-- summary: "Competitor pricing analysis notes"
-- about: [] (or project name if relevant)
+claudia memory document store \
+  --filename "2026-02-04-competitor-pricing-research.md" \
+  --source-type "capture" \
+  --summary "Competitor pricing analysis notes" \
+  --project-dir "$PWD" < research.md
 
 Response:
 "Filed your competitor pricing research.
@@ -140,12 +141,12 @@ Saved to: general/documents/2026-02-04-competitor-pricing-research.md"
 ```
 User: "Save this contract from Acme Corp"
 
-Call memory.document (operation="store"):
-- content: [contract text]
-- filename: "2026-02-04-acme-corp-contract.md"
-- source_type: "upload"
-- summary: "Service agreement with Acme Corp"
-- about: ["Acme Corp"]
+claudia memory document store \
+  --filename "2026-02-04-acme-corp-contract.md" \
+  --source-type "upload" \
+  --summary "Service agreement with Acme Corp" \
+  --about "Acme Corp" \
+  --project-dir "$PWD" < contract.md
 
 Response:
 "Filed the Acme Corp contract.
@@ -156,9 +157,9 @@ Saved to: clients/acme-corp/documents/2026-02-04-contract.md"
 
 If you also extract facts from the document:
 
-1. File the document first (get document_id from response)
-2. Extract memories using memory.remember or memory.batch
-3. Call memory.document again with `memory_ids=[...]` to link provenance
+1. File the document first (get document_id from JSON response)
+2. Extract memories using `claudia memory save` or `claudia memory batch`
+3. Call `claudia memory document store --memory-ids "id1,id2,..."` to link provenance
 
 This creates the chain: memory -> document -> file on disk.
 

--- a/template-v2/.claude/skills/fix-duplicates/SKILL.md
+++ b/template-v2/.claude/skills/fix-duplicates/SKILL.md
@@ -19,10 +19,10 @@ Find and merge duplicate entities in the memory system. Duplicates happen when t
 
 ### Step 1: Find Potential Duplicates
 
-Search for entities with similar names using `memory.entities`:
+Search for entities with similar names using `claudia memory entities`:
 
 ```
-memory.entities(operation: "search", query="*", limit=100)
+claudia memory entities search --query "*" --limit 100 --project-dir "$PWD"
 ```
 
 Then compare names using these heuristics:
@@ -56,10 +56,10 @@ Which would you like to merge? (e.g., "merge 1" or "merge all people")
 
 ### Step 3: Execute Merge
 
-When user confirms, call `memory.entities` to merge:
+When user confirms, call `claudia memory entities` to merge:
 
 ```
-memory.entities(operation: "merge", source_id=87, target_id=42, reason="Duplicate detected - same person with name variant")
+claudia memory entities merge --source-id 87 --target-id 42 --reason "Duplicate detected - same person with name variant" --project-dir "$PWD"
 ```
 
 **Important:** Always merge the entity with fewer memories INTO the one with more memories. The target entity keeps its name and attributes; the source's name becomes an alias.

--- a/template-v2/.claude/skills/ingest-sources/SKILL.md
+++ b/template-v2/.claude/skills/ingest-sources/SKILL.md
@@ -61,7 +61,7 @@ Show inventory to user before proceeding. This prevents partial processing.
 ```
 For each source in inventory:
     1. READ the full content
-    2. CALL memory.document with operation="store" immediately (do not skip!)
+    2. CALL `claudia memory document store --project-dir "$PWD"` immediately (do not skip!)
     3. THEN extract entities/facts/commitments
 ```
 
@@ -181,22 +181,24 @@ Files are auto-routed to entity folders:
 - `projects/alpha/emails/...`
 
 **2. Create/update entities:**
-```
-Call memory.batch with entity operations:
+```bash
+claudia memory batch --project-dir "$PWD" <<'EOF'
 [
   { "op": "entity", "name": "Sarah Chen", "type": "person", "description": "Product lead at Acme Corp" },
   { "op": "entity", "name": "Jim Ferry", "type": "person", "description": "Partnership contact" },
   { "op": "entity", "name": "Acme Corp", "type": "organization", "description": "Client company" }
 ]
+EOF
 ```
 
 **3. Store facts and relationships:**
-```
-Call memory.batch with remember and relate operations:
+```bash
+claudia memory batch --project-dir "$PWD" <<'EOF'
 [
   { "op": "remember", "content": "Sarah prefers async communication", "about": ["Sarah Chen"], "importance": 0.7 },
   { "op": "relate", "source": "Sarah Chen", "target": "Acme Corp", "relationship": "works_at", "strength": 0.9 }
 ]
+EOF
 ```
 
 **4. Link provenance:**
@@ -283,7 +285,7 @@ Ask for confirmation on:
 - [ ] **`dedicated_to` field populated** for sources primarily about an entity
 - [ ] **Verification phase completed** with user confirmation
 - [ ] **Dedicated source rule enforced** (2+ dedicated = must appear proportionally)
-- [ ] **All sources filed** via memory.document
+- [ ] **All sources filed** via `claudia memory document store`
 - [ ] **Provenance chain complete** (memories link to documents)
 - [ ] **No entity lost** that had dedicated sources
 

--- a/template-v2/.claude/skills/judgment-awareness.md
+++ b/template-v2/.claude/skills/judgment-awareness.md
@@ -22,7 +22,7 @@ outputs:
 
 # Judgment Awareness Skill
 
-**Triggers:** Activates at session start (after `memory.briefing`) and during any priority conflict, escalation decision, surfacing choice, or delegation routing.
+**Triggers:** Activates at session start (after `claudia memory briefing`) and during any priority conflict, escalation decision, surfacing choice, or delegation routing.
 
 ---
 
@@ -57,7 +57,7 @@ If a judgment rule conflicts with a principle, the principle wins silently.
 
 ### At Session Start
 
-After calling `memory.briefing`, silently check for `context/judgment.yaml`:
+After calling `claudia memory briefing`, silently check for `context/judgment.yaml`:
 
 1. If the file exists, read it and hold the rules in context
 2. If the file does not exist, continue normally (graceful degradation)

--- a/template-v2/.claude/skills/map-connections/SKILL.md
+++ b/template-v2/.claude/skills/map-connections/SKILL.md
@@ -84,22 +84,23 @@ Co-mentioned or contextually implied:
 
 Before creating entities:
 1. Normalize names to canonical form (lowercase, no titles)
-2. Check if entity already exists in memory via `memory.entities` (operation="search")
+2. Check if entity already exists in memory via `claudia memory entities search --project-dir "$PWD"`
 3. Merge new information with existing entity data
 4. Track which entities are new vs updated
 
 ### 5. Store in Memory
 
-Use `memory.batch` for efficiency:
+Use `claudia memory batch` for efficiency:
 
-```
-memory.batch operations=[
-  {op: "entity", name: "Sarah Chen", type: "person", description: "CEO at Acme Corp"},
-  {op: "entity", name: "Acme Corp", type: "organization"},
-  {op: "relate", source: "Sarah Chen", target: "Acme Corp", relationship: "works_at", strength: 1.0, origin_type: "extracted"},
-  {op: "relate", source: "Sarah Chen", target: "Tom Miller", relationship: "works_with", strength: 1.0, origin_type: "inferred"},
-  ...
+```bash
+claudia memory batch --project-dir "$PWD" <<'EOF'
+[
+  {"op": "entity", "name": "Sarah Chen", "type": "person", "description": "CEO at Acme Corp"},
+  {"op": "entity", "name": "Acme Corp", "type": "organization"},
+  {"op": "relate", "source": "Sarah Chen", "target": "Acme Corp", "relationship": "works_at", "strength": 1.0, "origin_type": "extracted"},
+  {"op": "relate", "source": "Sarah Chen", "target": "Tom Miller", "relationship": "works_with", "strength": 1.0, "origin_type": "inferred"}
 ]
+EOF
 ```
 
 For relationship `origin_type`:

--- a/template-v2/.claude/skills/meditate/SKILL.md
+++ b/template-v2/.claude/skills/meditate/SKILL.md
@@ -40,9 +40,9 @@ Silently retrieve:
 - Existing reflections to avoid duplication
 - Active commitments and relationship states
 
-```
-Call memory.reflections to see what already exists
-Call memory.session with operation="context" for recent context (if available)
+```bash
+claudia memory reflections --project-dir "$PWD"    # see what already exists
+claudia memory session context --project-dir "$PWD" # recent context (if available)
 ```
 
 ### Step 2: Generate Reflections
@@ -150,7 +150,7 @@ User responses:
 
 ### Step 5: Store and Close
 
-Call `memory.end_session` with:
+Run `claudia memory end-session --project-dir "$PWD"` with:
 - `narrative`: Brief session summary
 - `reflections`: Array of approved reflections with type, content, and optional about fields
 - Other structured extractions (facts, commitments, entities) as needed
@@ -184,7 +184,7 @@ If only reflections (no rules): "Got it, I'll keep that in mind. See you next ti
 
 ### Storage
 
-Reflections are stored in the memory daemon's `reflections` table with:
+Reflections are stored in the memory system's `reflections` table with:
 - `reflection_type`: observation, pattern, learning, question
 - `content`: The reflection text
 - `about_entity_id`: Optional link to a specific entity
@@ -205,8 +205,8 @@ When similar reflections accumulate over time:
 ### Retrieval
 
 Reflections surface through:
-- `memory.reflections` tool for explicit retrieval
-- `memory.session` (operation="context") includes relevant reflections
+- `claudia memory reflections` CLI command for explicit retrieval
+- `claudia memory session context` includes relevant reflections
 - Semantic search matches reflections to current context
 
 ---
@@ -238,8 +238,8 @@ User: "That thing you learned about me preferring bullet points -
        that's only for technical content, not conversations."
 
 Claudia:
-1. Call memory.reflections with query to find the reflection
-2. Call memory.reflections with action: "update" and new content
+1. Run `claudia memory reflections --query "bullet points" --project-dir "$PWD"` to find the reflection
+2. Run `claudia memory reflections --action update --id <id> --content "..." --project-dir "$PWD"` to update
 3. Confirm: "Updated. I'll keep that distinction in mind."
 ```
 
@@ -248,7 +248,7 @@ User: "Delete the reflection about Monday mornings"
 
 Claudia:
 1. Search for the reflection
-2. Call memory.reflections with action: "delete" and reflection_id
+2. Run `claudia memory reflections --action delete --id <id> --project-dir "$PWD"` to delete
 3. Confirm: "Done, I've removed that."
 ```
 
@@ -256,7 +256,7 @@ Claudia:
 User: "Show me all your reflections about me"
 
 Claudia:
-1. Call memory.reflections with limit: 50
+1. Run `claudia memory reflections --limit 50 --project-dir "$PWD"`
 2. Format nicely with timeline info
 3. Offer to edit or delete any
 ```
@@ -289,9 +289,9 @@ At session start, load high-importance reflections to inform the interaction sty
 
 ---
 
-## Without Memory Daemon
+## Without Claudia CLI
 
-If the memory daemon is unavailable, store reflections in `context/learnings.md`:
+If the Claudia CLI is unavailable, store reflections in `context/learnings.md`:
 
 ```markdown
 ## Reflections

--- a/template-v2/.claude/skills/meeting-prep/SKILL.md
+++ b/template-v2/.claude/skills/meeting-prep/SKILL.md
@@ -36,9 +36,9 @@ From `people/[person].md`:
 
 Query for documents linked to this person:
 ```
-Call memory.document with operation="search", entity=[person name]
+claudia memory document search --entity "[person name]" --project-dir "$PWD"
 ```
-This returns recent transcripts, emails, and files involving the person. Include the most relevant (up to 3) in the briefing with their summaries.
+This returns recent transcripts, emails, and files involving the person (JSON output). Include the most relevant (up to 3) in the briefing with their summaries.
 
 Also check:
 - Last meeting notes (if any)

--- a/template-v2/.claude/skills/memory-audit/SKILL.md
+++ b/template-v2/.claude/skills/memory-audit/SKILL.md
@@ -23,10 +23,11 @@ When run without arguments, produce a system-level overview of everything in mem
 Query the memory system for aggregate counts:
 
 ```
-Call memory.entities with operation="search" and a broad query ("*" or "") to get total entity count.
-Call memory.recall with compact=true, limit=1 to estimate memory volume.
-Call memory.document with operation="search" (no filters) to count documents.
+claudia memory entities search --query "*" --project-dir "$PWD"
+claudia memory recall "*" --compact --limit 1 --project-dir "$PWD"
+claudia memory document search --project-dir "$PWD"
 ```
+Parse the JSON output from each command to get counts.
 
 Display:
 ```
@@ -44,9 +45,9 @@ Display:
 ### 2. People (Top 10 by Importance)
 
 ```
-Call memory.entities with operation="search", types=["person"], limit=10
+claudia memory entities search --types "person" --limit 10 --project-dir "$PWD"
 For each person:
-  Call memory.about to get memory count, last mentioned, key facts
+  claudia memory about "[person name]" --project-dir "$PWD"
 ```
 
 Display as a table:
@@ -62,21 +63,22 @@ Display as a table:
 
 Same pattern with types=["project"]:
 ```
-Call memory.entities with operation="search", types=["project"], limit=10
+claudia memory entities search --types "project" --limit 10 --project-dir "$PWD"
 ```
 
 ### 4. Active Patterns
 
 ```
-Call memory.session with operation="context" to get active patterns and insights
+claudia memory session context --project-dir "$PWD"
 ```
 
 ### 5. Provenance Sample
 
 Pick the 3 most recent high-importance memories and trace them:
 ```
-Call memory.recall with compact=true, limit=3
-For each result, call memory.provenance with operation="trace" to get full provenance
+claudia memory recall "*" --compact --limit 3 --project-dir "$PWD"
+For each result, run:
+  claudia memory provenance trace --memory-id "[id]" --project-dir "$PWD"
 ```
 
 Display:
@@ -99,7 +101,7 @@ When run with an entity name (e.g., `/memory-audit Sarah Chen`):
 ### 1. Profile
 
 ```
-Call memory.about with the entity name
+claudia memory about "[entity name]" --project-dir "$PWD"
 ```
 
 Display:
@@ -115,7 +117,7 @@ Display:
 
 ### 2. All Memories (grouped by type)
 
-From the memory.about response, group memories:
+From the `claudia memory about` JSON response, group memories:
 ```
 ### Facts (N)
 - [content] (importance: X, created: date)
@@ -137,7 +139,7 @@ From the memory.about response, group memories:
 ### 4. Linked Documents
 
 ```
-Call memory.document with operation="search", entity=[entity name]
+claudia memory document search --entity "[entity name]" --project-dir "$PWD"
 ```
 
 Display:
@@ -150,7 +152,7 @@ Display:
 
 For each commitment or high-importance memory (importance > 0.7):
 ```
-Call memory.provenance with operation="trace" for the memory ID
+claudia memory provenance trace --memory-id "[memory ID]" --project-dir "$PWD"
 ```
 
 Display:

--- a/template-v2/.claude/skills/memory-health/SKILL.md
+++ b/template-v2/.claude/skills/memory-health/SKILL.md
@@ -19,10 +19,10 @@ Provide a dashboard view of the memory system's health, including entity counts,
 
 ### Step 1: Gather Statistics
 
-Use `memory.session` to get current system state:
+Use the Claudia CLI to get current system state:
 
-```
-memory.session(operation="context", scope="full")
+```bash
+claudia memory session context --scope full --project-dir "$PWD"
 ```
 
 This returns entity counts, memory counts, relationship counts, and predictions.

--- a/template-v2/.claude/skills/memory-manager.md
+++ b/template-v2/.claude/skills/memory-manager.md
@@ -1,6 +1,6 @@
 ---
 name: memory-manager
-description: Handle cross-session persistence using the enhanced memory system (MCP) with fallback to markdown files.
+description: Handle cross-session persistence using the Claudia CLI with fallback to markdown files.
 user-invocable: false
 invocation: proactive
 effort-level: medium
@@ -9,6 +9,31 @@ effort-level: medium
 # Memory Manager Skill
 
 **Triggers:** Session start (load) and session end (save).
+
+---
+
+## CLI Command Reference
+
+All memory operations use the `claudia` CLI via the Bash tool. Every command outputs JSON.
+
+| Operation | CLI Command |
+|-----------|-------------|
+| Save a memory | `claudia memory save "content" --type fact --importance 0.8 --person "Name"` |
+| Recall/search | `claudia memory recall "query" --limit 10` |
+| Entity context | `claudia memory about "entity name"` |
+| Create entity | `claudia memory entities create "Name" --type person` |
+| Relate entities | `claudia memory relate --source "A" --target "B" --type works_with` |
+| Batch operations | `claudia memory batch --file ops.json` |
+| Buffer turn | `claudia memory session buffer --user-content "..." --assistant-content "..."` |
+| End session | `claudia memory end-session --summary "..." --narrative "..."` |
+| File document | `claudia memory document store ./file.md --source-type transcript --about "Name"` |
+| Correct memory | `claudia memory modify correct <id> "correction text"` |
+| Invalidate | `claudia memory modify invalidate <id>` |
+| Briefing | `claudia memory briefing` |
+| Reflections | `claudia memory reflections --save "learning text" --type observation` |
+| Consolidate | `claudia memory consolidate` |
+
+All commands accept `--project-dir "$PWD"` to specify the workspace.
 
 ---
 
@@ -21,19 +46,19 @@ These are non-negotiable. Violating them defeats the purpose of the memory syste
 When processing source material (transcripts, emails, documents):
 
 1. **Check for duplicates** (by source_type + source_ref)
-2. **File it first** via `memory.document` (operation: "store") with full raw content
+2. **File it first** via `claudia memory document store` with full raw content
 3. **Ask user about extraction** (don't auto-extract)
-4. If user says extract: use Document Processor agent (Haiku) for longer content, or extract manually for short notes. Review agent output before storing via `memory.batch`.
+4. If user says extract: use Document Processor agent (Haiku) for longer content, or extract manually for short notes. Review agent output before storing via `claudia memory batch`.
 
-**If you find yourself reading source documents** without calling `memory.document` (operation: "store") for each one, **STOP and fix it**. File first, then ask if extraction should happen now or later.
+**If you find yourself reading source documents** without running `claudia memory document store` for each one, **STOP and fix it**. File first, then ask if extraction should happen now or later.
 
-### 2. Verify Memory Tools at Session Start
+### 2. Verify Memory CLI at Session Start
 
-Before greeting, check that `memory.*` tools are in your available tools. If missing, follow the `memory-availability` rule (never silently fall back).
+Before greeting, verify the `claudia` CLI is available by running `claudia system-health --project-dir "$PWD"`. If unavailable, follow the `memory-availability` rule (never silently fall back).
 
 ### 3. Buffer Turns During Sessions
 
-Call `memory.session` (operation: "buffer") for each meaningful exchange. This ensures nothing is lost if the session ends abruptly.
+Run `claudia memory session buffer` for each meaningful exchange. This ensures nothing is lost if the session ends abruptly.
 
 ### 4. Trust North Star: Origin Tracking
 
@@ -88,13 +113,13 @@ Before creating a new person or project file:
 
 When looking for information about a person or topic:
 
-1. `memory.about("[entity name]")` - single call, returns all memories + relationships + recent session narratives
+1. `claudia memory about "entity name"` - single call, returns all memories + relationships + recent session narratives
 2. If no results, check if `people/[name].md` exists - single file read
 3. If neither has it, it's unknown. Tell the user and ask if they have source material.
 4. **Last resort:** `episodic-memory__search` (cross-workspace conversation history). Only use this when Claudia's own memory and local files have nothing, and the information might exist in a prior Claude Code conversation from another workspace.
 
 Do NOT:
-- Call both `memory.recall` AND `memory.about` for the same entity (about is the targeted lookup, recall is for broad searches)
+- Call both `claudia memory recall` AND `claudia memory about` for the same entity (about is the targeted lookup, recall is for broad searches)
 - Search episodic memory for information that should be in Claudia's memory
 - Jump to episodic-memory search before exhausting Claudia's own memory system
 - Parse raw `.jsonl` session logs. The cost-to-recovery ratio is poor and it rarely succeeds. If data was lost during context compaction, ask the user for the source material (Granola notes, email, recording).
@@ -105,10 +130,10 @@ Do NOT:
 
 Avoid redundant memory calls within a session:
 
-- **Session-local awareness:** If you already called `memory.about` for an entity in this session, do not call it again. Use the results you already have.
-- **Recall dedup:** Do not call `memory.recall` with a query that overlaps an entity you already fetched with `memory.about`. The about call already returned that entity's full context.
-- **File-vs-memory rule:** If you just read a person file (`people/[name].md`), do not also call `memory.about` for the same person unless you need memories not in the file (e.g., cross-project context or recent session narratives).
-- **Batch preference:** When you need context on multiple entities at once, prefer `memory.batch` over sequential `memory.about` calls.
+- **Session-local awareness:** If you already ran `claudia memory about` for an entity in this session, do not call it again. Use the results you already have.
+- **Recall dedup:** Do not run `claudia memory recall` with a query that overlaps an entity you already fetched with `claudia memory about`. The about call already returned that entity's full context.
+- **File-vs-memory rule:** If you just read a person file (`people/[name].md`), do not also run `claudia memory about` for the same person unless you need memories not in the file (e.g., cross-project context or recent session narratives).
+- **Batch preference:** When you need context on multiple entities at once, prefer `claudia memory batch` over sequential about calls.
 - **Skip search when context is fresh:** If the user just told you something in this conversation, remember it directly. Don't search memory for what was just said.
 
 ---
@@ -119,16 +144,16 @@ When the enhanced memory system is available:
 
 ### 0. Catch Up on Unsummarized Sessions
 
-Call `memory.session` (operation: "unsummarized"). For each result, review buffered turns, write a retroactive narrative, extract structured facts/commitments/entities, and call `memory.end_session` to finalize. Note in the narrative that it was "Reconstructed from N buffered turns from [date]".
+Run `claudia memory session unsummarized`. For each result, review buffered turns, write a retroactive narrative, extract structured facts/commitments/entities, and run `claudia memory end-session` to finalize. Note in the narrative that it was "Reconstructed from N buffered turns from [date]".
 
 ### 1. Minimal Startup (2 calls max)
 
 1. Read `context/me.md` (for greeting personalization)
-2. Call `memory.briefing` (~500 tokens of aggregate context: commitments, cooling, unread, predictions)
+2. Run `claudia memory briefing` (~500 tokens of aggregate context: commitments, cooling, unread, predictions)
 
-Pull full context on-demand via `memory.recall` / `memory.about` during conversation. Do NOT read learnings.md, patterns.md, commitments.md, or waiting.md at startup (they duplicate the memory database).
+Pull full context on-demand via `claudia memory recall` / `claudia memory about` during conversation. Do NOT read learnings.md, patterns.md, commitments.md, or waiting.md at startup (they duplicate the memory database).
 
-**Fallback:** If `memory.briefing` unavailable, use `memory.temporal` (operation: "morning").
+**Fallback:** If briefing unavailable, use `claudia memory temporal morning`.
 
 ### 2. Session Start (Markdown Fallback)
 
@@ -144,10 +169,10 @@ After each meaningful exchange, buffer the turn for later summarization:
 
 ```
 After each substantive turn:
-└── Call memory.session (operation: "buffer") with:
-    ├── user_content: What the user said (summarized if very long)
-    ├── assistant_content: What I said (key points, not full response)
-    └── episode_id: Reuse the ID from the first buffer call
+└── Run claudia memory session buffer with:
+    ├── --user-content "What the user said (summarized if very long)"
+    ├── --assistant-content "What I said (key points, not full response)"
+    └── --episode-id (Reuse the ID from the first buffer call)
 ```
 
 **What counts as "meaningful":**
@@ -161,11 +186,11 @@ After each substantive turn:
 - Pure tool output with no discussion
 - Trivial back-and-forth
 
-The first `memory.session` (operation: "buffer") call creates an episode and returns an `episode_id`. Reuse that ID for all subsequent turns in the session.
+The first `claudia memory session buffer` call creates an episode and returns an `episode_id`. Reuse that ID for all subsequent turns in the session.
 
 ### Immediate Memory (Still Active)
 
-For high-importance items, still call `memory.remember` immediately in addition to buffering:
+For high-importance items, still run `claudia memory save` immediately in addition to buffering:
 - Explicit commitments ("I'll send the proposal by Friday")
 - Critical facts the user explicitly asks you to remember
 - Urgent relationship updates
@@ -182,7 +207,7 @@ Think of it like taking notes during a meeting versus trying to remember everyth
 
 #### Commitments: Store Them Immediately
 
-When someone makes a promise (the user, or someone they're telling you about), that's too important to buffer. Call `memory.remember` right away with:
+When someone makes a promise (the user, or someone they're telling you about), that's too important to buffer. Run `claudia memory save` right away with:
 - `type`: "commitment"
 - `importance`: 0.9 (commitments matter)
 - `about`: whoever made the promise
@@ -194,7 +219,7 @@ Then add it to `context/commitments.md`. Two places is better than zero. If cont
 
 First time a name comes up, just note it mentally. No action needed.
 
-Second time they're mentioned with real context (their role, what they're working on, how they connect to others), that's your signal to call `memory.entities` (operation: "create").
+Second time they're mentioned with real context (their role, what they're working on, how they connect to others), that's your signal to run `claudia memory entities create`.
 
 A casual name-drop doesn't need a database entry. A person who matters to the conversation does.
 
@@ -205,16 +230,16 @@ The threshold is "meaningful context":
 
 #### Relationships: Capture the Connections
 
-When you hear language like "Sarah works with Mike" or "they're our client," capture that silently with `memory.relate`. Don't announce it, just do it. These connections are exactly what the memory system is for.
+When you hear language like "Sarah works with Mike" or "they're our client," capture that silently with `claudia memory relate`. Don't announce it, just do it. These connections are exactly what the memory system is for.
 
 | When you hear... | Call... |
 |------------------|---------|
-| "X works with Y" | `memory.relate(X, Y, "works_with")` |
-| "X reports to Y" | `memory.relate(X, Y, "reports_to")` |
-| "X is Y's manager" | `memory.relate(Y, X, "reports_to")` |
-| "X is our client" | `memory.relate(X, user_org, "client_of")` |
-| "X knows Y" | `memory.relate(X, Y, "knows")` |
-| "X introduced me to Y" | `memory.relate(X, Y, "introduced")` |
+| "X works with Y" | `claudia memory relate --source X --target Y --type works_with` |
+| "X reports to Y" | `claudia memory relate --source X --target Y --type reports_to` |
+| "X is Y's manager" | `claudia memory relate --source Y --target X --type reports_to` |
+| "X is our client" | `claudia memory relate --source X --target [user_org] --type client_of` |
+| "X knows Y" | `claudia memory relate --source X --target Y --type knows` |
+| "X introduced me to Y" | `claudia memory relate --source X --target Y --type introduced` |
 
 These relationships are the hidden structure of someone's professional life. Capture them quietly. No need to narrate.
 
@@ -237,10 +262,10 @@ With the 1M context window, compaction happens less frequently, but it can still
 If you see a context compaction advisory, review what you can recover:
 
 1. Review what remains in your context
-2. Call `memory.remember` for any commitments you can piece together
-3. Call `memory.entities` (operation: "create") for people discussed in detail
-4. Call `memory.relate` for relationships mentioned
-5. Call `memory.session` (operation: "buffer") with a summary of recent exchanges
+2. Call `claudia memory save` for any commitments you can piece together
+3. Call `claudia memory entities` (operation: "create") for people discussed in detail
+4. Call `claudia memory relate` for relationships mentioned
+5. Call `claudia memory session` (operation: "buffer") with a summary of recent exchanges
 
 This is triage, not standard practice. The goal is to make proactive capture so habitual that post-compaction recovery rarely matters.
 
@@ -248,37 +273,34 @@ This is triage, not standard practice. The goal is to make proactive capture so 
 
 When a person or project is mentioned:
 ```
-Call memory.entities (operation: "create") to create/update:
-├── name: Entity name
-├── type: person/organization/project
-├── description: What we learned
-└── aliases: Alternative names mentioned
+Run claudia memory entities create to create/update:
+├── "Entity Name" (positional)
+├── --type person/organization/project
+├── --description "What we learned"
 ```
 
 When relationships between entities are mentioned:
 ```
-Call memory.relate:
-├── source: First entity
-├── target: Second entity
-├── relationship: works_with, manages, client_of, etc.
+Run claudia memory relate:
+├── --source "First entity"
+├── --target "Second entity"
+├── --type works_with, manages, client_of, etc.
 ```
 
 ### Batch Mid-Session Operations
 
-When processing a new person, meeting transcript, or topic that requires multiple memory operations (entity + memories + relationships) mid-session, use `memory.batch` to execute them in a single call instead of separate `memory.entities`, `memory.remember`, and `memory.relate` calls.
+When processing a new person, meeting transcript, or topic that requires multiple memory operations (entity + memories + relationships) mid-session, use `claudia memory batch` to execute them in a single call instead of separate `claudia memory entities`, `claudia memory save`, and `claudia memory relate` calls.
 
-```
-memory.batch({
-  operations: [
-    { op: "entity", name: "Kris Krisko", type: "person", description: "..." },
-    { op: "remember", content: "...", about: ["Kris Krisko"], type: "fact", importance: 0.8 },
-    { op: "remember", content: "...", about: ["Kris Krisko", "Beemok"], type: "observation", importance: 0.7 },
-    { op: "relate", source: "Kamil Banc", target: "Kris Krisko", relationship: "potential_partner", strength: 0.5 }
-  ]
-})
+```bash
+echo '[
+  {"op":"entity","name":"Kris Krisko","type":"person","description":"..."},
+  {"op":"remember","content":"...","about":["Kris Krisko"],"type":"fact","importance":0.8},
+  {"op":"remember","content":"...","about":["Kris Krisko","Beemok"],"type":"observation","importance":0.7},
+  {"op":"relate","source":"Kamil Banc","target":"Kris Krisko","relationship":"potential_partner","strength":0.5}
+]' | claudia memory batch --project-dir "$PWD"
 ```
 
-Use `memory.batch` for mid-session entity creation (e.g., user pastes meeting notes and you need to store a new person immediately). Use `memory.end_session` for the full session wrap-up. After a batch call, write the person/project file and report using the Session Update format. Do not narrate between operations.
+Use `claudia memory batch` for mid-session entity creation (e.g., user pastes meeting notes and you need to store a new person immediately). Use `claudia memory end-session` for the full session wrap-up. After a batch call, write the person/project file and report using the Session Update format. Do not narrate between operations.
 
 ### Document Filing (Source Preservation)
 
@@ -298,13 +320,11 @@ Use `memory.batch` for mid-session entity creation (e.g., user pastes meeting no
 #### How to File
 
 ```
-Call memory.document (operation: "store") with:
-├── content: The full raw text (do not summarize)
-├── filename: YYYY-MM-DD-[entity]-[topic].md (e.g., "2026-02-04-sarah-chen-kickoff.md")
-├── source_type: "transcript", "gmail", "upload", or "capture"
-├── summary: One-line description of what this is
-├── about: [list of entity names mentioned]
-└── memory_ids: [list of memory IDs if you already extracted memories]
+Run claudia memory document store with:
+├── <file-path> (the document to store)
+├── --source-type "transcript", "gmail", "upload", or "capture"
+├── --summary "One-line description"
+├── --about "entity1,entity2" (entity names mentioned)
 ```
 
 #### The Filing Flow
@@ -315,7 +335,7 @@ Call memory.document (operation: "store") with:
    - If found: "I already have this filed at [path]. Want me to pull up what I extracted?"
    - If not found: Continue to step 2
 
-2. **File immediately** using `memory.document` (operation: "store") with full content
+2. **File immediately** using `claudia memory document store` with full content
    - Do NOT automatically extract in the same turn
 
 3. **Ask about extraction**
@@ -328,7 +348,7 @@ Call memory.document (operation: "store") with:
    - Extract relationships (how they're connected)
    - Extract commitments (promises made)
    - Present findings for user verification before storing
-   - Store verified info via memory.batch
+   - Store verified info via `claudia memory batch`
 
 5. **If user says "later"**
    - Done. User can ask "extract that transcript" anytime later
@@ -372,19 +392,14 @@ Every fact traces back to its source. User can always ask "where did you learn t
 
 ### Enhanced Memory
 
-Before wrapping up, generate a session summary by calling `memory.end_session`:
+Before wrapping up, generate a session summary by calling `claudia memory end-session`:
 
 ```
-Call memory.end_session with:
-├── episode_id: The episode from session buffer calls
-├── narrative: Free-form summary of the session (see below)
-├── facts: Structured facts extracted [{content, type, about, importance}]
-├── commitments: Promises made [{content, about, importance}]
-├── entities: New/updated entities [{name, type, description, aliases}]
-├── relationships: Observed relationships [{source, target, relationship}]
-├── key_topics: Main topics discussed ["topic1", "topic2"]
-└── reflections: Learnings about working with this user (see /meditate skill)
-    [{content, type: observation|pattern|learning|question, about?}]
+Run claudia memory end-session with:
+├── --episode-id (The episode from session buffer calls)
+├── --narrative "Free-form summary of the session (see below)"
+├── --file session-data.json (JSON with facts, entities, relationships, reflections)
+Or pipe JSON to stdin with all structured data.
 ```
 
 **Writing the narrative:**
@@ -437,17 +452,17 @@ Reflections are persistent learnings about working with this user. Unlike memori
 
 ### Applying Reflections
 
-When `memory.briefing` returns active reflections, **apply them silently**. Do NOT announce reflections. They inform behavior invisibly (adjust format/style, anticipate needs).
+When `claudia memory briefing` returns active reflections, **apply them silently**. Do NOT announce reflections. They inform behavior invisibly (adjust format/style, anticipate needs).
 
-**Exception:** Surface reflections if the user explicitly asks ("show me your reflections" / "what have you learned?") via `memory.reflections`.
+**Exception:** Surface reflections if the user explicitly asks ("show me your reflections" / "what have you learned?") via `claudia memory reflections`.
 
 ### Managing Reflections
 
-- **Generate** via `/meditate` skill at session end, or anytime via `memory.end_session` with reflections array
-- **Retrieve** via `memory.reflections` (action: "get")
-- **Edit/Delete** via `memory.reflections` (action: "update"/"delete") when user requests changes
+- **Generate** via `/meditate` skill at session end, or anytime via `claudia memory end-session` with reflections array
+- **Retrieve** via `claudia memory reflections` (action: "get")
+- **Edit/Delete** via `claudia memory reflections` (action: "update"/"delete") when user requests changes
 - **Decay** is very slow (~2 year half-life). Well-confirmed reflections (3+) decay even slower.
-- **Without daemon** reflections go to `context/learnings.md` under a "Reflections" heading.
+- **Without CLI** reflections go to `context/learnings.md` under a "Reflections" heading.
 
 ---
 
@@ -469,11 +484,11 @@ Users can correct mistakes in the memory system through natural language. User c
 ### Correction Flow
 
 1. **Acknowledge immediately**: "Let me fix that."
-2. **Search for the memory**: Use `memory.recall` with the topic
+2. **Search for the memory**: Use `claudia memory recall` with the topic
 3. **Present what you found**: Show the user the memory/memories that might be wrong
 4. **Offer options**:
-   - **Correct**: Update the content, keep the history (use `memory.modify`, operation: "correct")
-   - **Invalidate**: Mark as no longer true (use `memory.modify`, operation: "invalidate")
+   - **Correct**: Update the content, keep the history (use `claudia memory modify`, operation: "correct")
+   - **Invalidate**: Mark as no longer true (use `claudia memory modify`, operation: "invalidate")
    - **No change**: User clarifies it's actually correct
 5. **Confirm action**: "Fixed. I've updated [brief description]."
 
@@ -483,12 +498,10 @@ Users can correct mistakes in the memory system through natural language. User c
 ```
 User: "Actually, Sarah works at Acme now, not TechCorp"
 
-1. Search: memory.recall("Sarah works TechCorp")
+1. Search: `claudia memory recall "Sarah works TechCorp" --project-dir "$PWD"`
 2. Show: "I have a memory that 'Sarah Chen works at TechCorp'. Is this the one?"
 3. User confirms
-4. Call: memory.modify(operation="correct", memory_id=42,
-                       correction="Sarah Chen works at Acme",
-                       reason="User correction: moved companies")
+4. Run: `claudia memory modify correct --memory-id 42 --correction "Sarah Chen works at Acme" --reason "User correction: moved companies" --project-dir "$PWD"`
 5. Respond: "Updated. I now know Sarah works at Acme."
 ```
 
@@ -496,10 +509,10 @@ User: "Actually, Sarah works at Acme now, not TechCorp"
 ```
 User: "That project is cancelled, don't remind me about it"
 
-1. Search: memory.recall("project [name]")
+1. Search: `claudia memory recall "project [name]" --project-dir "$PWD"`
 2. Show: "I have 5 memories about [project]. Want me to mark them all as no longer relevant?"
 3. User confirms
-4. Call: memory.modify (operation: "invalidate") for each, with reason="Project cancelled"
+4. Run: `claudia memory modify invalidate --memory-id [id] --reason "Project cancelled" --project-dir "$PWD"` for each
 5. Respond: "Done. I won't surface those memories anymore."
 ```
 
@@ -510,7 +523,7 @@ User: "John Smith and Jon Smith are the same person"
 1. Search for both entities
 2. Confirm: "I found both. Jon Smith has fewer memories. Should I merge Jon into John?"
 3. User confirms
-4. Call: memory.entities(operation="merge", source_id=87, target_id=42, reason="User confirmed same person")
+4. Run: `claudia memory entities merge --source-id 87 --target-id 42 --reason "User confirmed same person" --project-dir "$PWD"`
 5. Respond: "Merged. All memories about Jon are now linked to John Smith."
 ```
 
@@ -555,7 +568,7 @@ Never persist:
 ### User Control
 
 User can:
-- Ask "What do you know about me?" → Call `memory.recall` with broad query
+- Ask "What do you know about me?" → Call `claudia memory recall` with broad query
 - Ask to forget something → Remove from files/database
 - Request to start fresh → Delete context files/database
 - Review any stored information
@@ -567,7 +580,7 @@ User can:
 ### Crash Safety
 
 **Enhanced Memory:**
-- Every `memory.remember` call is immediately committed to SQLite with WAL mode
+- Every `claudia memory save` call is immediately committed to SQLite with WAL mode
 - Survives terminal close, process kill, system crash
 - No data loss even if session ends abruptly
 
@@ -578,4 +591,4 @@ User can:
 
 ### Health Check
 
-If enhanced memory seems slow or unavailable, check `curl http://localhost:3848/health`. If unhealthy, fall back to markdown and suggest `/diagnose`.
+If memory seems slow or unavailable, run `claudia system-health --project-dir "$PWD"`. If it fails, fall back to markdown and suggest `/diagnose`.

--- a/template-v2/.claude/skills/morning-brief/SKILL.md
+++ b/template-v2/.claude/skills/morning-brief/SKILL.md
@@ -12,14 +12,14 @@ Provide a concise morning brief to start the day with clarity. Surface what matt
 
 ### Enhanced Memory System (if available)
 
-1. **Call `memory.temporal`** (operation: "morning") to get a curated morning digest in a single call:
+1. **Run `claudia memory temporal morning --project-dir "$PWD"`** to get a curated morning digest in a single call:
    - Stale commitments (3+ days old, importance > 0.3)
    - Cooling relationships (people not contacted in 30+ days)
    - Cross-entity connections (people who co-appear but have no explicit relationship)
    - Active predictions and insights
    - Recent activity (72h)
 
-2. **Call `memory.recall`** for specific follow-up queries as needed
+2. **Run `claudia memory recall "query" --project-dir "$PWD"`** for specific follow-up queries as needed
 
 ### Judgment Rules (if available)
 
@@ -37,14 +37,14 @@ Use `context/commitments.md`, `context/waiting.md`, and `people/` files.
 
 ## Temporal Awareness
 
-When enhanced memory is available, use urgency-driven ordering. Call `memory.temporal` to organize the brief by time sensitivity:
+When enhanced memory is available, use urgency-driven ordering. Run `claudia memory temporal` to organize the brief by time sensitivity:
 
 ### Urgency Tiers (in order)
 
-1. **Urgent** (`memory.temporal` with operation: "upcoming", days=2): Overdue commitments + due today + due tomorrow. These lead the brief.
-2. **This Week** (`memory.temporal` with operation: "upcoming", days=7): Remaining commitments due this week.
-3. **Since Last Session** (`memory.temporal` with operation: "since"): New memories, entities, and changes since the last conversation.
-4. **Reconnections** (`memory.graph` with operation: "reconnect"): People trending toward dormancy who need attention, with context (last topic, open commitments).
+1. **Urgent** (`claudia memory temporal upcoming --days 2 --project-dir "$PWD"`): Overdue commitments + due today + due tomorrow. These lead the brief.
+2. **This Week** (`claudia memory temporal upcoming --days 7 --project-dir "$PWD"`): Remaining commitments due this week.
+3. **Since Last Session** (`claudia memory temporal since --project-dir "$PWD"`): New memories, entities, and changes since the last conversation.
+4. **Reconnections** (`claudia memory graph reconnect --project-dir "$PWD"`): People trending toward dormancy who need attention, with context (last topic, open commitments).
 5. **Cooling Relationships**: From pattern detection (existing behavior).
 6. **Reflections**: Active high-importance reflections from `/meditate`.
 
@@ -56,7 +56,7 @@ The brief should be urgency-driven, not category-driven. The old approach said "
 
 ### 1. Predictions First (Enhanced Memory)
 
-If `memory.session` (operation: "context") returns predictions, lead with them:
+If `claudia memory session context --project-dir "$PWD"` returns predictions, lead with them:
 - **Relationship alerts** - "Sarah: no contact in 45 days"
 - **Commitment warnings** - "Proposal deadline was yesterday"
 - **Pattern insights** - "You've mentioned being stretched thin 3 times this week"
@@ -71,14 +71,14 @@ Check for urgent items:
 
 ### 3. Today's Commitments
 
-From `memory.recall` or `context/commitments.md`:
+From `claudia memory recall` or `context/commitments.md`:
 - What's due today
 - What's due this week that needs attention today
 - Any blocked items that need unblocking
 
 ### 4. Relationship Health Dashboard
 
-From `memory.temporal` (morning) relationship health section:
+From `claudia memory temporal morning` relationship health section:
 
 **Dormant relationships by severity:**
 - **30+ days**: Consider reaching out (still warm)
@@ -101,7 +101,7 @@ From predictions or checking `people/` files:
 ### 5. Today's Meetings (if calendar integration available)
 
 For each meeting:
-- Check `memory.about` or `people/` for relevant relationship context
+- Check `claudia memory about "name" --project-dir "$PWD"` or `people/` for relevant relationship context
 - Note any commitments to or from attendees
 - Check waiting items for pending items
 - Suggest 1-2 talking points based on history

--- a/template-v2/.claude/skills/relationship-tracker.md
+++ b/template-v2/.claude/skills/relationship-tracker.md
@@ -151,7 +151,7 @@ Track where relationships are in their development:
 
 When the user mentions wanting to connect with someone new or reach a specific person/organization:
 
-1. **Proactively check the graph** using `memory.graph` (operation: "path") BEFORE the user asks
+1. **Proactively check the graph** using `claudia memory graph path` BEFORE the user asks
 2. **If a path exists**, share it: "By the way, you're connected to [target] through [intermediate contacts]"
 3. **If no direct path**, check if any existing contacts work at the same organization or in the same industry
 
@@ -164,7 +164,7 @@ When discussing a person, include their contact velocity trend if relevant:
 
 ### Reconnection Context
 
-When surfacing reconnection suggestions (from `memory.graph` with operation: "reconnect"), include:
+When surfacing reconnection suggestions (from `claudia memory graph reconnect`), include:
 - Days since last contact
 - Last topic discussed
 - Any open commitments (especially overdue ones)

--- a/template-v2/.claude/skills/research/SKILL.md
+++ b/template-v2/.claude/skills/research/SKILL.md
@@ -32,7 +32,7 @@ If the topic is clear and narrow, skip this and go straight to work.
 ### 2. Check Memory First
 
 ```
-memory.recall([topic]):
+claudia memory recall "[topic]" --project-dir "$PWD":
 ├── Existing knowledge found -> Surface it
 │   "I have some context on this from [date]:
 │    [summary of stored facts]
@@ -106,7 +106,7 @@ Use whatever tools are available (see Concierge skill for tool detection).
 ### 5. Store and Connect
 
 After presenting findings:
-- Store key facts via `memory.remember` with `source:web:` provenance
+- Store key facts via `claudia memory save` with `source:web:` provenance
 - Update relevant entities if research revealed new information
 - Connect to existing relationships or projects where relevant
 

--- a/template-v2/.claude/skills/skill-index.json
+++ b/template-v2/.claude/skills/skill-index.json
@@ -157,10 +157,10 @@
     {
       "name": "diagnose",
       "path": "diagnose/SKILL.md",
-      "description": "Check memory daemon health and troubleshoot connectivity issues",
+      "description": "Check Claudia CLI health and troubleshoot connectivity issues",
       "invocation": "contextual",
       "effort_level": "low",
-      "triggers": ["is my memory working", "diagnose memory", "daemon health", "troubleshoot memory"]
+      "triggers": ["is my memory working", "diagnose memory", "cli health", "troubleshoot memory"]
     },
     {
       "name": "meeting-prep",

--- a/template-v2/.claude/skills/vault-awareness.md
+++ b/template-v2/.claude/skills/vault-awareness.md
@@ -125,12 +125,10 @@ view is color-coded by entity type, and Home.md surfaces what needs attention."
 ```
 
 ### User asks about sync status
-Use the MCP tool:
-```
-Call memory.vault(operation: "status") to check:
-- When the last sync happened
-- How many notes exist in each category
-- The vault path
+Use the CLI command:
+```bash
+claudia vault status --project-dir "$PWD"
+# Returns: when the last sync happened, how many notes exist in each category, the vault path
 ```
 
 ---
@@ -142,8 +140,9 @@ The vault syncs nightly at 3:15 AM (after consolidation), catching all changes f
 
 ### On-Demand
 When the user wants fresh data:
-```
-Call memory.vault(operation: "sync", full: false for incremental, full: true for complete rebuild)
+```bash
+claudia vault sync --project-dir "$PWD"           # incremental sync
+claudia vault sync --full --project-dir "$PWD"     # complete rebuild
 ```
 
 Trigger a sync when:
@@ -163,11 +162,11 @@ Users can request visual dashboards:
 
 | Request | Action |
 |---------|--------|
-| "Show me my relationship map" | `memory.vault(operation: "canvas", canvas_type: "relationship_map")` |
-| "Generate a morning brief canvas" | `memory.vault(operation: "canvas", canvas_type: "morning_brief")` |
-| "Show people connections" | `memory.vault(operation: "canvas", canvas_type: "people_overview")` |
-| "Make a project board for [name]" | `memory.vault(operation: "canvas", canvas_type: "project_board", project_name: "[name]")` |
-| "Update all canvases" | `memory.vault(operation: "canvas", canvas_type: "all")` |
+| "Show me my relationship map" | `claudia vault canvas --type relationship_map --project-dir "$PWD"` |
+| "Generate a morning brief canvas" | `claudia vault canvas --type morning_brief --project-dir "$PWD"` |
+| "Show people connections" | `claudia vault canvas --type people_overview --project-dir "$PWD"` |
+| "Make a project board for [name]" | `claudia vault canvas --type project_board --project-name "[name]" --project-dir "$PWD"` |
+| "Update all canvases" | `claudia vault canvas --type all --project-dir "$PWD"` |
 
 After generating, tell the user where to find it:
 ```
@@ -239,8 +238,8 @@ All imported changes use `origin_type='user_stated'` and `confidence=1.0`. If th
 
 ### Running Import
 
-- **MCP tool:** `memory.vault(operation: "import")` scans for changes and applies them
-- **CLI:** `python3 -m claudia_memory --import-vault`
+- **CLI command:** `claudia vault import --project-dir "$PWD"` scans for changes and applies them
+- **Alternative:** `claudia vault import --project-dir "$PWD"` (same command, explicit path)
 - **Nightly sync** continues as a safety net for anything missed
 
 ### User Guidance
@@ -267,10 +266,10 @@ The `project_hash` is the same 12-char SHA256 used for database paths (`~/.claud
 
 | Issue | Solution |
 |-------|----------|
-| Vault folder empty | Run `memory.vault(operation: "sync", full: true)` or `python3 -m claudia_memory --vault-sync` |
+| Vault folder empty | Run `claudia vault sync --full --project-dir "$PWD"` |
 | Stale data in Obsidian | Trigger an on-demand sync |
-| Graph view shows no connections | Ensure entities have relationships (use `memory.relate`) |
+| Graph view shows no connections | Ensure entities have relationships (use `claudia memory relate`) |
 | Graph all one color | Check `.obsidian/graph.json` exists (created on first sync) |
-| Canvas won't open | Verify `.canvas` is valid JSON, regenerate with `memory.vault(operation: "canvas")` |
-| Vault not updating overnight | Check scheduler is running via `memory.system_health` |
+| Canvas won't open | Verify `.canvas` is valid JSON, regenerate with `claudia vault canvas --project-dir "$PWD"` |
+| Vault not updating overnight | Check scheduler is running via `claudia system-health --project-dir "$PWD"` |
 | Old format after upgrade | Sync will auto-rebuild when format version < 2 |

--- a/template-v2/.mcp.json.example
+++ b/template-v2/.mcp.json.example
@@ -1,14 +1,6 @@
 {
   "mcpServers": {
 
-    "claudia-memory": {
-      "_disabled": true,
-      "command": "~/.claudia/daemon/venv/bin/python",
-      "args": ["-m", "claudia_memory", "--project-dir", "${workspaceFolder}"],
-      "_setup": "Run: ~/.claudia/daemon/scripts/install.sh",
-      "_windows": "On Windows, change command to: %USERPROFILE%\\.claudia\\daemon\\venv\\Scripts\\python.exe"
-    },
-
     "gmail": {
       "_disabled": true,
       "command": "npx",
@@ -32,6 +24,7 @@
       "3. Restart Claude Code",
       "4. Gmail/Calendar will open a browser for you to authenticate with YOUR Google account"
     ],
+    "memory": "Claudia's memory system now uses the `claudia` CLI (via Bash tool), not MCP. No MCP server needed for memory.",
     "security": "Each user authenticates with their own accounts. OAuth tokens are stored locally on your machine, never shared.",
     "not_included": {
       "filesystem": "Claude Code has native Read/Write/Edit tools",

--- a/template-v2/CLAUDE.md
+++ b/template-v2/CLAUDE.md
@@ -80,17 +80,17 @@ Check for `context/me.md` at the start of any session. If it doesn't exist, this
 
 At the start of every session (after confirming `context/me.md` exists):
 
-1. **Check available tools** - Look for `memory.*` tools BEFORE greeting.
-   - If missing: read context files directly (`me.md`, `commitments.md`, etc.), greet, and follow the `memory-availability` rule
+1. **Check memory CLI** - Verify `claudia` is available by running `claudia system-health --project-dir "$PWD"` via Bash tool BEFORE greeting.
+   - If unavailable: read context files directly (`me.md`, `commitments.md`, etc.), greet, and follow the `memory-availability` rule
 2. **Check for updates** - If `context/whats-new.md` exists: read it, mention the update in your greeting, then delete it (`rm context/whats-new.md`)
-3. **Load context** - Call `memory.briefing` for compact session summary (~500 tokens: commitments, cooling relationships, activity, reflections)
-   - If briefing shows alerts (overdue/cooling/unread): call `memory.session op=context budget=brief` for detail
-4. **Catch up** - If briefing mentions unsummarized sessions, generate retroactive summaries via `memory.end_session`
+3. **Load context** - Run `claudia memory briefing --project-dir "$PWD"` for compact session summary (~500 tokens: commitments, cooling relationships, activity, reflections)
+   - If briefing shows alerts (overdue/cooling/unread): run `claudia memory session context --project-dir "$PWD"` for detail
+4. **Catch up** - If briefing mentions unsummarized sessions, generate retroactive summaries via `claudia memory end-session`
 5. **Greet naturally** - Use loaded context, surface urgent items
 
 ### Vault Lookups
 
-See vault-awareness skill for vault file paths, PARA structure, and the MCP-vs-vault decision guide.
+See vault-awareness skill for vault file paths, PARA structure, and the CLI-vs-vault decision guide.
 
 ### Returning User Greetings
 
@@ -280,7 +280,7 @@ I don't just wait for instructions. I actively:
 
 ### 8. Source Preservation
 
-**I always file raw source material before extracting from it.** Transcripts, emails, documents all get filed via `memory.document` (operation: "store") with entity links, creating a provenance chain so every fact traces back to its source. See `claudia-principles.md` for the full filing flow and what gets filed where.
+**I always file raw source material before extracting from it.** Transcripts, emails, documents all get filed via `claudia memory document store` with entity links, creating a provenance chain so every fact traces back to its source. See `claudia-principles.md` for the full filing flow and what gets filed where.
 
 ---
 
@@ -309,13 +309,13 @@ I use proactive, contextual, and explicit skills. See `.claude/skills/README.md`
 
 I adapt to whatever tools are available. When you ask me to do something that needs external access:
 
-1. **Check what MCP tools I have** (you'll see them in my available tools)
+1. **Check what's available** (MCP tools for integrations, `claudia` CLI for memory)
 2. **If I have the capability, use it**
 3. **If I don't, tell you honestly and offer to help you add it**
 
-**Memory system:** My memory daemon is a core capability, not just another integration. It gives me persistent memory with semantic search, pattern detection, and relationship tracking across sessions using a local SQLite database with vector embeddings. When the memory daemon is active, all my other behaviors (commitment tracking, pattern recognition, risk surfacing, relationship context) become significantly more powerful because they draw on accumulated knowledge rather than just the current session.
+**Memory system:** My memory CLI (`claudia`) is a core capability, not just another integration. It gives me persistent memory with semantic search, pattern detection, and relationship tracking across sessions using a local SQLite database with vector embeddings. All memory operations go through `claudia memory <command>` via the Bash tool. When the CLI is available, all my other behaviors (commitment tracking, pattern recognition, risk surfacing, relationship context) become significantly more powerful because they draw on accumulated knowledge rather than just the current session.
 
-**Obsidian vault:** My memory syncs to an Obsidian vault at `~/.claudia/vault/` using a PARA-inspired structure: `Active/` for projects, `Relationships/` for people and organizations, `Reference/` for concepts and locations, `Archive/` for dormant entities. Every entity becomes a markdown note with `[[wikilinks]]`, so Obsidian's graph view acts as a relationship visualizer. My own lookup files (MOC tables, patterns, reflections, sessions) live in `Claudia's Desk/`, keeping the human-facing folders clean. The vault syncs nightly and on-demand via `memory.vault` (operation: "sync"). SQLite remains the source of truth; the vault is a read projection.
+**Obsidian vault:** My memory syncs to an Obsidian vault at `~/.claudia/vault/` using a PARA-inspired structure: `Active/` for projects, `Relationships/` for people and organizations, `Reference/` for concepts and locations, `Archive/` for dormant entities. Every entity becomes a markdown note with `[[wikilinks]]`, so Obsidian's graph view acts as a relationship visualizer. My own lookup files (MOC tables, patterns, reflections, sessions) live in `Claudia's Desk/`, keeping the human-facing folders clean. The vault syncs on-demand via `claudia vault sync`. SQLite remains the source of truth; the vault is a read projection.
 
 **External integrations** (Gmail, Google Calendar, Brave Search) are optional add-ons that extend what I can see and do. I work fully without them. The core value is relationships and context.
 


### PR DESCRIPTION
## Summary

- **Adds `cli/` directory** (21 files, ~14k lines) implementing the full Claudia memory system as Node.js CLI subcommands, replacing the Python MCP daemon
- **Updates all 35 template-v2 files** to reference CLI commands (`claudia memory save`, `claudia memory recall`, etc.) instead of MCP tools (`memory.remember`, `memory.recall`, etc.)
- **Eliminates the #1 source of flakiness**: no more daemon startup bugs, port conflicts, or MCP schema drift

### New CLI Architecture

| Layer | Files | Purpose |
|-------|-------|---------|
| `cli/core/` | 7 files | Database (better-sqlite3 + sqlite-vec), embeddings (Ollama HTTP), config, paths, guards, output, language-model |
| `cli/services/` | 8 files | remember, recall, consolidate, vault-sync, documents, audit, ingest, extraction |
| `cli/commands/` | 5 files | memory (36 subcommands), system, cognitive, vault, setup |
| `cli/index.js` | 1 file | Commander.js entry point |

### Command Mapping (21 MCP tools → CLI)

| MCP Tool | CLI Command |
|----------|-------------|
| `memory.remember` | `claudia memory save` |
| `memory.recall` | `claudia memory recall` |
| `memory.about` | `claudia memory about` |
| `memory.relate` | `claudia memory relate` |
| `memory.batch` | `claudia memory batch` |
| `memory.end_session` | `claudia memory end-session` |
| `memory.system_health` | `claudia system-health` |
| + 14 more | Full parity |

### Template Changes

- Hooks: `session-health-check.sh/py` and `pre-compact.sh/py` rewritten for CLI
- 20+ skill files updated (morning-brief, meditate, diagnose, memory-audit, etc.)
- Rules, agents, and CLAUDE.md all reference CLI invocation pattern
- `.mcp.json.example`: claudia-memory MCP server entry removed

## Test plan

- [ ] `claudia system-health --project-dir .` opens existing DB and reports stats
- [ ] `claudia memory save "test" --project-dir .` stores a memory
- [ ] `claudia memory recall "test" --project-dir .` retrieves it
- [ ] `claudia memory about <entity> --project-dir .` returns entity context
- [ ] Verify zero MCP references remain in template-v2/ (`grep -r "memory\." template-v2/`)
- [ ] Open Claude Code in a workspace and verify hooks call CLI commands
- [ ] Existing Python-created `.db` files are readable by the new CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)