### PR TITLE
fix(mcp): underscore tool names for Claude Desktop compatibility

### DIFF
--- a/.claude/rules/claudia-principles.md
+++ b/.claude/rules/claudia-principles.md
@@ -191,7 +191,7 @@ Each significant action gets confirmed individually. "Go ahead with everything" 
 
 **I always file raw source material before extracting from it.**
 
-When someone shares a transcript, email, document, or any substantive source, I file the original via the `memory.file` MCP tool before extracting memories. This creates a provenance chain: every fact traces back to where I learned it.
+When someone shares a transcript, email, document, or any substantive source, I file the original via the `memory_file` MCP tool before extracting memories. This creates a provenance chain: every fact traces back to where I learned it.
 
 | Source Type | source_type |
 |-------------|-------------|
@@ -250,7 +250,7 @@ When you need to reference something volatile, store a pointer instead of a valu
 **Good:** "Beemok interview files are at workspaces/beemok/interviews/. Count files for current total."
 
 **Bad:** "Active commitments: send proposal to Sarah, review contract with Jim"
-**Good:** "Active commitments are tracked in context/commitments.md and via the `memory.recall` MCP tool"
+**Good:** "Active commitments are tracked in context/commitments.md and via the `memory_recall` MCP tool"
 
 ### The Timestamp Rule
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,14 +80,14 @@ Check for `context/me.md` at the start of any session. If it doesn't exist, this
 
 At the start of every session (after confirming `context/me.md` exists):
 
-1. **Check memory system** - You MUST attempt to call the `memory.briefing` MCP tool as your first action. Three outcomes:
+1. **Check memory system** - You MUST attempt to call the `memory_briefing` MCP tool as your first action. Three outcomes:
    - **Tool responds:** Daemon is healthy. Use its output as session context.
    - **Tool exists but errors:** Daemon started but has an issue. Tell the user, then fall back to context files.
    - **Tool not in your palette:** Daemon didn't start. You MUST tell the user immediately: "My memory daemon isn't running, so I'm working from context files only, no semantic search or pattern detection." Then read context files (`me.md`, `commitments.md`, etc.) and follow the `memory-availability` rule. Do NOT silently fall back.
 2. **Check for updates** - If `context/whats-new.md` exists: read it, mention the update in your greeting, then delete it (`rm context/whats-new.md`)
-3. **Load context** - Call the `memory.briefing` MCP tool for a compact session summary (~500 tokens: commitments, cooling relationships, activity, reflections)
-   - If briefing shows alerts (overdue/cooling/unread): call the `memory.session_context` MCP tool for detail
-4. **Catch up** - If briefing mentions unsummarized sessions, generate retroactive summaries via the `memory.end_session` MCP tool
+3. **Load context** - Call the `memory_briefing` MCP tool for a compact session summary (~500 tokens: commitments, cooling relationships, activity, reflections)
+   - If briefing shows alerts (overdue/cooling/unread): call the `memory_session_context` MCP tool for detail
+4. **Catch up** - If briefing mentions unsummarized sessions, generate retroactive summaries via the `memory_end_session` MCP tool
 5. **Greet naturally** - Use loaded context, surface urgent items
 
 ### Vault Lookups
@@ -282,7 +282,7 @@ I don't just wait for instructions. I actively:
 
 ### 8. Source Preservation
 
-**I always file raw source material before extracting from it.** Transcripts, emails, documents all get filed via the `memory.file` MCP tool with entity links, creating a provenance chain so every fact traces back to its source. See `claudia-principles.md` for the full filing flow and what gets filed where.
+**I always file raw source material before extracting from it.** Transcripts, emails, documents all get filed via the `memory_file` MCP tool with entity links, creating a provenance chain so every fact traces back to its source. See `claudia-principles.md` for the full filing flow and what gets filed where.
 
 ---
 
@@ -315,7 +315,7 @@ I adapt to whatever tools are available. When you ask me to do something that ne
 2. **If I have the capability, use it**
 3. **If I don't, tell you honestly and offer to help you add it**
 
-**Memory system:** My memory is a core capability, not just another integration. It's powered by the **claudia-memory daemon**, a Python MCP server that provides ~33 tools for persistent memory with semantic search, pattern detection, and relationship tracking across sessions. The daemon manages a local SQLite database with vector embeddings. Memory operations use MCP tools (e.g., `memory.recall`, `memory.remember`, `memory.about`) called directly, not CLI commands. The `claudia` npm binary handles only `setup` and `system-health`. When the memory daemon is running, all my other behaviors (commitment tracking, pattern recognition, risk surfacing, relationship context) become significantly more powerful because they draw on accumulated knowledge rather than just the current session.
+**Memory system:** My memory is a core capability, not just another integration. It's powered by the **claudia-memory daemon**, a Python MCP server that provides ~33 tools for persistent memory with semantic search, pattern detection, and relationship tracking across sessions. The daemon manages a local SQLite database with vector embeddings. Memory operations use MCP tools (e.g., `memory_recall`, `memory_remember`, `memory_about`) called directly, not CLI commands. The `claudia` npm binary handles only `setup` and `system-health`. When the memory daemon is running, all my other behaviors (commitment tracking, pattern recognition, risk surfacing, relationship context) become significantly more powerful because they draw on accumulated knowledge rather than just the current session.
 
 **Obsidian vault:** My memory syncs to an Obsidian vault at `~/.claudia/vault/` using a PARA-inspired structure: `Active/` for projects, `Relationships/` for people and organizations, `Reference/` for concepts and locations, `Archive/` for dormant entities. Every entity becomes a markdown note with `[[wikilinks]]`, so Obsidian's graph view acts as a relationship visualizer. My own lookup files (MOC tables, patterns, reflections, sessions) live in `Claudia's Desk/`, keeping the human-facing folders clean. The vault syncs on-demand via `claudia vault sync`. SQLite remains the source of truth; the vault is a read projection.
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -1932,7 +1932,7 @@ ${contextual.map(s => `- **/${s.name}** - ${s.description}`).join('\n')}
 ${explicit.map(s => `- **/${s.name}** - ${s.description}`).join('\n')}
 
 ## Memory System
-Memory operations use MCP tools from the claudia-memory daemon (memory.recall, memory.remember, memory.about, etc.).
+Memory operations use MCP tools from the claudia-memory daemon (memory_recall, memory_remember, memory_about, etc.).
 The daemon provides ~33 tools for semantic search, pattern detection, and relationship tracking.
 See the memory-manager skill for the full tool reference.`;
     } catch {

--- a/memory-daemon/README.md
+++ b/memory-daemon/README.md
@@ -13,7 +13,7 @@ A superhuman memory system for Claudia that:
 ┌─────────────────────────────────────────────────────────────────┐
 │  Claude Code (Terminal)                                         │
 │  - User talks to Claudia                                        │
-│  - Claudia calls memory.* MCP tools automatically              │
+│  - Claudia calls memory_* MCP tools automatically              │
 └─────────────────────────┬───────────────────────────────────────┘
                           │ MCP Protocol
 ┌─────────────────────────▼───────────────────────────────────────┐
@@ -75,14 +75,14 @@ Once installed, Claudia has access to these tools:
 
 | Tool | Description |
 |------|-------------|
-| `memory.remember` | Store facts, preferences, observations |
-| `memory.recall` | Semantic search across all memories |
-| `memory.about` | Get everything known about an entity |
-| `memory.relate` | Create relationships between entities |
-| `memory.predictions` | Get proactive suggestions |
-| `memory.consolidate` | Manual consolidation trigger |
-| `memory.entity` | Create/update entity information |
-| `memory.search_entities` | Search for people, projects, etc. |
+| `memory_remember` | Store facts, preferences, observations |
+| `memory_recall` | Semantic search across all memories |
+| `memory_about` | Get everything known about an entity |
+| `memory_relate` | Create relationships between entities |
+| `memory_predictions` | Get proactive suggestions |
+| `memory_consolidate` | Manual consolidation trigger |
+| `memory_entity` | Create/update entity information |
+| `memory_search_entities` | Search for people, projects, etc. |
 
 ## How It Works
 

--- a/memory-daemon/claudia_memory/daemon/health.py
+++ b/memory-daemon/claudia_memory/daemon/health.py
@@ -290,7 +290,7 @@ class HealthCheckHandler(BaseHTTPRequestHandler):
             self.send_error(500, str(e))
 
     def _send_briefing_response(self):
-        """Send compact session briefing (same data as memory.briefing MCP tool).
+        """Send compact session briefing (same data as memory_briefing MCP tool).
 
         Lets session hooks call briefing data over HTTP before MCP tools register,
         providing a pre-MCP layer in the fallback chain.

--- a/memory-daemon/claudia_memory/daemon/scheduler.py
+++ b/memory-daemon/claudia_memory/daemon/scheduler.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 RELEVANT_TOOL_PREFIXES = {
     "gmail", "google_workspace", "slack", "telegram",
     "SLACK_", "GMAIL_", "NOTION_", "CALENDAR_",
-    "memory.file", "memory.remember",
+    "memory_file", "memory_remember",
 }
 
 COMMITMENT_RE = re.compile(

--- a/memory-daemon/claudia_memory/mcp/server.py
+++ b/memory-daemon/claudia_memory/mcp/server.py
@@ -158,17 +158,17 @@ def _guard_response_size(text: str, tool_name: str) -> str:
 # They return a CallToolResult directly.
 
 
-@_handler("memory.temporal", "memory.upcoming", "memory.since", "memory.timeline", "memory.morning_context")
+@_handler("memory_temporal", "memory_upcoming", "memory_since", "memory_timeline", "memory_morning_context")
 async def _handle_temporal(arguments, db, config, logger, **ctx):
     # Determine operation from merged tool or backward-compat alias
-    name = ctx.get("tool_name", "memory.temporal")
-    if name == "memory.upcoming":
+    name = ctx.get("tool_name", "memory_temporal")
+    if name == "memory_upcoming":
         op = "upcoming"
-    elif name == "memory.since":
+    elif name == "memory_since":
         op = "since"
-    elif name == "memory.timeline":
+    elif name == "memory_timeline":
         op = "timeline"
-    elif name == "memory.morning_context":
+    elif name == "memory_morning_context":
         op = "morning"
     else:
         op = arguments.get("operation", "upcoming")
@@ -240,18 +240,18 @@ async def _handle_temporal(arguments, db, config, logger, **ctx):
         )
 
 
-@_handler("memory.graph", "memory.project_network", "memory.find_path", "memory.network_hubs", "memory.dormant_relationships", "memory.reconnections")
+@_handler("memory_graph", "memory_project_network", "memory_find_path", "memory_network_hubs", "memory_dormant_relationships", "memory_reconnections")
 async def _handle_graph(arguments, db, config, logger, **ctx):
-    name = ctx.get("tool_name", "memory.graph")
-    if name == "memory.project_network":
+    name = ctx.get("tool_name", "memory_graph")
+    if name == "memory_project_network":
         op = "network"
-    elif name == "memory.find_path":
+    elif name == "memory_find_path":
         op = "path"
-    elif name == "memory.network_hubs":
+    elif name == "memory_network_hubs":
         op = "hubs"
-    elif name == "memory.dormant_relationships":
+    elif name == "memory_dormant_relationships":
         op = "dormant"
-    elif name == "memory.reconnections":
+    elif name == "memory_reconnections":
         op = "reconnect"
     else:
         op = arguments.get("operation", "network")
@@ -347,18 +347,18 @@ async def _handle_graph(arguments, db, config, logger, **ctx):
         )
 
 
-@_handler("memory.entities", "memory.entity", "memory.search_entities", "memory.merge_entities", "memory.delete_entity", "memory.entity_overview")
+@_handler("memory_entities", "memory_entity", "memory_search_entities", "memory_merge_entities", "memory_delete_entity", "memory_entity_overview")
 async def _handle_entities(arguments, db, config, logger, **ctx):
-    name = ctx.get("tool_name", "memory.entities")
-    if name == "memory.entity":
+    name = ctx.get("tool_name", "memory_entities")
+    if name == "memory_entity":
         op = "create"
-    elif name == "memory.search_entities":
+    elif name == "memory_search_entities":
         op = "search"
-    elif name == "memory.merge_entities":
+    elif name == "memory_merge_entities":
         op = "merge"
-    elif name == "memory.delete_entity":
+    elif name == "memory_delete_entity":
         op = "delete"
-    elif name == "memory.entity_overview":
+    elif name == "memory_entity_overview":
         op = "overview"
     else:
         op = arguments.get("operation", "search")
@@ -438,16 +438,16 @@ async def _handle_entities(arguments, db, config, logger, **ctx):
         )
 
 
-@_handler("memory.vault", "memory.sync_vault", "memory.vault_status", "memory.generate_canvas", "memory.import_vault_edits")
+@_handler("memory_vault", "memory_sync_vault", "memory_vault_status", "memory_generate_canvas", "memory_import_vault_edits")
 async def _handle_vault(arguments, db, config, logger, **ctx):
-    name = ctx.get("tool_name", "memory.vault")
-    if name == "memory.sync_vault":
+    name = ctx.get("tool_name", "memory_vault")
+    if name == "memory_sync_vault":
         op = "sync"
-    elif name == "memory.vault_status":
+    elif name == "memory_vault_status":
         op = "status"
-    elif name == "memory.generate_canvas":
+    elif name == "memory_generate_canvas":
         op = "canvas"
