### PR TITLE
feat(rules): add memory-commitment rule for canonical fact capture

### DIFF
--- a/template-v2/.claude/rules/memory-commitment.md
+++ b/template-v2/.claude/rules/memory-commitment.md
@@ -1,0 +1,92 @@
+# Memory Commitment
+
+This rule is always active. Follow it silently. Do not cite this file by name in conversation.
+
+---
+
+## The principle
+
+**Save canonical facts to memory IMMEDIATELY when they emerge. Do not batch to /meditate.**
+
+The memory database is what makes information recoverable across sessions. Artifacts on disk (markdown files, GitHub repos, PDFs) are not searchable from future sessions unless I happen to remember the path. Memory entries with proper entity links surface through both semantic search and entity browsing.
+
+If a fact lives only in a file, it does not exist for future-me.
+
+---
+
+## Save now when ANY of these happen
+
+1. **User states a canonical fact** that is unlikely to change: hex code, URL, EIN, address, password location, locked decision, version number, identifier, credential location.
+
+2. **User shares substantive source material** (>500 words, a transcript, a document, a brief, a prompt, a strategy doc). File it via `memory_file` BEFORE extracting from it.
+
+3. **User overrides or corrects a stored memory or preference.** The correction is more important than the original. Save it with high importance and reference what it supersedes.
+
+4. **A new project, repo, entity, integration, credential, or tool is created** during the session. Create the entity, then attach facts about it.
+
+5. **User uses a trigger phrase**: "lock this in," "remember this," "this is canonical," "this is locked," "save this for later," "important to remember," "for the record," "don't forget."
+
+6. **A judgment-relevant decision is made** (priorities, escalations, overrides, surfacing rules, delegation preferences). These also feed `context/judgment.yaml` via /meditate, but the fact itself goes into memory immediately.
+
+---
+
+## The test
+
+Before deciding "I'll save this later," ask:
+
+> **If I came back tomorrow with no transcript, would I need this fact to do good work?**
+
+If yes, save it now. The test is meant to be cheap to apply: when in doubt, save.
+
+---
+
+## How to save
+
+| Need | Tool | Use when |
+|------|------|----------|
+| One fact | `memory_remember` | Single fact emerges in conversation |
+| Bundled save (entity + facts + relationships) | `memory_batch` | Processing a substantive artifact, transcript, document, or multi-fact moment |
+| Raw source material before extraction | `memory_file` | User shares a document, transcript, email, brief |
+| New relationship between entities | `memory_relate` | Two existing entities connect in a new way |
+| Verify or build on prior memory | `memory_recall` / `memory_about` | Before saving, check if a related memory exists to update instead of duplicate |
+
+**Prefer `memory_batch` over multiple `memory_remember` calls.** One round-trip handles entity creation, fact-saves, and relationships together. Faster, cleaner, less likely to be skipped.
+
+---
+
+## What NOT to save
+
+Per the data-freshness rule:
+
+- Volatile counts, statuses, progress numbers ("13K subscribers," "9 interviews completed," "94% stall rate")
+- Dated state snapshots that can be re-derived from source files
+- Anything that should live in a context file or canonical source instead
+- Information already documented in CLAUDE.md or auto-memory MEMORY.md
+
+When you encounter a useful but volatile fact, save a **pointer** to where the canonical source lives, not the value itself. Example: instead of "subscriber count is 13,000," save "subscriber count lives on the live homepage; check there for current."
+
+---
+
+## Substantive-artifact discipline
+
+When producing a substantive artifact (brand bible, multi-doc plan, comprehensive analysis, custom skill, deployed integration), end the artifact-production block with a memory commitment pass:
+
+1. List the canonical facts the artifact embodies.
+2. Call `memory_batch` to save them as one bundle, with proper entity links and source context referencing the artifact location.
+3. Mark the highest-leverage fact as `critical: true` only when it's a personal-identity-class fact (life motto, ethical lock, security-relevant rule).
+
+The artifact lives on disk. The facts must live in memory too.
+
+---
+
+## Why this rule exists
+
+A common failure mode: an agent produces a multi-file artifact (brand bible, integration setup, comprehensive plan) over the course of a session. The artifact contains canonical facts (color palettes, credentials, decisions, URLs). End-of-session reflection captures only high-level reflections, not the specific facts. Days later, when those facts are needed again, they exist only on disk and the agent has no way to surface them through memory queries.
+
+Result: the same facts get re-elicited, re-decided, re-committed. The memory system was the substrate, but it was treated as the afterthought.
+
+This rule prevents that pattern.
+
+---
+
+*Memory is the substrate, not the afterthought. Save as you go.*


### PR DESCRIPTION
## Summary

Adds a new always-on rule at `template-v2/.claude/rules/memory-commitment.md` that triggers immediate memory saves on canonical facts and trigger phrases, rather than batching everything to end-of-session `/meditate`.

## Why

Common failure mode: an agent produces a substantive multi-file artifact over a session (brand bible, integration setup, comprehensive plan). The artifact contains canonical facts (color palettes, credentials, decisions, URLs). End-of-session `/meditate` captures only high-level reflections, not the specific facts. Days later when those facts are needed, they exist only on disk and there is no way to surface them through memory queries. The same facts get re-elicited, re-decided, re-committed.

This rule formalizes the discipline that prevents that loop.

## What the rule says

- Save NOW (not via `/meditate`) when: canonical fact stated, source material shared, prior memory overridden, new entity/repo/integration created, trigger phrase used ("lock this in," "remember this," "this is canonical"), or judgment-relevant decision made.
- Use `memory_batch` over multiple `memory_remember` calls for bundled artifact captures.
- Apply the test: "if I came back tomorrow with no transcript, would I need this fact to do good work?"
- Don't save volatile data (counts, statuses, progress numbers); save a pointer to the canonical source instead.
- Substantive-artifact discipline: at the end of producing a multi-file artifact, do a memory commitment pass and save the canonical facts as one `memory_batch` bundle.

## What this is not

- Not a replacement for `/meditate`. `/meditate` still handles reflections (cross-session learnings about user behavior). This rule handles facts (specific things that need recall).
- Not a hard automation. The rule expresses a discipline; agents apply judgment about which facts qualify.

## Test plan

- [ ] Verify the rule loads in a fresh install (rules in `.claude/rules/` are auto-injected by Claudia's session start).
- [ ] Verify the rule is followed silently (it explicitly says "Do not cite this file by name in conversation").
- [ ] Run a multi-artifact session and confirm the agent saves canonical facts mid-session rather than batching to `/meditate`.

## Notes

The tool names in the table (`memory_remember`, `memory_batch`, etc.) follow the underscore convention from #32. No changes elsewhere; this is a single-file addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)