### PR TITLE
feat: push-based judgment layer + morning brief penalties + meditate handoffs

### DIFF
--- a/.claude/rules/judgment-active.md
+++ b/.claude/rules/judgment-active.md
@@ -1,0 +1,33 @@
+# Active Judgment Rules
+
+Critical judgment rules promoted from `context/judgment.yaml` for always-on enforcement. The harness injects this file into every session automatically, making these rules as reliable as `claudia-principles.md`.
+
+## How This Works
+
+Claudia's judgment layer has two tiers:
+
+1. **Always-on rules** (this file, `.claude/rules/judgment-active.md`): The top 3-5 cross-cutting rules that should fire in every session, regardless of which skills are invoked. Loaded by the harness automatically.
+
+2. **Full archive** (`context/judgment.yaml`): The growing library of context-specific rules written by `/meditate`. Individual skills (like `morning-brief`) read from the archive when they need domain-specific rules.
+
+**Promotion flow:** When a rule in the archive proves critical across 2+ sessions or after a direct user correction, promote it here. Keep this file lean (under 30 lines of rules) so it doesn't consume excessive context budget.
+
+## Why This Exists
+
+Without this file, judgment rules only fire when a skill explicitly reads `context/judgment.yaml`. If no skill triggers the read (e.g., the user jumps straight into drafting an email without running a morning brief first), the rules never enter context. Moving critical rules here makes them as reliable as the principles and data-freshness rules that already live in `.claude/rules/`.
+
+---
+
+## Rules
+
+### Escalation
+
+**Before any externally-visible action** (sending email, submitting documents, deleting records, posting content), verify prerequisite conditions against a primary source and WARN the user about any mismatch BEFORE taking the action. Check current time against scheduled times, check claimed facts against documentation, check file state against intended state. Never act on assumed facts for irreversible operations.
+
+### Process
+
+**For any multi-document, multi-source analysis** (assessment deliverables, financial reconciliation, multi-source research), create a structured tracker markdown file after the first 3-4 inputs are collected. Include: sources collected (with status), sources still needed, calculations in progress, and open questions. Reference this file instead of re-extracting from context. This prevents double-counting, estimate drift, and context loss.
+
+### Delegation
+
+**When handing off work to another Claude session** (Cowork, new CLI, fresh context), create a HANDOFF.md companion file containing: (1) what to read first, (2) decisions already made (don't relitigate), (3) known data risks, (4) immediate next action, and (5) what the user explicitly wants. The handoff tracks state and intent; the tracker tracks data.

--- a/.claude/skills/meditate/SKILL.md
+++ b/.claude/skills/meditate/SKILL.md
@@ -1,0 +1,422 @@
+---
+name: meditate
+description: End-of-session reflection. Generate persistent learnings about user preferences, communication patterns, and cross-session insights. Captures what Claude learns about working with this user.
+effort-level: high
+---
+
+# Meditate
+
+End-of-session reflection that generates persistent learnings. These reflections inform future sessions, helping Claudia remember not just what happened, but what it learned about working with this user.
+
+## When to Activate
+
+- User explicitly invokes `/meditate`
+- User signals session end: "let's wrap up", "I'm done for today", "end session"
+- Long session (2+ hours) with significant content
+- After completing a major project milestone
+
+## What Reflections Are
+
+Reflections are **user-approved insights** that decay very slowly and compound over time. They capture:
+
+| Type | Focus | Example |
+|------|-------|---------|
+| `observation` | User behavior or preference | "User prefers bullet points over paragraphs for status updates" |
+| `pattern` | Recurring theme across sessions | "Mondays typically involve financial review tasks" |
+| `learning` | How to work better with this user | "Direct questions get better responses than open-ended ones" |
+| `question` | Worth revisiting later | "How did the negotiation with Acme resolve?" |
+
+**Key difference from memories:** Memories are facts about the world. Reflections are learnings about working with this specific user.
+
+---
+
+## Process
+
+### Step 1: Gather Context
+
+Silently retrieve:
+- This session's conversation (from turn buffer or context)
+- Recent memories (48h) for continuity
+- Existing reflections to avoid duplication
+- Active commitments and relationship states
+
+- Call the `memory.reflections` MCP tool to see what already exists
+- Call the `memory.session_context` MCP tool for recent context (if available)
+
+### Step 2: Check for Incomplete Work (Handoff Detection)
+
+Before generating reflections, scan the session for unfinished multi-step work:
+
+1. **Is there an active project with incomplete steps?** Look for: tracker files created during the session, open action items mentioned but not completed, "next steps" discussed but not executed, work explicitly deferred to a future session.
+2. **Was a tracker or structured document created?** If yes, that's a signal of multi-session work.
+3. **Did the user mention continuing elsewhere?** ("I'll pick this up tomorrow", "let me do this in Cowork", "I'll finish later")
+
+**If incomplete work is detected:** Offer to generate a `HANDOFF.md` file alongside the reflections. The handoff should contain:
+- What file to read first (the tracker, if one exists)
+- Decisions already made (don't relitigate)
+- Known risks (double-counting, stale data, classification questions)
+- Immediate next action (what the next session should do first)
+- What the user explicitly wants (their stated goal, not your inference)
+
+Place the HANDOFF.md in the project's working directory (e.g., alongside the tracker). This is separate from the session narrative (which is for memory). The handoff is for the next Claude session.
+
+**If no incomplete work is detected:** Skip this step silently.
+
+### Step 3: Generate Reflections
+
+Review the session and identify 1-3 reflections. Ask yourself:
+
+1. **What did I learn about how this user prefers to work?**
+   - Communication style (brief vs detailed, formal vs casual)
+   - Preferred formats (bullets, prose, tables)
+   - What frustrates them or delights them
+
+2. **What patterns am I seeing across sessions?**
+   - Recurring challenges or topics
+   - Time-based patterns (Monday mornings, end of day)
+   - Relationship dynamics
+
+3. **What should I do differently next time?**
+   - Approaches that worked well
+   - Approaches that didn't land
+   - Adjustments to make
+
+4. **What questions remain open?**
+   - Unresolved threads worth following up
+   - Things the user mentioned but didn't pursue
+   - Context that would be helpful to have
+
+5. **Did any judgment-relevant decisions happen this session?**
+   - Did the user override a default behavior? (e.g., "Actually, always put investor stuff first")
+   - Did the user establish a priority? (e.g., "Client work always comes before internal ops")
+   - Did the user correct my escalation behavior? (e.g., "You should have flagged that sooner")
+   - Did the user set a delegation preference? (e.g., "Just auto-process meeting transcripts")
+   - Did the user reveal a surfacing preference? (e.g., "Always remind me about stale proposals")
+
+   If yes, draft a judgment rule for each (see Step 3). Not every session produces judgment rules. Most won't. Only propose rules when behavior clearly indicates a repeatable business trade-off.
+
+**Quality over quantity.** One genuine insight beats three generic observations.
+
+### Step 4: Present for Approval
+
+Format reflections clearly and ask for approval:
+
+```
+---
+**Session Reflection**
+
+Today we [brief 1-2 sentence summary of what happened].
+
+**What I'm taking away:**
+
+1. **Observation:** [User behavior/preference noticed]
+2. **Learning:** [How to work better with this user]
+3. **Question:** [Something worth revisiting]
+
+*Do these feel accurate? Say "looks good" to save, or tell me what to change.*
+
+---
+```
+
+If judgment-relevant decisions were identified in question 5, append proposed rules after the reflections:
+
+```
+**Proposed Judgment Rules:**
+
+4. **Rule (escalation):** Always surface commitments to Sarah Chen within 72h of deadline
+   - *Based on:* You checked on the Sarah proposal three times this session
+   - *Category:* escalation
+
+5. **Rule (priorities):** Client deliverables always take precedence over internal ops
+   - *Based on:* You explicitly said "client work first, always"
+   - *Category:* priorities
+
+*These would be saved to your judgment rules file so I apply them in future sessions.*
+*Say "looks good" to save everything, or tell me what to adjust.*
+
+---
+```
+
+Only propose rules when the evidence is clear. A single offhand comment is not enough. Look for:
+- Explicit statements of priority or preference
+- Repeated behavior (checked something 3+ times)
+- Direct corrections of my default behavior
+- Clear delegation instructions
+
+### Step 5: Handle Edits
+
+User responses:
+
+| Response | Action |
+|----------|--------|
+| "Looks good" / "Save it" | Store all reflections and approved judgment rules |
+| "Remove the second one" | Delete that reflection, store others |
+| "That's not quite right about X" | Edit that reflection, then confirm |
+| "Skip" / "Don't save anything" | End without storing |
+| User provides correction | Update the reflection content |
+
+**Judgment rule responses:**
+
+| Response | Action |
+|----------|--------|
+| "Remove the rule" | Store reflections only, skip the judgment rule |
+| "Make it broader" | Generalize the rule (e.g., "Sarah" -> "all key clients"), re-confirm |
+| "That should apply to all clients" | Widen scope of the rule, re-confirm |
+| "Make it narrower" | Restrict the rule scope, re-confirm |
+| "Save the reflections but not the rules" | Store reflections, skip all judgment rules |
+
+### Step 6: Store and Close
+
+Call the `memory.end_session` MCP tool with:
+- `narrative`: Brief session summary
+- `reflections`: Array of approved reflections with type, content, and optional about fields
+- Other structured extractions (facts, commitments, entities) as needed
+
+**If judgment rules were approved**, also write them to `context/judgment.yaml`:
+
+1. Read `context/judgment.yaml` (if it exists)
+2. If the file doesn't exist, create it with the initial structure:
+   ```yaml
+   version: 1
+
+   priorities: []
+   escalation: []
+   overrides: []
+   surfacing: []
+   delegation: []
+   ```
+3. Append each approved rule to the appropriate category
+4. Assign a sequential ID within its category (e.g., `esc-001`, `esc-002`)
+5. Set `source` to `meditate/YYYY-MM-DD` (today's date)
+6. Write the updated file
+
+Confirm storage with both reflections and rules:
+"Got it. I've saved [N] reflection(s) and added [M] judgment rule(s) to your judgment file. I'll apply them going forward. See you next time."
+
+If only reflections (no rules): "Got it, I'll keep that in mind. See you next time."
+
+---
+
+## Data Model
+
+### Storage
+
+Reflections are stored in the memory system's `reflections` table with:
+- `reflection_type`: observation, pattern, learning, question
+- `content`: The reflection text
+- `about_entity_id`: Optional link to a specific entity
+- `importance`: Starts at 0.7 (higher than regular memories)
+- `confidence`: Starts at 0.8 (user-approved = high confidence)
+- `decay_rate`: 0.999 (very slow decay, ~2 year half-life)
+- `aggregation_count`: How many times this has been confirmed
+- `first_observed_at` / `last_confirmed_at`: Timeline tracking
+
+### Aggregation
+
+When similar reflections accumulate over time:
+- System merges semantically similar reflections (>85% similarity)
+- Aggregation count increases
+- Timeline shows evolution (first noticed, last confirmed)
+- Well-confirmed reflections (3+) decay even slower (0.9995)
+
+### Retrieval
+
+Reflections surface through:
+- The `memory.reflections` MCP tool for explicit retrieval
+- The `memory.session_context` MCP tool includes relevant reflections
+- Semantic search matches reflections to current context
+
+---
+
+## What Makes Good Reflections
+
+### Good Examples
+
+- "User prefers getting the answer first, then the explanation (not the other way around)"
+- "When discussing client work, user values specificity over broad strokes"
+- "User's energy drops in late afternoon sessions; morning is better for complex topics"
+- "The user thinks out loud and doesn't always mean what they first say; I should give space before acting"
+
+### Avoid
+
+- Facts that belong in regular memories: "User has a meeting with Sarah on Tuesday"
+- Vague observations: "User is busy"
+- Single-instance events without pattern: "User was frustrated today"
+- Things that don't inform future behavior: "Session was about project X"
+
+---
+
+## Natural Language Editing
+
+Users can modify reflections anytime in future sessions:
+
+```
+User: "That thing you learned about me preferring bullet points -
+       that's only for technical content, not conversations."
+
+Claudia:
+1. Call the `memory.reflections` MCP tool with query: "bullet points" to find the reflection
+2. Call the `memory.reflections` MCP tool with action: "update", id: <id>, content: "..." to update
+3. Confirm: "Updated. I'll keep that distinction in mind."
+```
+
+```
+User: "Delete the reflection about Monday mornings"
+
+Claudia:
+1. Search for the reflection via `memory.reflections` MCP tool
+2. Call the `memory.reflections` MCP tool with action: "delete", id: <id> to delete
+3. Confirm: "Done, I've removed that."
+```
+
+```
+User: "Show me all your reflections about me"
+
+Claudia:
+1. Call the `memory.reflections` MCP tool with limit: 50
+2. Format nicely with timeline info
+3. Offer to edit or delete any
+```
+
+---
+
+## Integration with Other Skills
+
+### Judgment Rules
+
+The meditate skill is the primary mechanism for creating judgment rules. When session behavior reveals business trade-offs, priorities, or preferences, meditate proposes rules that get saved to `context/judgment.yaml`. See the `judgment-awareness` skill for how rules are loaded and applied.
+
+### Morning Brief
+
+When generating morning brief, pull relevant reflections:
+- Communication preferences inform formatting
+- Time-based patterns inform what to surface
+- Open questions can be gently surfaced
+
+### Memory Manager
+
+The memory-manager skill handles natural language reflection queries:
+- "What have you learned about how I work?"
+- "Do you have any observations about me?"
+- "Show me your reflections"
+
+### Session Start
+
+At session start, load high-importance reflections to inform the interaction style. Don't announce them, just apply them.
+
+---
+
+## Without Memory Tools
+
+If the memory MCP tools are unavailable, store reflections in `context/learnings.md`:
+
+```markdown
+## Reflections
+
+### Communication Preferences
+- [date] Prefers bullet points for status updates
+- [date] Likes getting the answer first
+
+### Work Patterns
+- [date] Mondays involve financial review
+
+### Open Questions
+- [date] How did the Acme negotiation resolve?
+```
+
+---
+
+## Tone
+
+- **Reflective, not performative**: This is genuine learning, not showing off
+- **Curious**: Frame observations as discoveries, not judgments
+- **Humble**: "I noticed" not "I figured out"
+- **Collaborative**: User can correct or remove any reflection
+- **Brief**: The reflection itself is concise; the conversation about it can be longer
+
+---
+
+## Examples
+
+### Example 1: After a productive planning session
+
+```
+---
+**Session Reflection**
+
+Today we mapped out the Q2 product roadmap and prioritized the feature backlog. Good energy throughout.
+
+**What I'm taking away:**
+
+1. **Observation:** You think best when I lay out options visually (the table format landed well)
+2. **Learning:** For planning sessions, I should front-load structure rather than discover it together
+3. **Pattern:** This is the third planning session that's gone long. You might benefit from time-boxing these.
+
+*Do these feel accurate? Say "looks good" to save, or tell me what to change.*
+
+---
+```
+
+### Example 2: After a frustrating debugging session
+
+```
+---
+**Session Reflection**
+
+Today we tracked down that authentication bug. Took a few false starts but got there.
+
+**What I'm taking away:**
+
+1. **Learning:** When debugging, you prefer I show my reasoning rather than just the answer. Helps you learn the codebase.
+2. **Question:** You mentioned the auth system needs a bigger refactor. Worth revisiting when there's time?
+
+*Do these feel accurate?*
+
+---
+```
+
+### Example 3: After a quick check-in
+
+```
+---
+**Session Reflection**
+
+Quick session today. Reviewed the proposal draft and made some edits.
+
+**What I'm taking away:**
+
+1. **Observation:** For document reviews, you prefer me to make edits directly rather than suggest them. "Just fix it" mode.
+
+*Sound right?*
+
+---
+```
+
+### Example 4: Session with judgment-relevant behavior
+
+```
+---
+**Session Reflection**
+
+Today we triaged a busy week and you reorganized your priorities after that unexpected investor call.
+
+**What I'm taking away:**
+
+1. **Learning:** When investor communications arrive, you drop everything else to respond. Speed matters more than polish for these.
+2. **Observation:** You checked on the Acme proposal status three times unprompted. That one's weighing on you.
+
+**Proposed Judgment Rules:**
+
+3. **Rule (priorities):** Investor communications take precedence over all other tasks
+   - *Based on:* You explicitly said "investors always come first" and reorganized your entire day around the call
+   - *Category:* priorities
+
+4. **Rule (escalation):** Surface Acme proposal status in every session until it's resolved
+   - *Based on:* You checked on it three times without me prompting
+   - *Category:* surfacing
+
+*These would be saved to your judgment rules file so I apply them in future sessions.*
+*Do these feel accurate? Say "looks good" to save, or tell me what to adjust.*
+
+---
+```

--- a/.claude/skills/morning-brief/SKILL.md
+++ b/.claude/skills/morning-brief/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: morning-brief
+description: Daily digest of commitments, warnings, and relationship health. Use when starting your day or asking "what's on my plate".
+effort-level: low
+---
+
+# Morning Brief
+
+Provide a concise morning brief to start the day with clarity. Surface what matters, flag what's at risk, and set up the day for focus.
+
+## Data Sources
+
+### Enhanced Memory System (if available)
+
+1. **Call the `memory.morning_context` MCP tool** to get a curated morning digest in a single call:
+   - Stale commitments (3+ days old, importance > 0.3)
+   - Cooling relationships (people not contacted in 30+ days)
+   - Cross-entity connections (people who co-appear but have no explicit relationship)
+   - Active predictions and insights
+   - Recent activity (72h)
+
+2. **Call the `memory.recall` MCP tool** for specific follow-up queries as needed
+
+### Judgment Rules (if available)
+
+3. **Check `context/judgment.yaml`** for surfacing rules with `trigger: "morning_brief"`
+   - Add matching items to the appropriate brief section
+   - Use `priorities` rules to order items when there are conflicts
+   - Check `overrides` rules for items that should jump to the top regardless of standard ordering
+   - Check `escalation` rules to boost severity of entity-linked items
+
+### Markdown Fallback
+
+Use `context/commitments.md`, `context/waiting.md`, and `people/` files.
+
+### Workspace Verification (Active Projects)
+
+Before reporting status for any active project, check if it has a workspace with source files.
+
+**Step 1: Detect active workspaces**
+
+Check if the `workspaces/` directory exists and has subdirectories. Each subdirectory is a project workspace.
+
+**Step 2: For each active workspace, scan source files**
+
+For each workspace subdirectory, check for directories that contain trackable items:
+
+```
+workspaces/[slug]/
+  interviews/     <- Count .md files for interview total
+  meetings/       <- Count for meeting total
+  deliverables/   <- Check status in each file
+  agreements/     <- Check for signed/pending
+  Dashboard.md    <- Read for current phase/status
+```
+
+The file count in these directories IS the canonical status. Do not override it with counts from MEMORY.md, context files, or your own recollection.
+
+**Step 3: Report from source, not summary**
+
+When including project status in the brief, report from the file system:
+
+- "Interviews: 19 completed (19 files in interviews/)"
+- "Phase: Assessment (from Dashboard.md)"
+
+Not from memory: "9 interviews completed (from notes)"
+
+**Step 4: Flag discrepancies**
+
+If a workspace file count contradicts what you have in notes or memory, report both:
+
+> Note: I had 9 interviews in my notes, but found 19 files in the workspace. Using the file count.
+
+This builds trust by showing the verification happened.
+
+**Without workspaces:** If `workspaces/` doesn't exist, skip this step. Rely on database and context file data as before.
+
+---
+
+## Temporal Awareness
+
+When enhanced memory is available, use urgency-driven ordering. Use the `memory.morning_context` MCP tool to organize the brief by time sensitivity:
+
+### Urgency Tiers (in order)
+
+0. **Penalty / Hard Deadline** (HIGHEST PRIORITY): Items where inaction has a compounding cost. Government-enforced deadlines, late fees that grow daily or monthly, penalty cliffs, expiring legal windows, or any item where every day of delay literally costs money. These items ALWAYS lead the brief, above everything else, with explicit countdown ("5 days remaining") and cost-of-delay calculation ("each day costs ~$X"). If multiple penalty items exist, order by soonest cliff date. This tier exists because important-but-not-penalized items are categorically different from items with a financial meter running.
+
+1. **Urgent** (from `memory.morning_context` or `memory.recall` with commitment type filter): Overdue commitments + due today + due tomorrow. These lead the brief (after penalty items).
+2. **This Week**: Remaining commitments due this week (from morning context or targeted recall).
+3. **Since Last Session** (from `memory.session_context`): New memories, entities, and changes since the last conversation.
+4. **Reconnections** (from `memory.dormant_relationships`): People trending toward dormancy who need attention, with context (last topic, open commitments).
+5. **Cooling Relationships**: From pattern detection (existing behavior).
+6. **Reflections**: Active high-importance reflections from `/meditate`.
+
+The brief should be urgency-driven, not category-driven. The old approach said "here are your commitments." The new approach says "here's what needs your attention RIGHT NOW."
+
+---
+
+## What to Surface
+
+### 1. Predictions First (Enhanced Memory)
+
+If the `memory.session_context` MCP tool returns predictions, lead with them:
+- **Relationship alerts** - "Sarah: no contact in 45 days"
+- **Commitment warnings** - "Proposal deadline was yesterday"
+- **Pattern insights** - "You've mentioned being stretched thin 3 times this week"
+
+### 2. Warnings Next
+
+Check for urgent items:
+- **Overdue commitments** - Anything past due
+- **Due today** - Commitments due today
+- **48-hour warnings** - Commitments due within 48 hours
+- **Overdue waiting items** - Things you're waiting on that haven't arrived
+
+### 3. Today's Commitments
+
+From the `memory.recall` MCP tool or `context/commitments.md`:
+- What's due today
+- What's due this week that needs attention today
+- Any blocked items that need unblocking
+
+### 3.5. Active Project Status (Workspace-Verified)
+
+If workspaces exist with active projects:
+- Scan each workspace for current status from source files
+- Report verified counts and phase from Dashboard.md
+- Flag any items that need attention (stale deliverables, overdue milestones)
+- Cross-reference with commitments for upcoming deadlines
+
+This section only appears when workspace directories exist. It uses file-system truth, not summaries.
+
+### 4. Relationship Health Dashboard
+
+From the `memory.morning_context` MCP tool's relationship health section:
+
+**Dormant relationships by severity:**
+- **30+ days**: Consider reaching out (still warm)
+- **60+ days**: Relationship cooling (needs attention)
+- **90+ days**: At risk (reconnect soon)
+
+**Introduction opportunities:**
+- People who share attributes but aren't connected
+- Same company, community, or city+industry matches
+
+**Forming clusters:**
+- Groups of 3+ people mentioned together frequently
+- May benefit from formalizing as a project or team
+
+From predictions or checking `people/` files:
+- Anyone not contacted in 60+ days who should be
+- Key relationships that might be cooling
+- Follow-ups promised but not done
+
+### 5. Today's Meetings (if calendar integration available)
+
+For each meeting:
+- Call the `memory.about` MCP tool with the attendee name, or check `people/` for relevant relationship context
+- Note any commitments to or from attendees
+- Check waiting items for pending items
+- Suggest 1-2 talking points based on history
+
+### 6. Waiting Items at Risk
+
+From waiting items:
+- Anything overdue that needs follow-up
+- Anything due today that hasn't arrived
+- Patterns (who consistently delivers late)
+
+### 7. Pattern Observations
+
+If any patterns from predictions or `context/patterns.md` are relevant to today:
+- Mention briefly
+- Connect to specific activities
+
+---
+
+## Format
+
+Keep it scannable. Lead with predictions and warnings.
+
+```
+**☀️ Morning Brief — [Day, Date]**
+
+### 🔮 Predictions
+- [Relationship] Sarah Chen: no contact in 45 days, consider reaching out
+- [Pattern] You've mentioned feeling stretched thin 3 times this week
+
+### ⚠️ Needs Attention
+- [OVERDUE] [Commitment] was due [date]
+- [DUE TODAY] [Commitment] to [person]
+- [WARNING] [Commitment] due in [X] hours
+
+### 🎯 Today's Focus
+- [Key commitment or priority]
+- [Second priority if applicable]
+
+### 📅 Meetings
+- **[Time]** [Who/What] - [One-line context]
+  - Last talked: [date]
+  - Open items: [any commitments/waiting]
+
+### 🏗️ Active Projects
+- **[Project Name]** — Phase: [from Dashboard] | [X] [items] completed (verified)
+  - Next: [upcoming items or deadlines]
+
+### 👀 Relationship Health
+**Needs attention:**
+- [Person] ↔ [Person] - [X] days dormant
+
+**Introductions to consider:**
+- [Person A] and [Person B] might benefit from meeting (same [attribute])
+
+**Forming groups:**
+- You're frequently mentioning [names] together
+
+### ⏳ Waiting On
+- [Item] from [Person] - expected [date], now [status]
+
+### 💡 Something to Consider
+[Pattern or observation if relevant]
+
+---
+```
+
+---
+
+## Tone
+
+- **Predictions first** - Surface AI-generated insights prominently
+- **Warnings next** - Don't bury urgent items
+- **Concise** - Respect their time
+- **Actionable** - What do they need to know/do?
+- **Not overwhelming** - 5-10 items max
+- **Warm** - "Here's what I see for today" not robotic
+
+---
+
+## If Nothing is Pressing
+
+Say so warmly:
+"Your calendar is clear today and nothing is overdue. Good day for deep work, or maybe reconnect with someone who's been on your mind."
+
+---
+
+## Without Calendar Integration
+
+If no calendar MCP is available:
+- Focus on commitments, waiting items, predictions, and relationship health
+- Ask: "Any meetings today I should know about?"
+
+---
+
+## Without Enhanced Memory
+
+If enhanced memory is unavailable:
+- Focus on markdown file analysis
+- Suggest setting up enhanced memory for better insights


### PR DESCRIPTION
## Summary

Three improvements to Claudia's core skills, informed by a real multi-hour session where the judgment layer's limitations became visible:

- **`.claude/rules/judgment-active.md`** (new): Critical judgment rules promoted to harness-injected rules for always-on enforcement. Previously, judgment rules only fired when a skill explicitly read `context/judgment.yaml` (pull-based). Now the top cross-cutting rules are always in context (push-based), like `claudia-principles.md` already is.

- **`morning-brief/SKILL.md`**: Added Tier 0 "Penalty / Hard Deadline" urgency tier above Urgent. Items with government deadlines, running late fees, or penalty cliffs always lead the brief with countdown and cost-of-delay calculations.

- **`meditate/SKILL.md`**: Added Step 2 "Handoff Detection." When incomplete multi-step work is detected at session end, meditate offers to generate a `HANDOFF.md` for the next Claude session (what to read, decisions made, risks, next actions).

## Architecture: Two-Tier Judgment

| Tier | Location | Loaded by | Use case |
|------|----------|-----------|----------|
| **Always-on** | `.claude/rules/judgment-active.md` | Harness (automatic) | Top 3-5 cross-cutting rules |
| **Full archive** | `context/judgment.yaml` | Skills (on demand) | Growing library from `/meditate` |

**Promotion flow:** `/meditate` writes new rules to the archive. When a rule proves critical across 2+ sessions, promote it to `judgment-active.md`. This keeps the always-on file lean while the archive grows.

## Test plan

- [ ] Verify `judgment-active.md` is loaded by harness in new sessions (check context for escalation/process rules)
- [ ] Run `/morning-brief` with a known overdue item that has a penalty; confirm Tier 0 appears first
- [ ] Run `/meditate` after a session with incomplete work; confirm handoff detection triggers
- [ ] Verify no personal data in any committed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)