-    elif name == "memory.import_vault_edits":
+    elif name == "memory_import_vault_edits":
         op = "import"
     else:
         op = arguments.get("operation", "status")
@@ -522,14 +522,14 @@ async def _handle_vault(arguments, db, config, logger, **ctx):
         )
 
 
-@_handler("memory.modify", "memory.correct", "memory.invalidate", "memory.invalidate_relationship")
+@_handler("memory_modify", "memory_correct", "memory_invalidate", "memory_invalidate_relationship")
 async def _handle_modify(arguments, db, config, logger, **ctx):
-    name = ctx.get("tool_name", "memory.modify")
-    if name == "memory.correct":
+    name = ctx.get("tool_name", "memory_modify")
+    if name == "memory_correct":
         op = "correct"
-    elif name == "memory.invalidate":
+    elif name == "memory_invalidate":
         op = "invalidate"
-    elif name == "memory.invalidate_relationship":
+    elif name == "memory_invalidate_relationship":
         op = "invalidate_relationship"
     else:
         op = arguments.get("operation", "correct")
@@ -570,14 +570,14 @@ async def _handle_modify(arguments, db, config, logger, **ctx):
         )
 
 
-@_handler("memory.session", "memory.buffer_turn", "memory.session_context", "memory.unsummarized")
+@_handler("memory_session", "memory_buffer_turn", "memory_session_context", "memory_unsummarized")
 async def _handle_session(arguments, db, config, logger, **ctx):
-    name = ctx.get("tool_name", "memory.session")
-    if name == "memory.buffer_turn":
+    name = ctx.get("tool_name", "memory_session")
+    if name == "memory_buffer_turn":
         op = "buffer"
-    elif name == "memory.session_context":
+    elif name == "memory_session_context":
         op = "context"
-    elif name == "memory.unsummarized":
+    elif name == "memory_unsummarized":
         op = "unsummarized"
     else:
         op = arguments.get("operation", "context")
@@ -614,14 +614,14 @@ async def _handle_session(arguments, db, config, logger, **ctx):
         )
 
 
-@_handler("memory.document", "memory.file", "memory.documents", "memory.purge")
+@_handler("memory_document", "memory_file", "memory_documents", "memory_purge")
 async def _handle_document(arguments, db, config, logger, **ctx):
-    name = ctx.get("tool_name", "memory.document")
-    if name == "memory.file":
+    name = ctx.get("tool_name", "memory_document")
+    if name == "memory_file":
         op = "store"
-    elif name == "memory.documents":
+    elif name == "memory_documents":
         op = "search"
-    elif name == "memory.purge":
+    elif name == "memory_purge":
         op = "purge"
     else:
         op = arguments.get("operation", "search")
@@ -667,12 +667,12 @@ async def _handle_document(arguments, db, config, logger, **ctx):
         )
 
 
-@_handler("memory.provenance", "memory.trace", "memory.audit_history")
+@_handler("memory_provenance", "memory_trace", "memory_audit_history")
 async def _handle_provenance(arguments, db, config, logger, **ctx):
-    name = ctx.get("tool_name", "memory.provenance")
-    if name == "memory.trace":
+    name = ctx.get("tool_name", "memory_provenance")
+    if name == "memory_trace":
         op = "trace"
-    elif name == "memory.audit_history":
+    elif name == "memory_audit_history":
         op = "audit"
     else:
         op = arguments.get("operation", "trace")
@@ -739,11 +739,11 @@ async def _handle_provenance(arguments, db, config, logger, **ctx):
         )
 
 
-@_handler("memory.remember")
+@_handler("memory_remember")
 async def _handle_remember(arguments, db, config, logger, **ctx):
     _coerce_arg(arguments, "about")
     memory_id = remember_fact(
-        content=_require(arguments, "content", "memory.remember"),
+        content=_require(arguments, "content", "memory_remember"),
         memory_type=arguments.get("type", "fact"),
         about_entities=arguments.get("about"),
         importance=arguments.get("importance", 1.0),
@@ -774,7 +774,7 @@ async def _handle_remember(arguments, db, config, logger, **ctx):
     )
 
 
-@_handler("memory.recall")
+@_handler("memory_recall")
 async def _handle_recall(arguments, db, config, logger, **ctx):
     _coerce_arg(arguments, "types")
     _coerce_arg(arguments, "ids")
@@ -802,7 +802,7 @@ async def _handle_recall(arguments, db, config, logger, **ctx):
                 ]
             }
         )
-        response_text = _guard_response_size(response_text, "memory.recall")
+        response_text = _guard_response_size(response_text, "memory_recall")
         return CallToolResult(
             content=[TextContent(type="text", text=response_text)]
         )
@@ -844,7 +844,7 @@ async def _handle_recall(arguments, db, config, logger, **ctx):
                 ]
             }
         )
-        response_text = _guard_response_size(response_text, "memory.recall")
+        response_text = _guard_response_size(response_text, "memory_recall")
         return CallToolResult(
             content=[TextContent(type="text", text=response_text)]
         )
@@ -869,17 +869,17 @@ async def _handle_recall(arguments, db, config, logger, **ctx):
             ]
         }
     )
-    response_text = _guard_response_size(response_text, "memory.recall")
+    response_text = _guard_response_size(response_text, "memory_recall")
     return CallToolResult(
         content=[TextContent(type="text", text=response_text)]
     )
 
 
-@_handler("memory.about")
+@_handler("memory_about")
 async def _handle_about(arguments, db, config, logger, **ctx):
     _coerce_int(arguments, "limit")
     result = recall_about(
-        entity_name=_require(arguments, "entity", "memory.about"),
+        entity_name=_require(arguments, "entity", "memory_about"),
         limit=arguments.get("limit", 20),
         include_historical=arguments.get("include_historical", False),
     )
@@ -901,18 +901,18 @@ async def _handle_about(arguments, db, config, logger, **ctx):
         ]
 
     response_text = json.dumps(result)
-    response_text = _guard_response_size(response_text, "memory.about")
+    response_text = _guard_response_size(response_text, "memory_about")
     return CallToolResult(
         content=[TextContent(type="text", text=response_text)]
     )
 
 
-@_handler("memory.relate")
+@_handler("memory_relate")
 async def _handle_relate(arguments, db, config, logger, **ctx):
     relationship_id = relate_entities(
-        source=_require(arguments, "source", "memory.relate"),
-        target=_require(arguments, "target", "memory.relate"),
-        relationship=_require(arguments, "relationship", "memory.relate"),
+        source=_require(arguments, "source", "memory_relate"),
+        target=_require(arguments, "target", "memory_relate"),
+        relationship=_require(arguments, "relationship", "memory_relate"),
         strength=arguments.get("strength", 1.0),
         valid_at=arguments.get("valid_at"),
         supersedes=arguments.get("supersedes", False),
@@ -929,7 +929,7 @@ async def _handle_relate(arguments, db, config, logger, **ctx):
     )
 
 
-@_handler("memory.consolidate")
+@_handler("memory_consolidate")
 async def _handle_consolidate(arguments, db, config, logger, **ctx):
     result = run_full_consolidation()
     return CallToolResult(
@@ -942,7 +942,7 @@ async def _handle_consolidate(arguments, db, config, logger, **ctx):
     )
 
 
-@_handler("memory.end_session")
+@_handler("memory_end_session")
 async def _handle_end_session(arguments, db, config, logger, **ctx):
     _coerce_int(arguments, "episode_id")
     # Coerce all array fields (LLMs may send JSON strings)
@@ -970,7 +970,7 @@ async def _handle_end_session(arguments, db, config, logger, **ctx):
 
     result = end_session(
         episode_id=episode_id,
-        narrative=_require(arguments, "narrative", "memory.end_session"),
+        narrative=_require(arguments, "narrative", "memory_end_session"),
         facts=arguments.get("facts"),
         commitments=arguments.get("commitments"),
         entities=arguments.get("entities"),
@@ -1003,7 +1003,7 @@ async def _handle_end_session(arguments, db, config, logger, **ctx):
     )
 
 
-@_handler("memory.reflections")
+@_handler("memory_reflections")
 async def _handle_reflections(arguments, db, config, logger, **ctx):
     _coerce_int(arguments, "limit")
     _coerce_int(arguments, "reflection_id")
@@ -1097,7 +1097,7 @@ async def _handle_reflections(arguments, db, config, logger, **ctx):
         )
 
 
-@_handler("memory.batch")
+@_handler("memory_batch")
 async def _handle_batch(arguments, db, config, logger, **ctx):
     _coerce_arg(arguments, "operations")
     operations = arguments.get("operations", [])
@@ -1225,11 +1225,11 @@ async def _handle_ingest(arguments, db, config, logger, **ctx):
     )
 
 
-@_handler("memory.multi_recall")
+@_handler("memory_multi_recall")
 async def _handle_multi_recall(arguments, db, config, logger, **ctx):
     """Execute multiple recall queries in a single call and return deduplicated results.
 
-    This is the compound equivalent of calling memory.recall N times sequentially.
+    This is the compound equivalent of calling memory_recall N times sequentially.
     Saves N-1 model round trips and deduplicates overlapping results server-side.
     """
     _coerce_arg(arguments, "queries")
@@ -1309,11 +1309,11 @@ async def _handle_multi_recall(arguments, db, config, logger, **ctx):
     }
     text = json.dumps(response)
     return CallToolResult(
-        content=[TextContent(type="text", text=_guard_response_size(text, "memory.multi_recall"))]
+        content=[TextContent(type="text", text=_guard_response_size(text, "memory_multi_recall"))]
     )
 
 
-@_handler("memory.deep_context")
+@_handler("memory_deep_context")
 async def _handle_deep_context(arguments, db, config, logger, **ctx):
     """Server-side deep context assembly. Replaces 6-8 sequential MCP calls with one.
 
@@ -1321,7 +1321,7 @@ async def _handle_deep_context(arguments, db, config, logger, **ctx):
     temporal sweep + episode search. Deduplicates by memory ID across all steps.
     Returns a structured JSON object ready for synthesis.
     """
-    target = _require(arguments, "target", "memory.deep_context")
+    target = _require(arguments, "target", "memory_deep_context")
     entity_limit = arguments.get("entity_limit", 50)
     recall_limit = arguments.get("recall_limit", 50)
     connected_limit = arguments.get("connected_limit", 10)
@@ -1488,11 +1488,11 @@ async def _handle_deep_context(arguments, db, config, logger, **ctx):
 
     text = json.dumps(result)
     return CallToolResult(
-        content=[TextContent(type="text", text=_guard_response_size(text, "memory.deep_context"))]
+        content=[TextContent(type="text", text=_guard_response_size(text, "memory_deep_context"))]
     )
 
 
-@_handler("memory.briefing")
+@_handler("memory_briefing")
 async def _handle_briefing(arguments, db, config, logger, **ctx):
     briefing_text = _build_briefing()
     return CallToolResult(
@@ -1505,7 +1505,7 @@ async def _handle_briefing(arguments, db, config, logger, **ctx):
     )
 
 
-@_handler("memory.summary")
+@_handler("memory_summary")
 async def _handle_summary(arguments, db, config, logger, **ctx):
     _coerce_int(arguments, "top_facts_limit")
     entity_names = arguments.get("entities", [])
@@ -1601,7 +1601,7 @@ async def _handle_summary(arguments, db, config, logger, **ctx):
     )
 
 
-@_handler("memory.system_health")
+@_handler("memory_system_health")
 async def _handle_system_health(arguments, db, config, logger, **ctx):
     import urllib.request, urllib.error
     report = None
@@ -1626,7 +1626,7 @@ async def _handle_system_health(arguments, db, config, logger, **ctx):
     )
 
 
-@_handler("memory.backup")
+@_handler("memory_backup")
 async def _handle_backup(arguments, db, config, logger, **ctx):
     import urllib.request, urllib.error
     result = None
@@ -1650,11 +1650,11 @@ async def _handle_backup(arguments, db, config, logger, **ctx):
     )
 
 
-@_handler("memory.project_health")
+@_handler("memory_project_health")
 async def _handle_project_health(arguments, db, config, logger, **ctx):
     _coerce_int(arguments, "days_ahead")
     from ..services.recall import project_relationship_health
-    entity = _require(arguments, "entity", "memory.project_health")
+    entity = _require(arguments, "entity", "memory_project_health")
     days_ahead = arguments.get("days_ahead", 30)
     result = project_relationship_health(entity, days_ahead)
     return CallToolResult(
@@ -1662,13 +1662,13 @@ async def _handle_project_health(arguments, db, config, logger, **ctx):
     )
 
 
-@_handler("memory.lifecycle")
+@_handler("memory_lifecycle")
 async def _handle_lifecycle(arguments, db, config, logger, **ctx):
-    op = _require(arguments, "operation", "memory.lifecycle")
+    op = _require(arguments, "operation", "memory_lifecycle")
 
     if op == "set":
-        fact_id = _require(arguments, "fact_id", "memory.lifecycle")
-        tier = _require(arguments, "tier", "memory.lifecycle")
+        fact_id = _require(arguments, "fact_id", "memory_lifecycle")
+        tier = _require(arguments, "tier", "memory_lifecycle")
         reason = arguments.get("reason", "manual")
         if tier == "sacred":
             db.execute(
@@ -1690,7 +1690,7 @@ async def _handle_lifecycle(arguments, db, config, logger, **ctx):
         )
 
     elif op == "protect":
-        entity_name = _require(arguments, "entity", "memory.lifecycle")
+        entity_name = _require(arguments, "entity", "memory_lifecycle")
         reason = arguments.get("reason", "user-designated")
         canonical = entity_name.strip().lower()
         row = db.execute(
@@ -1709,7 +1709,7 @@ async def _handle_lifecycle(arguments, db, config, logger, **ctx):
         )
 
     elif op == "archive":
-        fact_id = _require(arguments, "fact_id", "memory.lifecycle")
+        fact_id = _require(arguments, "fact_id", "memory_lifecycle")
         db.execute(
             "UPDATE memories SET lifecycle_tier = 'archived', archived_at = datetime('now'), updated_at = datetime('now') WHERE fact_id = ?",
             (fact_id,),
@@ -1719,7 +1719,7 @@ async def _handle_lifecycle(arguments, db, config, logger, **ctx):
         )
 
     elif op == "restore":
-        fact_id = _require(arguments, "fact_id", "memory.lifecycle")
+        fact_id = _require(arguments, "fact_id", "memory_lifecycle")
         db.execute(
             "UPDATE memories SET lifecycle_tier = 'active', archived_at = NULL, updated_at = datetime('now') WHERE fact_id = ?",
             (fact_id,),
@@ -1758,12 +1758,12 @@ async def _handle_lifecycle(arguments, db, config, logger, **ctx):
         )
 
 
-@_handler("memory.context")
+@_handler("memory_context")
 async def _handle_context(arguments, db, config, logger, **ctx):
     from ..services.context_builder import build_context
     _coerce_int(arguments, "token_budget")
     result = build_context(
-        query=_require(arguments, "query", "memory.context"),
+        query=_require(arguments, "query", "memory_context"),
         token_budget=arguments.get("token_budget", 8000),
         include_sacred=arguments.get("include_sacred", True),
         entity=arguments.get("entity"),
@@ -1773,9 +1773,9 @@ async def _handle_context(arguments, db, config, logger, **ctx):
     )
 
 
-@_handler("memory.checkpoint")
+@_handler("memory_checkpoint")
 async def _handle_checkpoint(arguments, db, config, logger, **ctx):
-    op = _require(arguments, "operation", "memory.checkpoint")
+    op = _require(arguments, "operation", "memory_checkpoint")
 
     if op == "save":
         name = arguments.get("name", "manual")
@@ -1819,12 +1819,12 @@ async def _handle_checkpoint(arguments, db, config, logger, **ctx):
         )
 
 
-@_handler("memory.rollback")
+@_handler("memory_rollback")
 async def _handle_rollback(arguments, db, config, logger, **ctx):
-    op = _require(arguments, "operation", "memory.rollback")
+    op = _require(arguments, "operation", "memory_rollback")
 
     if op == "set":
-        ts = _require(arguments, "timestamp", "memory.rollback")
+        ts = _require(arguments, "timestamp", "memory_rollback")
         db.execute(
             "INSERT INTO _meta (key, value, updated_at) VALUES ('view_as_of', ?, datetime('now')) ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = datetime('now')",
             (ts,),
@@ -1864,7 +1864,7 @@ async def list_tools() -> ListToolsResult:
     """List all available memory tools"""
     tools = [
         Tool(
-            name="memory.remember",
+            name="memory_remember",
             title="Store a Memory",
             description="Store information in Claudia's memory. Use for facts, preferences, observations, or learnings about people, projects, or the user.",
             annotations=ToolAnnotations(destructiveHint=False),
@@ -1920,7 +1920,7 @@ async def list_tools() -> ListToolsResult:
             },
         ),
         Tool(
-            name="memory.recall",
+            name="memory_recall",
             title="Search Memory",
             description=(
                 "Search Claudia's memory for relevant information. Uses hybrid vector + full-text "
@@ -1967,7 +1967,7 @@ async def list_tools() -> ListToolsResult:
             },
         ),
         Tool(
-            name="memory.about",
+            name="memory_about",
             title="Get Entity Context",
             description="Get all context about a specific person, project, or entity. Returns memories, relationships, and metadata.",
             annotations=ToolAnnotations(readOnlyHint=True),
@@ -1993,7 +1993,7 @@ async def list_tools() -> ListToolsResult:
             },
         ),
         Tool(
-            name="memory.relate",
+            name="memory_relate",
             title="Create Relationship",
             description="Create or strengthen a relationship between two entities (people, projects, etc.)",
             annotations=ToolAnnotations(destructiveHint=False),
@@ -2041,7 +2041,7 @@ async def list_tools() -> ListToolsResult:
             },
         ),
         Tool(
-            name="memory.consolidate",
+            name="memory_consolidate",
             title="Run Consolidation",
             description="Manually trigger memory consolidation (decay, merging, pattern detection). Usually runs automatically at 3 AM.",
             annotations=ToolAnnotations(destructiveHint=False),
@@ -2051,7 +2051,7 @@ async def list_tools() -> ListToolsResult:
             },
         ),
         Tool(
-            name="memory.end_session",
+            name="memory_end_session",
             title="End Session",
             description=(
                 "Finalize a session with a narrative summary and structured extractions. "
@@ -2222,7 +2222,7 @@ async def list_tools() -> ListToolsResult:
             },
         ),
         Tool(
-            name="memory.reflections",
+            name="memory_reflections",
             title="Manage Reflections",
             description=(
                 "Get or search persistent reflections (observations, patterns, learnings, questions) "
@@ -2273,14 +2273,14 @@ async def list_tools() -> ListToolsResult:
             },
         ),
         Tool(
-            name="memory.batch",
+            name="memory_batch",
             title="Batch Memory Operations",
             description=(
                 "Execute multiple memory operations in a single call. Use this for mid-session "
                 "entity creation when processing a new person, meeting transcript, or topic that "
                 "requires entity creation, multiple memories, and relationships. Much more efficient "
-                "than calling memory.entity, memory.remember, and memory.relate separately. "
-                "For end-of-session summaries, use memory.end_session instead."
+                "than calling memory_entity, memory_remember, and memory_relate separately. "
+                "For end-of-session summaries, use memory_end_session instead."
             ),
             annotations=ToolAnnotations(destructiveHint=False),
             inputSchema={
@@ -2381,11 +2381,11 @@ async def list_tools() -> ListToolsResult:
             },
         ),
         Tool(
-            name="memory.multi_recall",
+            name="memory_multi_recall",
             title="Multi-Query Recall",
             description=(
                 "Execute multiple recall queries in a single call. Returns deduplicated results "
-                "grouped by query. Use instead of calling memory.recall repeatedly when you need "
+                "grouped by query. Use instead of calling memory_recall repeatedly when you need "
                 "to search across several dimensions (e.g., different topics, entity types, or "
                 "time-sensitive items). Saves round trips and deduplicates overlapping results "
                 "server-side. Each query can specify its own limit, types filter, and entity filter."
@@ -2417,7 +2417,7 @@ async def list_tools() -> ListToolsResult:
             },
         ),
         Tool(
-            name="memory.deep_context",
+            name="memory_deep_context",
             title="Deep Context Assembly",
             description=(
                 "Full-context deep analysis in a single call. Executes the complete deep-context "
@@ -2425,7 +2425,7 @@ async def list_tools() -> ListToolsResult:
                 "temporal sweep (observations/learnings/commitments), and episode search. "
                 "Deduplicates by memory ID across all steps. Returns structured JSON ready for "
                 "synthesis. Use for meeting prep, relationship deep dives, or strategic analysis. "
-                "Replaces 6-8 sequential memory.about/memory.recall calls with one compound call."
+                "Replaces 6-8 sequential memory_about/memory_recall calls with one compound call."
             ),
             annotations=ToolAnnotations(readOnlyHint=True),
             inputSchema={
@@ -2470,13 +2470,13 @@ async def list_tools() -> ListToolsResult:
             },
         ),
         Tool(
-            name="memory.briefing",
+            name="memory_briefing",
             title="Compact Briefing",
             description=(
                 "Compact session briefing (~500 tokens). Returns aggregate counts and highlights: "
                 "active commitments, cooling relationships, unread messages, top prediction, "
                 "recent activity. Call at session start instead of loading full context. "
-                "Use memory.recall or memory.about to drill into specifics during conversation."
+                "Use memory_recall or memory_about to drill into specifics during conversation."
             ),
             annotations=ToolAnnotations(readOnlyHint=True),
             inputSchema={
@@ -2521,12 +2521,12 @@ async def list_tools() -> ListToolsResult:
             },
         ),
         Tool(
-            name="memory.summary",
+            name="memory_summary",
             title="Entity Summaries",
             description=(
                 "Get a lightweight summary for one or more entities. Returns name, type, "
                 "importance, memory count, relationship count, last mentioned date, and "
-                "top facts. Cheaper than memory.about for quick overviews."
+                "top facts. Cheaper than memory_about for quick overviews."
             ),
             annotations=ToolAnnotations(readOnlyHint=True),
             inputSchema={
@@ -2547,7 +2547,7 @@ async def list_tools() -> ListToolsResult:
             },
         ),
         Tool(
-            name="memory.system_health",
+            name="memory_system_health",
             title="System Health Check",
             description=(
                 "Get comprehensive system health: schema version, component status, "
@@ -2561,7 +2561,7 @@ async def list_tools() -> ListToolsResult:
             },
         ),
         Tool(
-            name="memory.backup",
+            name="memory_backup",
             title="Trigger Database Backup",
             description=(
                 "Trigger an immediate backup of the memory database. Returns the path "
@@ -2574,7 +2574,7 @@ async def list_tools() -> ListToolsResult:
             },
         ),
         Tool(
-            name="memory.project_health",
+            name="memory_project_health",
             title="Project Health Check",
             description=(
                 "Project when a relationship will go dormant based on contact velocity. "
@@ -2601,7 +2601,7 @@ async def list_tools() -> ListToolsResult:
         ),
         # ── Merged tools (8 composite tools with operation parameter) ──
         Tool(
-            name="memory.temporal",
+            name="memory_temporal",
             title="Temporal Queries",
             description=(
                 "Time-based memory queries: upcoming deadlines, recent changes, entity timelines, "
@@ -2645,7 +2645,7 @@ async def list_tools() -> ListToolsResult:
             },
         ),
         Tool(
-            name="memory.graph",
+            name="memory_graph",
             title="Relationship Graph",
             description=(
                 "Explore the entity relationship graph: project networks, connection paths, "
@@ -2710,7 +2710,7 @@ async def list_tools() -> ListToolsResult:
             },
         ),
         Tool(
-            name="memory.entities",
+            name="memory_entities",
             title="Entity Management",
             description=(
                 "Create, search, merge, delete, or overview entities (people, projects, orgs). "
@@ -2795,7 +2795,7 @@ async def list_tools() -> ListToolsResult:
             },
         ),
         Tool(
-            name="memory.vault",
+            name="memory_vault",
             title="Obsidian Vault",
             description=(
                 "Manage the Obsidian vault integration: sync memory to vault, check status, "
@@ -2831,7 +2831,7 @@ async def list_tools() -> ListToolsResult:
             },
         ),
         Tool(
-            name="memory.modify",
+            name="memory_modify",
             title="Modify Memories & Relationships",
             description=(
                 "Correct, invalidate, or end relationships. "
@@ -2877,7 +2877,7 @@ async def list_tools() -> ListToolsResult:
             },
         ),
         Tool(
-            name="memory.session",
+            name="memory_session",
             title="Session Lifecycle",
             description=(
                 "Session management: buffer turns, load context, or check unsummarized sessions. "
@@ -2920,7 +2920,7 @@ async def list_tools() -> ListToolsResult:
             },
         ),
         Tool(
-            name="memory.document",
+            name="memory_document",
             title="Document Storage",
             description=(
                 "Store or search documents (transcripts, emails, files). "
@@ -2986,7 +2986,7 @@ async def list_tools() -> ListToolsResult:
             },
         ),
         Tool(
-            name="memory.provenance",
+            name="memory_provenance",
             title="Provenance & Audit",
             description=(
                 "Trace memory origins, get full audit trails, or verify hash chain integrity. "
@@ -3022,7 +3022,7 @@ async def list_tools() -> ListToolsResult:
         ),
         # ── Lifecycle / Sacred memory tools ──
         Tool(
-            name="memory.lifecycle",
+            name="memory_lifecycle",
             title="Memory Lifecycle",
             description="Manage memory lifecycle tiers (sacred/active/cooling/archived) and entity close-circle status.",
             inputSchema={
@@ -3058,7 +3058,7 @@ async def list_tools() -> ListToolsResult:
             },
         ),
         Tool(
-            name="memory.context",
+            name="memory_context",
             title="Build Context Window",
             description="Build a token-budgeted context window with sacred facts always included. Uses the Context Relevance Engine (CRE).",
             inputSchema={
@@ -3085,7 +3085,7 @@ async def list_tools() -> ListToolsResult:
             },
         ),
         Tool(
-            name="memory.checkpoint",
+            name="memory_checkpoint",
             title="Database Checkpoints",
             description="Save, list, or restore database checkpoints (labeled backups).",
             inputSchema={
@@ -3105,7 +3105,7 @@ async def list_tools() -> ListToolsResult:
             },
         ),
         Tool(
-            name="memory.rollback",
+            name="memory_rollback",
             title="Temporal Rollback",
             description="Set a temporal view filter so recall only returns memories created before a given timestamp. Non-destructive.",
             inputSchema={
@@ -3507,7 +3507,7 @@ def _build_session_context(token_budget: str = "normal") -> str:
         unsummarized = get_unsummarized_turns()
         if unsummarized:
             sections.append(f"## Unsummarized Sessions ({len(unsummarized)})\n")
-            sections.append("**Action needed:** Generate retroactive summaries using `memory.end_session` for each.\n")
+            sections.append("**Action needed:** Generate retroactive summaries using `memory_end_session` for each.\n")
             for session in unsummarized:
                 ep_id = session.get("episode_id", "?")
                 turn_count = session.get("turn_count", 0)

--- a/memory-daemon/claudia_memory/mcp/server.py
+++ b/memory-daemon/claudia_memory/mcp/server.py
@@ -1855,6 +1855,15 @@ async def _handle_rollback(arguments, db, config, logger, **ctx):
         )
 
 
+# ── Backward compatibility: accept dot-notation names during transition ──
+# Users who haven't updated skills/hooks may still call memory.recall instead
+# of memory_recall. Register aliases so both work. list_tools() only advertises
+# underscore names; these aliases only affect call_tool() dispatch.
+# TODO: Remove after v1.58.0 (2 release cycles)
+_DOT_ALIASES = {k.replace("_", ".", 1): v for k, v in _TOOL_HANDLERS.items()
+                if k.startswith("memory_")}
+_TOOL_HANDLERS.update(_DOT_ALIASES)
+
 # Initialize the MCP server
 server = Server("claudia-memory")
 

--- a/memory-daemon/claudia_memory/services/consolidate.py
+++ b/memory-daemon/claudia_memory/services/consolidate.py
@@ -2613,7 +2613,7 @@ class ConsolidateService:
                 f"Possible duplicate entities: '{candidate['entity_1']['name']}' "
                 f"and '{candidate['entity_2']['name']}' "
                 f"({candidate['similarity']:.0%} similar via {candidate['method']}). "
-                f"Consider merging with memory.merge_entities."
+                f"Consider merging with memory_merge_entities."
             )
             # Check for existing dedupe prediction
             existing = self.db.execute(

--- a/memory-daemon/claudia_memory/services/remember.py
+++ b/memory-daemon/claudia_memory/services/remember.py
@@ -1345,7 +1345,7 @@ class RememberService:
         # Validate episode exists before any DB operations
         episode = self.db.get_one("episodes", where="id = ?", where_params=(episode_id,))
         if not episode:
-            result["error"] = f"Episode {episode_id} not found. Call memory.buffer_turn first to create an episode."
+            result["error"] = f"Episode {episode_id} not found. Call memory_buffer_turn first to create an episode."
             logger.warning(f"end_session called with non-existent episode_id={episode_id}")
             return result
 

--- a/memory-daemon/scripts/diagnose.sh
+++ b/memory-daemon/scripts/diagnose.sh
@@ -171,7 +171,7 @@ echo ""
 if [ $ISSUES_FOUND -eq 0 ]; then
     echo -e "${GREEN}${BOLD}All checks passed!${NC}"
     echo ""
-    echo -e "If memory.* tools still don't appear in Claude Code:"
+    echo -e "If memory_* tools still don't appear in Claude Code:"
     echo ""
     echo -e "  ${YELLOW}${BOLD}→ Close this terminal and run 'claude' in a NEW terminal${NC}"
     echo ""

--- a/memory-daemon/tests/test_session_context.py
+++ b/memory-daemon/tests/test_session_context.py
@@ -106,7 +106,7 @@ class TestSessionContext:
                 assert "Unsummarized Sessions (2)" in result
                 assert "Episode 1" in result
                 assert "Episode 2" in result
-                assert "memory.end_session" in result
+                assert "memory_end_session" in result
         finally:
             db.close()
 

--- a/memory-daemon/tests/test_tool_name_compat.py
+++ b/memory-daemon/tests/test_tool_name_compat.py
@@ -1,0 +1,78 @@
+"""Tests for MCP tool name backward compatibility (dot-notation aliases).
+
+PR #32 renamed tools from memory.xxx to memory_xxx for Claude Desktop compat.
+The alias layer ensures both forms resolve to the same handler during transition.
+"""
+
+import asyncio
+import pytest
+
+
+class TestDotAliasRegistration:
+    """Verify that dot-notation aliases are registered in _TOOL_HANDLERS."""
+
+    def test_dot_aliases_registered(self):
+        """Core alias: memory.recall must resolve to the same handler as memory_recall."""
+        from claudia_memory.mcp.server import _TOOL_HANDLERS
+
+        assert "memory_recall" in _TOOL_HANDLERS, "memory_recall not registered"
+        assert "memory.recall" in _TOOL_HANDLERS, "memory.recall alias not registered"
+        assert _TOOL_HANDLERS["memory.recall"] is _TOOL_HANDLERS["memory_recall"], \
+            "memory.recall and memory_recall must point to the same handler"
+
+    def test_all_memory_tools_have_dot_aliases(self):
+        """Every memory_xxx tool must have a memory.xxx alias."""
+        from claudia_memory.mcp.server import _TOOL_HANDLERS
+
+        underscore_keys = [k for k in _TOOL_HANDLERS if k.startswith("memory_")]
+        assert len(underscore_keys) > 0, "No memory_ tools found"
+
+        for key in underscore_keys:
+            dot_alias = key.replace("_", ".", 1)
+            assert dot_alias in _TOOL_HANDLERS, f"Missing dot alias for {key}: expected {dot_alias}"
+            assert _TOOL_HANDLERS[dot_alias] is _TOOL_HANDLERS[key], \
+                f"{dot_alias} and {key} must point to the same handler"
+
+    def test_cognitive_ingest_unchanged(self):
+        """cognitive.ingest uses dots natively and must NOT get an underscore alias."""
+        from claudia_memory.mcp.server import _TOOL_HANDLERS
+
+        assert "cognitive.ingest" in _TOOL_HANDLERS, "cognitive.ingest should still be registered"
+        assert "cognitive_ingest" not in _TOOL_HANDLERS, \
+            "cognitive_ingest should NOT exist (alias loop must only affect memory_ prefix)"
+
+
+class TestListToolsUnderscore:
+    """Verify list_tools() only advertises underscore names."""
+
+    def test_list_tools_uses_underscore_only(self):
+        """list_tools() must return only underscore names, never dot names."""
+        from claudia_memory.mcp.server import list_tools
+
+        result = asyncio.run(list_tools())
+        tool_names = [t.name for t in result.tools]
+
+        # Sanity: memory_recall should be listed
+        assert "memory_recall" in tool_names, "memory_recall missing from list_tools"
+
+        # No dot-notation names should appear in the advertised list
+        dot_names = [n for n in tool_names if "." in n and n.startswith("memory")]
+        assert dot_names == [], f"list_tools must not advertise dot names: {dot_names}"
+
+
+class TestCallDispatch:
+    """Verify call_tool dispatches for both name forms."""
+
+    def test_dispatch_underscore_name(self):
+        """memory_recall must resolve in the handler registry."""
+        from claudia_memory.mcp.server import _TOOL_HANDLERS
+
+        handler = _TOOL_HANDLERS.get("memory_recall")
+        assert handler is not None, "memory_recall not found in _TOOL_HANDLERS"
+
+    def test_dispatch_dot_name(self):
+        """memory.recall must resolve in the handler registry (backward compat)."""
+        from claudia_memory.mcp.server import _TOOL_HANDLERS
+
+        handler = _TOOL_HANDLERS.get("memory.recall")
+        assert handler is not None, "memory.recall not found in _TOOL_HANDLERS (backward compat broken)"

--- a/template-v2/.claude/hooks/hooks.json
+++ b/template-v2/.claude/hooks/hooks.json
@@ -15,13 +15,13 @@
         "on_missing_me": "trigger_onboarding",
         "memory_verification": {
           "step_1_check_cli": "BEFORE anything else, verify the `claudia` CLI is available by running `claudia system-health --project-dir \"$PWD\"` via Bash tool. This checks that the claudia-memory daemon is configured and responsive. If the command fails or is not found: (1) Do NOT fall back to plugin:episodic-memory, mcp__plugin_episodic-memory_*, or any other memory search tool as a substitute — these give inferior, unrelated results and mask the real problem. (2) Tell the user: 'My memory tools are not available. The claudia-memory daemon may not be running or may not be configured as an MCP server. Check that the daemon is listed in your .mcp.json and that it starts without errors. Your context files are preserved.' (3) Continue with context files only (context/me.md, etc.) until fixed.",
-          "step_2_load_context": "Call the `memory.session_context` MCP tool to get a formatted context block with recent memories, commitments, and unsummarized session alerts. If the MCP tool is not available, the daemon may not be properly configured. Suggest: 'The claudia-memory daemon may need to be configured in .mcp.json. Run claudia system-health for diagnostics.'",
+          "step_2_load_context": "Call the `memory_session_context` MCP tool to get a formatted context block with recent memories, commitments, and unsummarized session alerts. If the MCP tool is not available, the daemon may not be properly configured. Suggest: 'The claudia-memory daemon may need to be configured in .mcp.json. Run claudia system-health for diagnostics.'",
           "fallback": "If memory MCP tools are not available: (1) Do NOT use plugin:episodic-memory or any other memory search tool as a substitute. (2) Tell the user: 'My memory tools are not available. The claudia-memory daemon may not be configured as an MCP server.' (3) Read context files directly (context/me.md, context/commitments.md, context/learnings.md, context/patterns.md, context/waiting.md) as the fallback. Make clear to the user they are in degraded mode with no semantic search or cross-session learning."
         },
         "enhanced_memory": {
-          "context_load": "Call the `memory.session_context` MCP tool to get a formatted context block with recent memories, commitments, and unsummarized session alerts.",
-          "catch_up": "If unsummarized sessions are reported in the context block, review buffered turns and call the `memory.end_session` MCP tool with a retroactive narrative and structured extractions for each.",
-          "recall_context": "Use the loaded context for greeting. For deeper search on specific topics, call the `memory.recall` MCP tool with the relevant query."
+          "context_load": "Call the `memory_session_context` MCP tool to get a formatted context block with recent memories, commitments, and unsummarized session alerts.",
+          "catch_up": "If unsummarized sessions are reported in the context block, review buffered turns and call the `memory_end_session` MCP tool with a retroactive narrative and structured extractions for each.",
+          "recall_context": "Use the loaded context for greeting. For deeper search on specific topics, call the `memory_recall` MCP tool with the relevant query."
         },
         "proactive_surfacing": {
           "description": "Surface urgent items naturally in the greeting. Keep it to a brief mention, not a full report.",
@@ -30,12 +30,12 @@
             {
               "type": "overdue_commitments",
               "description": "Commitments older than 7 days without resolution",
-              "query_hint": "Call the `memory.recall` MCP tool with query about overdue commitments and check dates"
+              "query_hint": "Call the `memory_recall` MCP tool with query about overdue commitments and check dates"
             },
             {
               "type": "cooling_relationships",
               "description": "Important people not mentioned in >30 days",
-              "query_hint": "Call the `memory.search_entities` MCP tool with type: person and check last_mentioned dates"
+              "query_hint": "Call the `memory_search_entities` MCP tool with type: person and check last_mentioned dates"
             }
           ],
           "examples": [
@@ -58,7 +58,7 @@
         ],
         "save_mode": "merge",
         "enhanced_memory": {
-          "summarize": "Call the `memory.end_session` MCP tool with a narrative summary and structured extractions from the session's buffered turns. The narrative should enhance stored information with tone, context, unresolved threads, and nuance that structured fields cannot capture."
+          "summarize": "Call the `memory_end_session` MCP tool with a narrative summary and structured extractions from the session's buffered turns. The narrative should enhance stored information with tone, context, unresolved threads, and nuance that structured fields cannot capture."
         }
       }
     },
@@ -75,10 +75,10 @@
   "notes": {
     "implementation": "These hooks define intended behaviors. Claude Code will execute them as behavioral guidelines rather than traditional script execution.",
     "memory_verification": "CRITICAL: At session start, verify memory availability by running `claudia system-health --project-dir \"$PWD\"` BEFORE proceeding. If memory MCP tools are not available, do NOT use plugin:episodic-memory as a substitute. Tell the user the claudia-memory daemon may need to be configured. Fall back to context files only (context/me.md, etc.) in the meantime.",
-    "session_start": "At session start: (1) Verify claudia system-health passes, (2) Call the `memory.session_context` MCP tool, (3) Read context files, (4) Check for unsummarized sessions. If me.md is missing, trigger onboarding.",
-    "session_end": "Before session ends, Claudia should generate a session summary via the `memory.end_session` MCP tool (enhanced memory) or update context files (markdown fallback). The summary includes both a free-form narrative and structured extractions.",
+    "session_start": "At session start: (1) Verify claudia system-health passes, (2) Call the `memory_session_context` MCP tool, (3) Read context files, (4) Check for unsummarized sessions. If me.md is missing, trigger onboarding.",
+    "session_end": "Before session ends, Claudia should generate a session summary via the `memory_end_session` MCP tool (enhanced memory) or update context files (markdown fallback). The summary includes both a free-form narrative and structured extractions.",
     "first_run": "The absence of context/me.md signals a first-run scenario requiring onboarding.",
-    "turn_buffering": "During sessions with enhanced memory, Claudia buffers each meaningful conversation turn via the `memory.buffer_turn` MCP tool. This ensures nothing is lost even if the session ends abruptly. The buffered turns are summarized at session end or caught up at next session start.",
-    "source_filing": "CRITICAL: When processing transcripts, emails, or documents, ALWAYS call the `memory.file` MCP tool BEFORE extracting information. The Source Preservation principle (#12) is non-negotiable. Raw sources must be filed for provenance."
+    "turn_buffering": "During sessions with enhanced memory, Claudia buffers each meaningful conversation turn via the `memory_buffer_turn` MCP tool. This ensures nothing is lost even if the session ends abruptly. The buffered turns are summarized at session end or caught up at next session start.",
+    "source_filing": "CRITICAL: When processing transcripts, emails, or documents, ALWAYS call the `memory_file` MCP tool BEFORE extracting information. The Source Preservation principle (#12) is non-negotiable. Raw sources must be filed for provenance."
   }
 }

--- a/template-v2/.claude/hooks/post-tool-capture.py
+++ b/template-v2/.claude/hooks/post-tool-capture.py
@@ -11,7 +11,7 @@ import sys
 import time
 from pathlib import Path
 
-SKIP_PREFIXES = ("memory.", "mcp__plugin_episodic", "cognitive.")
+SKIP_PREFIXES = ("memory_", "memory.", "mcp__plugin_episodic", "cognitive.")
 SKIP_NAMES = {"Read", "Glob", "Grep", "LS", "ListMcpResourcesTool", "ReadMcpResourceTool"}
 
 

--- a/template-v2/.claude/hooks/pre-compact.py
+++ b/template-v2/.claude/hooks/pre-compact.py
@@ -12,10 +12,10 @@ print(json.dumps({
     "additionalContext": (
         "Context compaction advisory: If important information was discussed recently, "
         "ensure it has been stored via MCP tools. Check: (1) Commitments: call the "
-        "memory.remember MCP tool for any promises not yet stored. (2) People: call the "
-        "memory.entity MCP tool for anyone discussed in detail. (3) Relationships: call the "
-        "memory.relate MCP tool for connections mentioned. (4) Buffer: call the "
-        "memory.buffer_turn MCP tool with a summary if recent exchanges were not buffered. "
+        "memory_remember MCP tool for any promises not yet stored. (2) People: call the "
+        "memory_entity MCP tool for anyone discussed in detail. (3) Relationships: call the "
+        "memory_relate MCP tool for connections mentioned. (4) Buffer: call the "
+        "memory_buffer_turn MCP tool with a summary if recent exchanges were not buffered. "
         "With 1M context, compaction is less frequent, but proactive capture remains good practice."
     )
 }))

--- a/template-v2/.claude/hooks/pre-compact.sh
+++ b/template-v2/.claude/hooks/pre-compact.sh
@@ -6,7 +6,7 @@
 # Inject advisory into compacted context
 cat <<EOF
 {
-  "additionalContext": "Context compaction advisory: If important information was discussed recently, ensure it has been stored via MCP tools. Check: (1) Commitments: call the memory.remember MCP tool for any promises not yet stored. (2) People: call the memory.entity MCP tool for anyone discussed in detail. (3) Relationships: call the memory.relate MCP tool for connections mentioned. (4) Buffer: call the memory.buffer_turn MCP tool with a summary if recent exchanges were not buffered. With 1M context, compaction is less frequent, but proactive capture remains good practice."
+  "additionalContext": "Context compaction advisory: If important information was discussed recently, ensure it has been stored via MCP tools. Check: (1) Commitments: call the memory_remember MCP tool for any promises not yet stored. (2) People: call the memory_entity MCP tool for anyone discussed in detail. (3) Relationships: call the memory_relate MCP tool for connections mentioned. (4) Buffer: call the memory_buffer_turn MCP tool with a summary if recent exchanges were not buffered. With 1M context, compaction is less frequent, but proactive capture remains good practice."
 }
 EOF
 exit 0

--- a/template-v2/.claude/rules/claudia-principles.md
+++ b/template-v2/.claude/rules/claudia-principles.md
@@ -191,7 +191,7 @@ Each significant action gets confirmed individually. "Go ahead with everything" 
 
 **I always file raw source material before extracting from it.**
 
-When someone shares a transcript, email, document, or any substantive source, I file the original via the `memory.file` MCP tool before extracting memories. This creates a provenance chain: every fact traces back to where I learned it.
+When someone shares a transcript, email, document, or any substantive source, I file the original via the `memory_file` MCP tool before extracting memories. This creates a provenance chain: every fact traces back to where I learned it.
 
 | Source Type | source_type |
 |-------------|-------------|
@@ -250,7 +250,7 @@ When you need to reference something volatile, store a pointer instead of a valu
 **Good:** "Beemok interview files are at workspaces/beemok/interviews/. Count files for current total."
 
 **Bad:** "Active commitments: send proposal to Sarah, review contract with Jim"
-**Good:** "Active commitments are tracked in context/commitments.md and via the `memory.recall` MCP tool"
+**Good:** "Active commitments are tracked in context/commitments.md and via the `memory_recall` MCP tool"
 
 ### The Timestamp Rule
 

--- a/template-v2/.claude/rules/memory-availability.md
+++ b/template-v2/.claude/rules/memory-availability.md
@@ -6,15 +6,15 @@ This rule is always active and applies to every session. Follow it silently - do
 
 ## How Memory Works
 
-Claudia's memory is provided by the **claudia-memory daemon**, a Python MCP server that registers memory tools (e.g., `memory.recall`, `memory.remember`, `memory.about`). When the daemon is running and configured as an MCP server, these tools appear as callable MCP tools alongside other integrations.
+Claudia's memory is provided by the **claudia-memory daemon**, a Python MCP server that registers memory tools (e.g., `memory_recall`, `memory_remember`, `memory_about`). When the daemon is running and configured as an MCP server, these tools appear as callable MCP tools alongside other integrations.
 
 The `claudia` npm binary handles **setup and health checks only** (`claudia setup`, `claudia system-health`). It does not provide memory operations. All memory operations are MCP tools from the daemon.
 
-> **Migration note:** Some skill files may still reference old CLI syntax like `claudia memory recall "query" --project-dir "$PWD"`. Interpret these as calls to the equivalent MCP tool (e.g., `memory.recall` with a query parameter). The CLI subcommands for memory were never built; the MCP tools are the real interface.
+> **Migration note:** Some skill files may still reference old CLI syntax like `claudia memory recall "query" --project-dir "$PWD"`. Interpret these as calls to the equivalent MCP tool (e.g., `memory_recall` with a query parameter). The CLI subcommands for memory were never built; the MCP tools are the real interface.
 
 ## Mandatory Disclosure
 
-**This is non-negotiable.** If you reach the Session Start Protocol and the `memory.briefing` tool is not available (not in your tool palette), you MUST disclose this to the user in your greeting. Do not wait to be asked. Do not silently fall back to context files. The user trusts that you will be honest about your capabilities in each session.
+**This is non-negotiable.** If you reach the Session Start Protocol and the `memory_briefing` tool is not available (not in your tool palette), you MUST disclose this to the user in your greeting. Do not wait to be asked. Do not silently fall back to context files. The user trusts that you will be honest about your capabilities in each session.
 
 A single sentence is sufficient: "Heads up: my memory daemon isn't running this session, so I'm working from context files only."
 

--- a/template-v2/.claude/skills/capture-meeting/SKILL.md
+++ b/template-v2/.claude/skills/capture-meeting/SKILL.md
@@ -30,7 +30,7 @@ User provides one of:
 
 **Always file the raw transcript/notes FIRST.** This is not optional. Source preservation creates provenance: every extracted fact can trace back to where it came from.
 
-Call the `memory.file` MCP tool with:
+Call the `memory_file` MCP tool with:
 - `filename`: "YYYY-MM-DD-[person]-[topic].md"
 - `source_type`: "transcript"
 - `summary`: "Brief 1-line summary of the meeting"
@@ -71,7 +71,7 @@ The file is automatically routed to the right folder:
    - Confirm entity names match existing entities
    - Adjust or remove any questionable extractions
 
-4. Call the `memory.batch` MCP tool with the reviewed operations array
+4. Call the `memory_batch` MCP tool with the reviewed operations array
 ```
 
 **Fallback: Manual extraction** (use when agent is unavailable or for very short notes)
@@ -101,9 +101,9 @@ The file is automatically routed to the right folder:
 
 ### 4. Link Provenance
 
-After extracting memories (facts, commitments) via the `memory.batch` or `memory.remember` MCP tools:
+After extracting memories (facts, commitments) via the `memory_batch` or `memory_remember` MCP tools:
 
-Call the `memory.file` MCP tool with the `memory_ids` parameter set to the IDs of the memories you extracted. This links the stored transcript to the memories extracted from it, creating the provenance chain: memory -> document -> file on disk.
+Call the `memory_file` MCP tool with the `memory_ids` parameter set to the IDs of the memories you extracted. This links the stored transcript to the memories extracted from it, creating the provenance chain: memory -> document -> file on disk.
 
 Now the user can ask "where did you learn that Sarah prefers async communication?" and you can point to the exact transcript.
 
@@ -128,7 +128,7 @@ For each participant in the meeting:
 
 - Add new commitments to `context/commitments.md` (ask for confirmation on wording and deadline)
 - Add new waiting items to `context/waiting.md`
-- If memory MCP tools are available, also store via the `memory.remember` MCP tool
+- If memory MCP tools are available, also store via the `memory_remember` MCP tool
 
 #### 5c. Update workspace files (if applicable)
 
@@ -226,7 +226,7 @@ Ask for confirmation on:
 
 ## Quality Checklist
 
-- [ ] **Raw transcript/notes filed** (`memory.file` MCP tool called with full content)
+- [ ] **Raw transcript/notes filed** (`memory_file` MCP tool called with full content)
 - [ ] Memories linked to source document (provenance chain complete)
 - [ ] Every action item has an owner
 - [ ] Every commitment has a deadline (even approximate)

--- a/template-v2/.claude/skills/capture-meeting/evals/basic.yaml
+++ b/template-v2/.claude/skills/capture-meeting/evals/basic.yaml
@@ -5,7 +5,7 @@ prompts:
   - prompt: "Here are my notes from a call with Sarah Chen about the Q4 roadmap. She mentioned they're moving to microservices, the migration is due by March 15. I promised to send her our API docs by Friday. Also met her colleague James Wright who leads the platform team."
     expectations:
       - "extracts at least one commitment (send API docs by Friday)"
-      - "files the source material via memory.file before extracting"
+      - "files the source material via memory_file before extracting"
       - "identifies Sarah Chen and James Wright as entities"
       - "detects the March 15 deadline"
       - "uses structured output format with emoji headers"

--- a/template-v2/.claude/skills/deep-context/SKILL.md
+++ b/template-v2/.claude/skills/deep-context/SKILL.md
@@ -18,7 +18,7 @@ Comprehensive deep analysis that leverages the full context window. Pulls memori
 
 ## The Deep Pull
 
-Call the `memory.deep_context` MCP tool with the target entity or topic. This compound tool executes the full pipeline server-side in a single call:
+Call the `memory_deep_context` MCP tool with the target entity or topic. This compound tool executes the full pipeline server-side in a single call:
 
 1. **Entity core** (limit=50): Everything known about the target (memories, relationships, metadata)
 2. **Semantic recall** (limit=50): Broad search to catch indirect references and related topics
@@ -44,13 +44,13 @@ All limits are configurable via the tool's input:
 
 ### Fallback (when memory daemon is unavailable)
 
-If the MCP tool is not available, execute these queries manually using `memory.about` and `memory.recall` MCP tools sequentially:
+If the MCP tool is not available, execute these queries manually using `memory_about` and `memory_recall` MCP tools sequentially:
 
-1. `memory.about` with the target (limit=50)
-2. `memory.recall` with the target (limit=50)
-3. `memory.about` for each of the top 3 connected entities (limit=10)
-4. `memory.recall` with types=["observation","learning","commitment"] (limit=30)
-5. `memory.recall` for "session with [target]" (limit=20)
+1. `memory_about` with the target (limit=50)
+2. `memory_recall` with the target (limit=50)
+3. `memory_about` for each of the top 3 connected entities (limit=10)
+4. `memory_recall` with types=["observation","learning","commitment"] (limit=30)
+5. `memory_recall` for "session with [target]" (limit=20)
 6. Deduplicate by memory ID across all steps
 
 If the memory daemon itself is down, fall back to reading `context/` files and `people/*.md` directly. Note degraded mode in output.

--- a/template-v2/.claude/skills/meditate/SKILL.md
+++ b/template-v2/.claude/skills/meditate/SKILL.md
@@ -40,8 +40,8 @@ Silently retrieve:
 - Existing reflections to avoid duplication
 - Active commitments and relationship states
 
-- Call the `memory.reflections` MCP tool to see what already exists
-- Call the `memory.session_context` MCP tool for recent context (if available)
+- Call the `memory_reflections` MCP tool to see what already exists
+- Call the `memory_session_context` MCP tool for recent context (if available)
 
 ### Step 2: Generate Reflections
 
@@ -148,7 +148,7 @@ User responses:
 
 ### Step 5: Store and Close
 
-Call the `memory.end_session` MCP tool with:
+Call the `memory_end_session` MCP tool with:
 - `narrative`: Brief session summary
 - `reflections`: Array of approved reflections with type, content, and optional about fields
 - Other structured extractions (facts, commitments, entities) as needed
@@ -203,8 +203,8 @@ When similar reflections accumulate over time:
 ### Retrieval
 
 Reflections surface through:
-- The `memory.reflections` MCP tool for explicit retrieval
-- The `memory.session_context` MCP tool includes relevant reflections
+- The `memory_reflections` MCP tool for explicit retrieval
+- The `memory_session_context` MCP tool includes relevant reflections
 - Semantic search matches reflections to current context
 
 ---
@@ -236,8 +236,8 @@ User: "That thing you learned about me preferring bullet points -
        that's only for technical content, not conversations."
 
 Claudia:
-1. Call the `memory.reflections` MCP tool with query: "bullet points" to find the reflection
-2. Call the `memory.reflections` MCP tool with action: "update", id: <id>, content: "..." to update
+1. Call the `memory_reflections` MCP tool with query: "bullet points" to find the reflection
+2. Call the `memory_reflections` MCP tool with action: "update", id: <id>, content: "..." to update
 3. Confirm: "Updated. I'll keep that distinction in mind."
 ```
 
@@ -245,8 +245,8 @@ Claudia:
 User: "Delete the reflection about Monday mornings"
 
 Claudia:
-1. Search for the reflection via `memory.reflections` MCP tool
-2. Call the `memory.reflections` MCP tool with action: "delete", id: <id> to delete
+1. Search for the reflection via `memory_reflections` MCP tool
+2. Call the `memory_reflections` MCP tool with action: "delete", id: <id> to delete
 3. Confirm: "Done, I've removed that."
 ```
 
@@ -254,7 +254,7 @@ Claudia:
 User: "Show me all your reflections about me"
 
 Claudia:
-1. Call the `memory.reflections` MCP tool with limit: 50
+1. Call the `memory_reflections` MCP tool with limit: 50
 2. Format nicely with timeline info
 3. Offer to edit or delete any
 ```

--- a/template-v2/.claude/skills/meditate/evals/basic.yaml
+++ b/template-v2/.claude/skills/meditate/evals/basic.yaml
@@ -8,7 +8,7 @@ prompts:
       - "generates reflections, not just a session summary"
       - "captures communication preferences observed during the session"
       - "extracts judgment rules from decisions (e.g., pricing approach)"
-      - "calls memory.end_session with narrative, facts, and reflections"
+      - "calls memory_end_session with narrative, facts, and reflections"
       - "narrative captures emotional tone (frustration about pricing)"
       - "identifies unresolved threads worth revisiting"
 

--- a/template-v2/.claude/skills/meeting-prep/SKILL.md
+++ b/template-v2/.claude/skills/meeting-prep/SKILL.md
@@ -21,12 +21,12 @@ Or naturally:
 
 ### Primary: Deep Context (one call)
 
-Call the `memory.deep_context` MCP tool with the person's name. This returns everything in one round trip: entity info, all memories, connected entities, temporal items (commitments, observations), and episode history. Use this data for all sections below.
+Call the `memory_deep_context` MCP tool with the person's name. This returns everything in one round trip: entity info, all memories, connected entities, temporal items (commitments, observations), and episode history. Use this data for all sections below.
 
-If deep_context is unavailable, fall back to sequential calls: `memory.about` for the entity, then `memory.recall` for broader context.
+If deep_context is unavailable, fall back to sequential calls: `memory_about` for the entity, then `memory_recall` for broader context.
 
 ### 1. Person Context
-From `memory.deep_context` result (or `people/[person].md` as fallback):
+From `memory_deep_context` result (or `people/[person].md` as fallback):
 - Role and organization
 - Relationship history
 - Last contact and topics

--- a/template-v2/.claude/skills/memory-health/SKILL.md
+++ b/template-v2/.claude/skills/memory-health/SKILL.md
@@ -38,7 +38,7 @@ Provide a dashboard view of the memory system's health, including entity counts,
 
 ### Step 1: Gather Statistics
 
-Use the `memory.system_health` MCP tool or direct SQLite queries with the schema above.
+Use the `memory_system_health` MCP tool or direct SQLite queries with the schema above.
 
 Alternatively, use the Claudia CLI to get current system state:
 

--- a/template-v2/.claude/skills/memory-manager.md
+++ b/template-v2/.claude/skills/memory-manager.md
@@ -18,7 +18,7 @@ Claudia's memory operates via **MCP tools** provided by the claudia-memory daemo
 
 The `claudia` npm binary handles setup and diagnostics (`claudia setup`, `claudia system-health`) via the Bash tool. All memory operations use MCP tools.
 
-**Migration note:** Some skill files may still reference old CLI syntax (e.g., `claudia memory recall "query" --project-dir "$PWD"`). Interpret these as calls to the equivalent MCP tool (e.g., `memory.recall` with query parameter). The CLI subcommands were never built; the MCP tools are the actual interface.
+**Migration note:** Some skill files may still reference old CLI syntax (e.g., `claudia memory recall "query" --project-dir "$PWD"`). Interpret these as calls to the equivalent MCP tool (e.g., `memory_recall` with query parameter). The CLI subcommands were never built; the MCP tools are the actual interface.
 
 ## MCP Tool Reference
 
@@ -26,31 +26,31 @@ The `claudia` npm binary handles setup and diagnostics (`claudia setup`, `claudi
 
 | Operation | MCP Tool | Key Parameters |
 |-----------|----------|----------------|
-| Store a memory | `memory.remember` | content, type, importance, about (entity names) |
-| Search memories | `memory.recall` | query, limit, types |
-| Entity context | `memory.about` | entity (name) |
-| Create/update entity | `memory.entity` | name, type, description |
-| Link entities | `memory.relate` | source, target, relationship, strength |
-| Correct memory | `memory.correct` | memory_id, correction, reason |
-| Invalidate memory | `memory.invalidate` | memory_id, reason |
-| Session briefing | `memory.briefing` | (none) |
-| Multi-query search | `memory.multi_recall` | queries (array of strings or objects), limit, compact |
-| Deep context | `memory.deep_context` | target, entity_limit, recall_limit, max_connections |
-| Manage reflections | `memory.reflections` | action (get/save/update/delete), content, type, query, id |
-| Run consolidation | `memory.consolidate` | lightweight (bool) |
+| Store a memory | `memory_remember` | content, type, importance, about (entity names) |
+| Search memories | `memory_recall` | query, limit, types |
+| Entity context | `memory_about` | entity (name) |
+| Create/update entity | `memory_entity` | name, type, description |
+| Link entities | `memory_relate` | source, target, relationship, strength |
+| Correct memory | `memory_correct` | memory_id, correction, reason |
+| Invalidate memory | `memory_invalidate` | memory_id, reason |
+| Session briefing | `memory_briefing` | (none) |
+| Multi-query search | `memory_multi_recall` | queries (array of strings or objects), limit, compact |
+| Deep context | `memory_deep_context` | target, entity_limit, recall_limit, max_connections |
+| Manage reflections | `memory_reflections` | action (get/save/update/delete), content, type, query, id |
+| Run consolidation | `memory_consolidate` | lightweight (bool) |
 
 ### Document Storage
 
 | Operation | MCP Tool | Key Parameters |
 |-----------|----------|----------------|
-| Store document | `memory.file` | filename, source_type, summary, about (entity names), content |
-| Search documents | `memory.documents` | query, source_type, entity, limit |
+| Store document | `memory_file` | filename, source_type, summary, about (entity names), content |
+| Search documents | `memory_documents` | query, source_type, entity, limit |
 
 Source types: `gmail`, `transcript`, `upload`, `capture`, `session`.
 
 ### Batch Operations
 
-Call `memory.batch` with an operations array. Each operation is an object:
+Call `memory_batch` with an operations array. Each operation is an object:
 
 ```json
 [
@@ -66,10 +66,10 @@ Valid `op` values: `entity`, `remember`, `relate`, `correct`, `invalidate`.
 
 | Operation | MCP Tool | Key Parameters |
 |-----------|----------|----------------|
-| Buffer a turn | `memory.buffer_turn` | user_content, assistant_content, episode_id |
-| End session | `memory.end_session` | episode_id, narrative, reflections, facts, entities, relationships |
-| Load full context | `memory.session_context` | scope |
-| Check unsummarized | `memory.unsummarized` | (none) |
+| Buffer a turn | `memory_buffer_turn` | user_content, assistant_content, episode_id |
+| End session | `memory_end_session` | episode_id, narrative, reflections, facts, entities, relationships |
+| Load full context | `memory_session_context` | scope |
+| Check unsummarized | `memory_unsummarized` | (none) |
 
 ### Valid Parameter Values
 
@@ -85,14 +85,14 @@ Valid `op` values: `entity`, `remember`, `relate`, `correct`, `invalidate`.
 
 | Operation | MCP Tool | Key Parameters |
 |-----------|----------|----------------|
-| Morning digest | `memory.morning_context` | (none) |
-| Project connections | `memory.project_network` | entity |
-| Connection path | `memory.find_path` | source, target |
-| Find hubs | `memory.network_hubs` | limit |
-| Dormant relationships | `memory.dormant_relationships` | days_threshold |
-| Search entities | `memory.search_entities` | query, types, limit |
-| Merge entities | `memory.merge_entities` | source_id, target_id, reason |
-| Provenance trace | `memory.trace` | memory_id |
+| Morning digest | `memory_morning_context` | (none) |
+| Project connections | `memory_project_network` | entity |
+| Connection path | `memory_find_path` | source, target |
+| Find hubs | `memory_network_hubs` | limit |
+| Dormant relationships | `memory_dormant_relationships` | days_threshold |
+| Search entities | `memory_search_entities` | query, types, limit |
+| Merge entities | `memory_merge_entities` | source_id, target_id, reason |
+| Provenance trace | `memory_trace` | memory_id |
 | Extract from text | `cognitive.ingest` | text, context |
 
 ---
@@ -106,11 +106,11 @@ These are non-negotiable. Violating them defeats the purpose of the memory syste
 When processing source material (transcripts, emails, documents):
 
 1. **Check for duplicates** (by source_type + source_ref)
-2. **File it first** via `memory.file` with full raw content
+2. **File it first** via `memory_file` with full raw content
 3. **Ask user about extraction** (don't auto-extract)
-4. If user says extract: use Document Processor agent (Haiku) for longer content, or extract manually for short notes. Review agent output before storing via `memory.batch`.
+4. If user says extract: use Document Processor agent (Haiku) for longer content, or extract manually for short notes. Review agent output before storing via `memory_batch`.
 
-**If you find yourself reading source documents** without calling `memory.file` for each one, **STOP and fix it**. File first, then ask if extraction should happen now or later.
+**If you find yourself reading source documents** without calling `memory_file` for each one, **STOP and fix it**. File first, then ask if extraction should happen now or later.
 
 ### 2. Verify Memory System at Session Start
 
@@ -118,7 +118,7 @@ Before greeting, verify the `claudia` CLI is available by running `claudia syste
 
 ### 3. Buffer Turns During Sessions
 
-Call `memory.buffer_turn` for each meaningful exchange. This ensures nothing is lost if the session ends abruptly.
+Call `memory_buffer_turn` for each meaningful exchange. This ensures nothing is lost if the session ends abruptly.
 
 ### 4. Trust North Star: Origin Tracking
 
@@ -173,13 +173,13 @@ Before creating a new person or project file:
 
 When looking for information about a person or topic:
 
-1. Call `memory.about` with the entity name. Single call, returns all memories + relationships + recent session narratives.
+1. Call `memory_about` with the entity name. Single call, returns all memories + relationships + recent session narratives.
 2. If no results, check if `people/[name].md` exists (single file read).
 3. If neither has it, it's unknown. Tell the user and ask if they have source material.
 4. **Last resort:** `episodic-memory__search` (cross-workspace conversation history). Only use this when Claudia's own memory and local files have nothing, and the information might exist in a prior Claude Code conversation from another workspace.
 
 Do NOT:
-- Call both `memory.recall` AND `memory.about` for the same entity (about is the targeted lookup, recall is for broad searches)
+- Call both `memory_recall` AND `memory_about` for the same entity (about is the targeted lookup, recall is for broad searches)
 - Search episodic memory for information that should be in Claudia's memory
 - Jump to episodic-memory search before exhausting Claudia's own memory system
 - Parse raw `.jsonl` session logs. The cost-to-recovery ratio is poor and it rarely succeeds. If data was lost during context compaction, ask the user for the source material (Granola notes, email, recording).
@@ -190,12 +190,12 @@ Do NOT:
 
 Avoid redundant memory calls within a session:
 
-- **Session-local awareness:** If you already called `memory.about` for an entity in this session, do not call it again. Use the results you already have.
-- **Recall dedup:** Do not call `memory.recall` with a query that overlaps an entity you already fetched with `memory.about`. The about call already returned that entity's full context.
-- **File-vs-memory rule:** If you just read a person file (`people/[name].md`), do not also call `memory.about` for the same person unless you need memories not in the file (e.g., cross-project context or recent session narratives).
-- **Batch preference:** When you need to store multiple items at once, use `memory.batch` over sequential calls.
+- **Session-local awareness:** If you already called `memory_about` for an entity in this session, do not call it again. Use the results you already have.
+- **Recall dedup:** Do not call `memory_recall` with a query that overlaps an entity you already fetched with `memory_about`. The about call already returned that entity's full context.
+- **File-vs-memory rule:** If you just read a person file (`people/[name].md`), do not also call `memory_about` for the same person unless you need memories not in the file (e.g., cross-project context or recent session narratives).
+- **Batch preference:** When you need to store multiple items at once, use `memory_batch` over sequential calls.
 - **Skip search when context is fresh:** If the user just told you something in this conversation, remember it directly. Don't search memory for what was just said.
-- **Compound tools first:** When you need multiple recall queries (e.g., morning brief, meeting prep), prefer `memory.multi_recall` over sequential `memory.recall` calls. For deep entity analysis, prefer `memory.deep_context` over manual multi-step pulls.
+- **Compound tools first:** When you need multiple recall queries (e.g., morning brief, meeting prep), prefer `memory_multi_recall` over sequential `memory_recall` calls. For deep entity analysis, prefer `memory_deep_context` over manual multi-step pulls.
 
 ### Compound Tools Reference
 
@@ -203,11 +203,11 @@ These tools batch multiple operations into a single call, reducing round trips:
 
 | Tool | Replaces | When to Use |
 |------|----------|-------------|
-| `memory.batch` | N sequential remember/entity/relate calls | Storing multiple items from meeting notes, transcripts, etc. |
-| `memory.multi_recall` | N sequential recall calls | Morning brief follow-ups, research across multiple dimensions |
-| `memory.deep_context` | 6-8 about/recall/episode calls | Meeting prep, relationship deep dives, strategic analysis |
-| `memory.briefing` | Loading all context files at session start | Session start (already standard protocol) |
-| `memory.morning_context` | Multiple temporal/commitment queries | Morning brief data assembly |
+| `memory_batch` | N sequential remember/entity/relate calls | Storing multiple items from meeting notes, transcripts, etc. |
+| `memory_multi_recall` | N sequential recall calls | Morning brief follow-ups, research across multiple dimensions |
+| `memory_deep_context` | 6-8 about/recall/episode calls | Meeting prep, relationship deep dives, strategic analysis |
+| `memory_briefing` | Loading all context files at session start | Session start (already standard protocol) |
+| `memory_morning_context` | Multiple temporal/commitment queries | Morning brief data assembly |
 
 ---
 
@@ -217,16 +217,16 @@ When the enhanced memory system is available:
 
 ### 0. Catch Up on Unsummarized Sessions
 
-Call `memory.unsummarized`. For each result, review buffered turns, write a retroactive narrative, extract structured facts/commitments/entities, and call `memory.end_session` to finalize. Note in the narrative that it was "Reconstructed from N buffered turns from [date]".
+Call `memory_unsummarized`. For each result, review buffered turns, write a retroactive narrative, extract structured facts/commitments/entities, and call `memory_end_session` to finalize. Note in the narrative that it was "Reconstructed from N buffered turns from [date]".
 
 ### 1. Minimal Startup (2 calls max)
 
 1. Read `context/me.md` (for greeting personalization)
-2. Call `memory.briefing` (~500 tokens of aggregate context: commitments, cooling, unread, predictions)
+2. Call `memory_briefing` (~500 tokens of aggregate context: commitments, cooling, unread, predictions)
 
-Pull full context on-demand via `memory.recall` / `memory.about` during conversation. Do NOT read learnings.md, patterns.md, commitments.md, or waiting.md at startup (they duplicate the memory database).
+Pull full context on-demand via `memory_recall` / `memory_about` during conversation. Do NOT read learnings.md, patterns.md, commitments.md, or waiting.md at startup (they duplicate the memory database).
 
-**Fallback:** If briefing unavailable, call `memory.morning_context`.
+**Fallback:** If briefing unavailable, call `memory_morning_context`.
 
 ### 2. Session Start (Markdown Fallback)
 
@@ -241,7 +241,7 @@ If enhanced memory is unavailable, read: `context/me.md`, `context/learnings.md`
 After each meaningful exchange, buffer the turn for later summarization:
 
 ```
-After each substantive turn, call memory.buffer_turn with:
+After each substantive turn, call memory_buffer_turn with:
 - user_content: "What the user said (summarized if very long)"
 - assistant_content: "What I said (key points, not full response)"
 - episode_id: Reuse the ID from the first buffer call
@@ -258,11 +258,11 @@ After each substantive turn, call memory.buffer_turn with:
 - Pure tool output with no discussion
 - Trivial back-and-forth
 
-The first `memory.buffer_turn` call creates an episode and returns an `episode_id`. Reuse that ID for all subsequent turns in the session.
+The first `memory_buffer_turn` call creates an episode and returns an `episode_id`. Reuse that ID for all subsequent turns in the session.
 
 ### Immediate Memory (Still Active)
 
-For high-importance items, call `memory.remember` immediately in addition to buffering:
+For high-importance items, call `memory_remember` immediately in addition to buffering:
 - Explicit commitments ("I'll send the proposal by Friday")
 - Critical facts the user explicitly asks you to remember
 - Urgent relationship updates
@@ -279,7 +279,7 @@ Think of it like taking notes during a meeting versus trying to remember everyth
 
 #### Commitments: Store Them Immediately
 
-When someone makes a promise (the user, or someone they're telling you about), that's too important to buffer. Call `memory.remember` right away with:
+When someone makes a promise (the user, or someone they're telling you about), that's too important to buffer. Call `memory_remember` right away with:
 - `type`: "commitment"
 - `importance`: 0.9 (commitments matter)
 - `about`: whoever made the promise
@@ -291,7 +291,7 @@ Then add it to `context/commitments.md`. Two places is better than zero. If cont
 
 First time a name comes up, just note it mentally. No action needed.
 
-Second time they're mentioned with real context (their role, what they're working on, how they connect to others), that's your signal to call `memory.entity`.
+Second time they're mentioned with real context (their role, what they're working on, how they connect to others), that's your signal to call `memory_entity`.
 
 A casual name-drop doesn't need a database entry. A person who matters to the conversation does.
 
@@ -302,9 +302,9 @@ The threshold is "meaningful context":
 
 #### Relationships: Capture the Connections
 
-When you hear language like "Sarah works with Mike" or "they're our client," capture that silently with `memory.relate`. Don't announce it, just do it. These connections are exactly what the memory system is for.
+When you hear language like "Sarah works with Mike" or "they're our client," capture that silently with `memory_relate`. Don't announce it, just do it. These connections are exactly what the memory system is for.
 
-| When you hear... | Call `memory.relate` with... |
+| When you hear... | Call `memory_relate` with... |
 |------------------|------------------------------|
 | "X works with Y" | source: X, target: Y, relationship: "works_with" |
 | "X reports to Y" | source: X, target: Y, relationship: "reports_to" |
@@ -334,10 +334,10 @@ With the 1M context window, compaction happens less frequently, but it can still
 If you see a context compaction advisory, review what you can recover:
 
 1. Review what remains in your context
-2. Call `memory.remember` for any commitments you can piece together
-3. Call `memory.entity` for people discussed in detail
-4. Call `memory.relate` for relationships mentioned
-5. Call `memory.buffer_turn` with a summary of recent exchanges
+2. Call `memory_remember` for any commitments you can piece together
+3. Call `memory_entity` for people discussed in detail
+4. Call `memory_relate` for relationships mentioned
+5. Call `memory_buffer_turn` with a summary of recent exchanges
 
 This is triage, not standard practice. The goal is to make proactive capture so habitual that post-compaction recovery rarely matters.
 
@@ -345,7 +345,7 @@ This is triage, not standard practice. The goal is to make proactive capture so 
 
 When a person or project is mentioned:
 ```
-Call memory.entity with:
+Call memory_entity with:
 - name: "Entity Name"
 - type: person/organization/project
 - description: "What we learned"
@@ -353,7 +353,7 @@ Call memory.entity with:
 
 When relationships between entities are mentioned:
 ```
-Call memory.relate with:
+Call memory_relate with:
 - source: "First entity"
 - target: "Second entity"
 - relationship: works_with, manages, client_of, etc.
@@ -361,7 +361,7 @@ Call memory.relate with:
 
 ### Batch Mid-Session Operations
 
-When processing a new person, meeting transcript, or topic that requires multiple memory operations (entity + memories + relationships) mid-session, call `memory.batch` with a single operations array instead of making sequential tool calls.
+When processing a new person, meeting transcript, or topic that requires multiple memory operations (entity + memories + relationships) mid-session, call `memory_batch` with a single operations array instead of making sequential tool calls.
 
 ```json
 [
@@ -372,7 +372,7 @@ When processing a new person, meeting transcript, or topic that requires multipl
 ]
 ```
 
-Use `memory.batch` for mid-session entity creation (e.g., user pastes meeting notes and you need to store a new person immediately). Use `memory.end_session` for the full session wrap-up. After a batch call, write the person/project file and report using the Session Update format. Do not narrate between operations.
+Use `memory_batch` for mid-session entity creation (e.g., user pastes meeting notes and you need to store a new person immediately). Use `memory_end_session` for the full session wrap-up. After a batch call, write the person/project file and report using the Session Update format. Do not narrate between operations.
 
 ### Document Filing (Source Preservation)
 
@@ -392,7 +392,7 @@ Use `memory.batch` for mid-session entity creation (e.g., user pastes meeting no
 #### How to File
 
 ```
-Call memory.file with:
+Call memory_file with:
 - filename: "Descriptive-name.md"
 - source_type: "transcript", "gmail", "upload", or "capture"
 - summary: "One-line description"
@@ -404,11 +404,11 @@ Call memory.file with:
 
 1. **Check for duplicates first**
    - If source has an identifiable ID (email message-id, URL, file hash):
-   - Call `memory.documents` with the source reference
+   - Call `memory_documents` with the source reference
    - If found: "I already have this filed at [path]. Want me to pull up what I extracted?"
    - If not found: Continue to step 2
 
-2. **File immediately** using `memory.file` with full content
+2. **File immediately** using `memory_file` with full content
    - Do NOT automatically extract in the same turn
 
 3. **Ask about extraction**
@@ -421,7 +421,7 @@ Call memory.file with:
    - Extract relationships (how they're connected)
    - Extract commitments (promises made)
    - Present findings for user verification before storing
-   - Store verified info via `memory.batch`
+   - Store verified info via `memory_batch`
 
 5. **If user says "later"**
    - Done. User can ask "extract that transcript" anytime later
@@ -444,7 +444,7 @@ Before filing any source with an external identifier:
 | Upload | Filename + size, or content hash |
 | URL/Capture | URL |
 
-Call `memory.documents` with the identifier to check for existing copies.
+Call `memory_documents` with the identifier to check for existing copies.
 
 If exists, surface it: "I filed this on [date]. Summary: [summary]. Want me to show what I extracted?"
 
@@ -458,10 +458,10 @@ Every fact traces back to its source. User can always ask "where did you learn t
 
 ### Enhanced Memory
 
-Before wrapping up, generate a session summary by calling `memory.end_session`:
+Before wrapping up, generate a session summary by calling `memory_end_session`:
 
 ```
-Call memory.end_session with:
+Call memory_end_session with:
 - episode_id: The episode from buffer_turn calls
 - narrative: "Free-form summary of the session (see below)"
 - facts: [...] (structured extractions)
@@ -520,15 +520,15 @@ Reflections are persistent learnings about working with this user. Unlike memori
 
 ### Applying Reflections
 
-When `memory.briefing` returns active reflections, **apply them silently**. Do NOT announce reflections. They inform behavior invisibly (adjust format/style, anticipate needs).
+When `memory_briefing` returns active reflections, **apply them silently**. Do NOT announce reflections. They inform behavior invisibly (adjust format/style, anticipate needs).
 
-**Exception:** Surface reflections if the user explicitly asks ("show me your reflections" / "what have you learned?") via `memory.reflections`.
+**Exception:** Surface reflections if the user explicitly asks ("show me your reflections" / "what have you learned?") via `memory_reflections`.
 
 ### Managing Reflections
 
-- **Generate** via `/meditate` skill at session end, or anytime via `memory.end_session` with reflections array
-- **Retrieve** via `memory.reflections` (action: "get")
-- **Edit/Delete** via `memory.reflections` (action: "update"/"delete") when user requests changes
+- **Generate** via `/meditate` skill at session end, or anytime via `memory_end_session` with reflections array
+- **Retrieve** via `memory_reflections` (action: "get")
+- **Edit/Delete** via `memory_reflections` (action: "update"/"delete") when user requests changes
 - **Decay** is very slow (~2 year half-life). Well-confirmed reflections (3+) decay even slower.
 - **Without memory tools:** reflections go to `context/learnings.md` under a "Reflections" heading.
 
@@ -552,11 +552,11 @@ Users can correct mistakes in the memory system through natural language. User c
 ### Correction Flow
 
 1. **Acknowledge immediately**: "Let me fix that."
-2. **Search for the memory**: Call `memory.recall` with the topic
+2. **Search for the memory**: Call `memory_recall` with the topic
 3. **Present what you found**: Show the user the memory/memories that might be wrong
 4. **Offer options**:
-   - **Correct**: Update the content, keep the history (call `memory.correct`)
-   - **Invalidate**: Mark as no longer true (call `memory.invalidate`)
+   - **Correct**: Update the content, keep the history (call `memory_correct`)
+   - **Invalidate**: Mark as no longer true (call `memory_invalidate`)
    - **No change**: User clarifies it's actually correct
 5. **Confirm action**: "Fixed. I've updated [brief description]."
 
@@ -566,10 +566,10 @@ Users can correct mistakes in the memory system through natural language. User c
 ```
 User: "Actually, Sarah works at Acme now, not TechCorp"
 
-1. Search: call memory.recall with query "Sarah works TechCorp"
+1. Search: call memory_recall with query "Sarah works TechCorp"
 2. Show: "I have a memory that 'Sarah Chen works at TechCorp'. Is this the one?"
 3. User confirms
-4. Call memory.correct with memory_id, correction: "Sarah Chen works at Acme", reason: "User correction: moved companies"
+4. Call memory_correct with memory_id, correction: "Sarah Chen works at Acme", reason: "User correction: moved companies"
 5. Respond: "Updated. I now know Sarah works at Acme."
 ```
 
@@ -577,10 +577,10 @@ User: "Actually, Sarah works at Acme now, not TechCorp"
 ```
 User: "That project is cancelled, don't remind me about it"
 
-1. Search: call memory.recall with query "project [name]"
+1. Search: call memory_recall with query "project [name]"
 2. Show: "I have 5 memories about [project]. Want me to mark them all as no longer relevant?"
 3. User confirms
-4. Call memory.invalidate for each memory_id with reason: "Project cancelled"
+4. Call memory_invalidate for each memory_id with reason: "Project cancelled"
 5. Respond: "Done. I won't surface those memories anymore."
 ```
 
@@ -591,7 +591,7 @@ User: "John Smith and Jon Smith are the same person"
 1. Search for both entities
 2. Confirm: "I found both. Jon Smith has fewer memories. Should I merge Jon into John?"
 3. User confirms
-4. Call memory.merge_entities with source_id (Jon), target_id (John), reason: "User confirmed same person"
+4. Call memory_merge_entities with source_id (Jon), target_id (John), reason: "User confirmed same person"
 5. Respond: "Merged. All memories about Jon are now linked to John Smith."
 ```
 
@@ -636,7 +636,7 @@ Never persist:
 ### User Control
 
 User can:
-- Ask "What do you know about me?" → Call `memory.recall` with broad query
+- Ask "What do you know about me?" → Call `memory_recall` with broad query
 - Ask to forget something → Remove from files/database
 - Request to start fresh → Delete context files/database
 - Review any stored information
@@ -648,7 +648,7 @@ User can:
 ### Crash Safety
 
 **Enhanced Memory:**
-- Every `memory.remember` call is immediately committed to SQLite with WAL mode
+- Every `memory_remember` call is immediately committed to SQLite with WAL mode
 - Survives terminal close, process kill, system crash
 - No data loss even if session ends abruptly
 

--- a/template-v2/.claude/skills/morning-brief/SKILL.md
+++ b/template-v2/.claude/skills/morning-brief/SKILL.md
@@ -12,14 +12,14 @@ Provide a concise morning brief to start the day with clarity. Surface what matt
 
 ### Enhanced Memory System (if available)
 
-1. **Call the `memory.morning_context` MCP tool** to get a curated morning digest in a single call:
+1. **Call the `memory_morning_context` MCP tool** to get a curated morning digest in a single call:
    - Stale commitments (3+ days old, importance > 0.3)
    - Cooling relationships (people not contacted in 30+ days)
    - Cross-entity connections (people who co-appear but have no explicit relationship)
    - Active predictions and insights
    - Recent activity (72h)
 
-2. **Call `memory.multi_recall`** for follow-up queries (batches multiple searches in one call), or `memory.recall` for a single specific query
+2. **Call `memory_multi_recall`** for follow-up queries (batches multiple searches in one call), or `memory_recall` for a single specific query
 
 ### Judgment Rules (if available)
 
@@ -79,14 +79,14 @@ This builds trust by showing the verification happened.
 
 ## Temporal Awareness
 
-When enhanced memory is available, use urgency-driven ordering. Use the `memory.morning_context` MCP tool to organize the brief by time sensitivity:
+When enhanced memory is available, use urgency-driven ordering. Use the `memory_morning_context` MCP tool to organize the brief by time sensitivity:
 
 ### Urgency Tiers (in order)
 
-1. **Urgent** (from `memory.morning_context` or `memory.recall` with commitment type filter): Overdue commitments + due today + due tomorrow. These lead the brief.
+1. **Urgent** (from `memory_morning_context` or `memory_recall` with commitment type filter): Overdue commitments + due today + due tomorrow. These lead the brief.
 2. **This Week**: Remaining commitments due this week (from morning context or targeted recall).
-3. **Since Last Session** (from `memory.session_context`): New memories, entities, and changes since the last conversation.
-4. **Reconnections** (from `memory.dormant_relationships`): People trending toward dormancy who need attention, with context (last topic, open commitments).
+3. **Since Last Session** (from `memory_session_context`): New memories, entities, and changes since the last conversation.
+4. **Reconnections** (from `memory_dormant_relationships`): People trending toward dormancy who need attention, with context (last topic, open commitments).
 5. **Cooling Relationships**: From pattern detection (existing behavior).
 6. **Reflections**: Active high-importance reflections from `/meditate`.
 
@@ -98,7 +98,7 @@ The brief should be urgency-driven, not category-driven. The old approach said "
 
 ### 1. Predictions First (Enhanced Memory)
 
-If the `memory.session_context` MCP tool returns predictions, lead with them:
+If the `memory_session_context` MCP tool returns predictions, lead with them:
 - **Relationship alerts** - "Sarah: no contact in 45 days"
 - **Commitment warnings** - "Proposal deadline was yesterday"
 - **Pattern insights** - "You've mentioned being stretched thin 3 times this week"
@@ -113,7 +113,7 @@ Check for urgent items:
 
 ### 3. Today's Commitments
 
-From the `memory.recall` MCP tool or `context/commitments.md`:
+From the `memory_recall` MCP tool or `context/commitments.md`:
 - What's due today
 - What's due this week that needs attention today
 - Any blocked items that need unblocking
@@ -130,7 +130,7 @@ This section only appears when workspace directories exist. It uses file-system 
 
 ### 4. Relationship Health Dashboard
 
-From the `memory.morning_context` MCP tool's relationship health section:
+From the `memory_morning_context` MCP tool's relationship health section:
 
 **Dormant relationships by severity:**
 - **30+ days**: Consider reaching out (still warm)
@@ -153,7 +153,7 @@ From predictions or checking `people/` files:
 ### 5. Today's Meetings (if calendar integration available)
 
 For each meeting:
-- Call the `memory.about` MCP tool with the attendee name, or check `people/` for relevant relationship context
+- Call the `memory_about` MCP tool with the attendee name, or check `people/` for relevant relationship context
 - Note any commitments to or from attendees
 - Check waiting items for pending items
 - Suggest 1-2 talking points based on history

--- a/template-v2/.claude/skills/research/SKILL.md
+++ b/template-v2/.claude/skills/research/SKILL.md
@@ -54,7 +54,7 @@ If the topic is clear and narrow, skip this and go straight to work.
 Before reaching for the web, check what Claudia already knows:
 
 ```
-memory.recall "[topic]":
+memory_recall "[topic]":
 ├── Fresh results (< 7 days) → Use them, offer to refresh
 │   "I have some context on this from [date]:
 │    [summary of stored facts]
@@ -145,7 +145,7 @@ Source: [URL] (fetched [date])
 ### 6. Store and Connect
 
 After presenting findings:
-- Store key facts via `memory.remember` with `source:web:` provenance
+- Store key facts via `memory_remember` with `source:web:` provenance
 - Update relevant entities if research revealed new information
 - Connect to existing relationships or projects where relevant
 

--- a/template-v2/.claude/skills/skill-index.json
+++ b/template-v2/.claude/skills/skill-index.json
@@ -585,7 +585,7 @@
     {
       "name": "deep-context",
       "path": "deep-context/SKILL.md",
-      "description": "Full-context deep analysis using memory.deep_context compound tool (single call replaces 6-8 sequential calls) for comprehensive synthesis",
+      "description": "Full-context deep analysis using memory_deep_context compound tool (single call replaces 6-8 sequential calls) for comprehensive synthesis",
       "invocation": "contextual",
       "effort_level": "max",
       "triggers": ["deep dive", "full context", "everything about", "strategic analysis"],

--- a/template-v2/CLAUDE.md
+++ b/template-v2/CLAUDE.md
@@ -80,14 +80,14 @@ Check for `context/me.md` at the start of any session. If it doesn't exist, this
 
 At the start of every session (after confirming `context/me.md` exists):
 
-1. **Check memory system** - You MUST attempt to call the `memory.briefing` MCP tool as your first action. Three outcomes:
+1. **Check memory system** - You MUST attempt to call the `memory_briefing` MCP tool as your first action. Three outcomes:
    - **Tool responds:** Daemon is healthy. Use its output as session context.
    - **Tool exists but errors:** Daemon started but has an issue. Tell the user, then fall back to context files.
    - **Tool not in your palette:** Daemon didn't start. You MUST tell the user immediately: "My memory daemon isn't running, so I'm working from context files only, no semantic search or pattern detection." Then read context files (`me.md`, `commitments.md`, etc.) and follow the `memory-availability` rule. Do NOT silently fall back.
 2. **Check for updates** - If `context/whats-new.md` exists: read it, mention the update in your greeting, then delete it (`rm context/whats-new.md`)
-3. **Load context** - Call the `memory.briefing` MCP tool for a compact session summary (~500 tokens: commitments, cooling relationships, activity, reflections)
-   - If briefing shows alerts (overdue/cooling/unread): call the `memory.session_context` MCP tool for detail
-4. **Catch up** - If briefing mentions unsummarized sessions, generate retroactive summaries via the `memory.end_session` MCP tool
+3. **Load context** - Call the `memory_briefing` MCP tool for a compact session summary (~500 tokens: commitments, cooling relationships, activity, reflections)
+   - If briefing shows alerts (overdue/cooling/unread): call the `memory_session_context` MCP tool for detail
+4. **Catch up** - If briefing mentions unsummarized sessions, generate retroactive summaries via the `memory_end_session` MCP tool
 5. **Greet naturally** - Use loaded context, surface urgent items
 
 ### Vault Lookups
@@ -282,7 +282,7 @@ I don't just wait for instructions. I actively:
 
 ### 8. Source Preservation
 
-**I always file raw source material before extracting from it.** Transcripts, emails, documents all get filed via the `memory.file` MCP tool with entity links, creating a provenance chain so every fact traces back to its source. See `claudia-principles.md` for the full filing flow and what gets filed where.
+**I always file raw source material before extracting from it.** Transcripts, emails, documents all get filed via the `memory_file` MCP tool with entity links, creating a provenance chain so every fact traces back to its source. See `claudia-principles.md` for the full filing flow and what gets filed where.
 
 ---
 
@@ -315,7 +315,7 @@ I adapt to whatever tools are available. When you ask me to do something that ne
 2. **If I have the capability, use it**
 3. **If I don't, tell you honestly and offer to help you add it**
 
-**Memory system:** My memory is a core capability, not just another integration. It's powered by the **claudia-memory daemon**, a Python MCP server that provides ~33 tools for persistent memory with semantic search, pattern detection, and relationship tracking across sessions. The daemon manages a local SQLite database with vector embeddings. Memory operations use MCP tools (e.g., `memory.recall`, `memory.remember`, `memory.about`) called directly, not CLI commands. The `claudia` npm binary handles only `setup` and `system-health`. When the memory daemon is running, all my other behaviors (commitment tracking, pattern recognition, risk surfacing, relationship context) become significantly more powerful because they draw on accumulated knowledge rather than just the current session.
+**Memory system:** My memory is a core capability, not just another integration. It's powered by the **claudia-memory daemon**, a Python MCP server that provides ~33 tools for persistent memory with semantic search, pattern detection, and relationship tracking across sessions. The daemon manages a local SQLite database with vector embeddings. Memory operations use MCP tools (e.g., `memory_recall`, `memory_remember`, `memory_about`) called directly, not CLI commands. The `claudia` npm binary handles only `setup` and `system-health`. When the memory daemon is running, all my other behaviors (commitment tracking, pattern recognition, risk surfacing, relationship context) become significantly more powerful because they draw on accumulated knowledge rather than just the current session.
 
 **Obsidian vault:** My memory syncs to an Obsidian vault at `~/.claudia/vault/` using a PARA-inspired structure: `Active/` for projects, `Relationships/` for people and organizations, `Reference/` for concepts and locations, `Archive/` for dormant entities. Every entity becomes a markdown note with `[[wikilinks]]`, so Obsidian's graph view acts as a relationship visualizer. My own lookup files (MOC tables, patterns, reflections, sessions) live in `Claudia's Desk/`, keeping the human-facing folders clean. The vault syncs on-demand via `claudia vault sync`. SQLite remains the source of truth; the vault is a read projection.
 


### PR DESCRIPTION
## Summary

- Renames all MCP tool names from dot notation (`memory.recall`) to underscore (`memory_recall`)
- Claude Desktop enforces the MCP spec: tool names must match `^[a-zA-Z0-9_-]{1,64}$`
- Dot notation works in Claude Code but is rejected by Claude Desktop, blocking Desktop users

## Changes

- **server.py** — 125 string replacements across Tool() definitions, `@_handler()` decorators, string comparisons, and dispatch defaults
- **scheduler.py** — 2 prefix strings in `RELEVANT_TOOL_PREFIXES`
- **test_session_context.py** — 1 test assertion

Zero logic changes. Pure rename. No database or data impact.

## Test plan

- [ ] Start daemon locally, verify all tools register with underscore names
- [ ] Connect to Claude Code, verify tools respond (Claude Code accepts both formats)
- [ ] Connect to Claude Desktop via MCP config, verify no `FrontendRemoteMcpToolDefinition.name` error
- [ ] Run existing test suite (`pytest memory-daemon/tests/`)

## Context

Reported by [@Jose](https://github.com/) (Tilth & Co) who hit the error when connecting Claudia to Claude Desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)