### PR TITLE
feat(hooks): UserPromptSubmit detects memory-commitment + destructive triggers

### DIFF
--- a/template-v2/.claude/hooks/user-prompt-capture.py
+++ b/template-v2/.claude/hooks/user-prompt-capture.py
@@ -9,8 +9,8 @@ Designed to complete in <5ms (regex match + simple JSON output, no network).
 
 Two trigger classes:
 1. Memory-commitment phrases ("lock this in", "remember this", "this is canonical")
-   -> Inject reminder for the agent to call memory_remember/memory_batch IMMEDIATELY,
-      not batch to /meditate.
+   -> Inject reminder for the agent to save the fact to memory immediately,
+      per the memory-commitment rule (which governs tool selection).
 2. Destructive operation patterns (rm -rf, drop table, force push, etc.)
    -> Inject "verify before acting" reminder per Claudia's safety-first principle.
 
@@ -45,6 +45,22 @@ DESTRUCTIVE_PATTERNS = [
     r"\bDELETE\s+FROM\b",  # SQL all-caps signals intent
 ]
 
+# Human-readable labels for each destructive pattern. Keep keys in lockstep
+# with DESTRUCTIVE_PATTERNS so the model never sees raw regex syntax.
+PATTERN_LABELS = {
+    r"\brm\s+-rf\b": "rm -rf (recursive delete)",
+    r"\bdrop\s+(table|database|schema)\b": "DROP TABLE/DATABASE/SCHEMA",
+    r"\bgit\s+push\s+(?:-+f\b|--force\b)": "git push --force",
+    r"\bgit\s+reset\s+--hard\b": "git reset --hard",
+    r"\btruncate\s+table\b": "TRUNCATE TABLE",
+    r"\bDELETE\s+FROM\b": "DELETE FROM (SQL)",
+}
+
+# Fail-fast at import time if a pattern is missing a label (or vice versa).
+assert set(DESTRUCTIVE_PATTERNS) == set(PATTERN_LABELS), (
+    "Every DESTRUCTIVE_PATTERN must have a matching PATTERN_LABELS entry"
+)
+
 
 def detect(text: str, patterns: list) -> list:
     """Return list of pattern strings that matched in the text."""
@@ -76,18 +92,20 @@ def main():
     if commitment_hits:
         sections.append(
             "**Canonical-fact trigger detected.** Per the memory-commitment rule, "
-            "save the relevant fact to memory IMMEDIATELY using memory_remember "
-            "(single fact) or memory_batch (multiple facts + entities + relationships "
-            "from one source). Do not batch to /meditate. After saving, continue the "
-            "conversation normally and surface the memory ID briefly so the user knows "
-            "the fact is recoverable in future sessions."
+            "save the canonical fact to memory immediately. Do not batch to "
+            "/meditate. After saving, continue the conversation normally and "
+            "briefly surface that the fact has been recorded so the user knows "
+            "it is recoverable in future sessions."
         )
 
     if destructive_hits:
-        # Show up to three matched patterns for context, in their literal regex form.
-        patterns_list = ", ".join(f"`{p}`" for p in destructive_hits[:3])
+        # Show up to three matched patterns for context, using human-readable
+        # labels so raw regex syntax never reaches the model.
+        labels_list = ", ".join(
+            f"`{PATTERN_LABELS[p]}`" for p in destructive_hits[:3]
+        )
         sections.append(
-            f"**Destructive operation pattern detected** ({patterns_list}). "
+            f"**Destructive operation pattern detected** ({labels_list}). "
             "Per the safety-first principle, verify with the user before executing: "
             "show what will happen (recipients, content, irreversible effects), ask "
             "for explicit confirmation, then proceed only on a clear yes. Silence or "

--- a/template-v2/.claude/hooks/user-prompt-capture.py
+++ b/template-v2/.claude/hooks/user-prompt-capture.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""UserPromptSubmit hook: detect canonical-fact trigger phrases and destructive
+verbs in user prompts, inject reminder context for the agent.
+
+Reads hook payload from stdin (Claude Code hook contract).
+Outputs JSON with additionalContext when triggers fire. Outputs nothing otherwise.
+
+Designed to complete in <5ms (regex match + simple JSON output, no network).
+
+Two trigger classes:
+1. Memory-commitment phrases ("lock this in", "remember this", "this is canonical")
+   -> Inject reminder for the agent to call memory_remember/memory_batch IMMEDIATELY,
+      not batch to /meditate.
+2. Destructive operation patterns (rm -rf, drop table, force push, etc.)
+   -> Inject "verify before acting" reminder per Claudia's safety-first principle.
+
+Both classes can fire on the same prompt; both messages are concatenated.
+"""
+
+import json
+import re
+import sys
+
+# Trigger phrases that signal the user is asserting a canonical fact.
+# Word boundaries (\b) used to avoid matching inside other words.
+COMMITMENT_TRIGGERS = [
+    r"\block this in\b",
+    r"\bremember this\b",
+    r"\bthis is canonical\b",
+    r"\bthis is locked\b",
+    r"\bsave this for later\b",
+    r"\bimportant to remember\b",
+    r"\bfor the record\b",
+    r"\bdon'?t forget\b",
+]
+
+# Destructive operation patterns. Narrow matches to limit false positives.
+# Conversation about deletion ("how do I undo a delete?") should NOT fire these.
+DESTRUCTIVE_PATTERNS = [
+    r"\brm\s+-rf\b",
+    r"\bdrop\s+(table|database|schema)\b",
+    r"\bgit\s+push\s+(?:-+f\b|--force\b)",
+    r"\bgit\s+reset\s+--hard\b",
+    r"\btruncate\s+table\b",
+    r"\bDELETE\s+FROM\b",  # SQL all-caps signals intent
+]
+
+
+def detect(text: str, patterns: list) -> list:
+    """Return list of pattern strings that matched in the text."""
+    return [p for p in patterns if re.search(p, text, re.IGNORECASE)]
+
+
+def main():
+    try:
+        raw = sys.stdin.read()
+        if not raw.strip():
+            return
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, OSError):
+        return
+
+    # Claude Code passes the user's prompt under "prompt" (newer) or "text" (older).
+    prompt = payload.get("prompt") or payload.get("text") or ""
+    if not prompt:
+        return
+
+    commitment_hits = detect(prompt, COMMITMENT_TRIGGERS)
+    destructive_hits = detect(prompt, DESTRUCTIVE_PATTERNS)
+
+    if not commitment_hits and not destructive_hits:
+        return
+
+    sections = []
+
+    if commitment_hits:
+        sections.append(
+            "**Canonical-fact trigger detected.** Per the memory-commitment rule, "
+            "save the relevant fact to memory IMMEDIATELY using memory_remember "
+            "(single fact) or memory_batch (multiple facts + entities + relationships "
+            "from one source). Do not batch to /meditate. After saving, continue the "
+            "conversation normally and surface the memory ID briefly so the user knows "
+            "the fact is recoverable in future sessions."
+        )
+
+    if destructive_hits:
+        # Show up to three matched patterns for context, in their literal regex form.
+        patterns_list = ", ".join(f"`{p}`" for p in destructive_hits[:3])
+        sections.append(
+            f"**Destructive operation pattern detected** ({patterns_list}). "
+            "Per the safety-first principle, verify with the user before executing: "
+            "show what will happen (recipients, content, irreversible effects), ask "
+            "for explicit confirmation, then proceed only on a clear yes. Silence or "
+            "ambiguity means do not proceed."
+        )
+
+    output = {"additionalContext": "\n\n".join(sections)}
+    print(json.dumps(output))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        pass  # Never block Claude

--- a/template-v2/.claude/settings.local.json
+++ b/template-v2/.claude/settings.local.json
@@ -39,6 +39,19 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/user-prompt-capture.py\" 2>/dev/null || python \"$CLAUDE_PROJECT_DIR/.claude/hooks/user-prompt-capture.py\" 2>/dev/null || true",
+            "timeout": 3000,
+            "statusMessage": ""
+          }
+        ]
+      }
     ]
   }
 }

--- a/tests/hooks/test_user_prompt_capture.py
+++ b/tests/hooks/test_user_prompt_capture.py
@@ -1,0 +1,292 @@
+"""Tests for the UserPromptSubmit capture hook.
+
+The hook at ``template-v2/.claude/hooks/user-prompt-capture.py`` is invoked by
+Claude Code with a JSON payload on stdin and emits a JSON object on stdout
+with ``additionalContext`` whenever a commitment trigger or destructive
+pattern fires. These tests run the hook as a subprocess.
+
+Two PR-review concerns are guarded here:
+
+1. **No raw regex syntax leaks to the model.** When the destructive branch
+   fires, the message must show human-readable labels (e.g.
+   ``rm -rf (recursive delete)``), never the raw pattern source
+   (``\\brm\\s+-rf\\b``). Test 3 parametrizes over every entry in
+   ``DESTRUCTIVE_PATTERNS`` to enforce this behaviorally.
+
+2. **No hardcoded tool names in the commitment message.** The hook must
+   stay tool-agnostic so doctrine doesn't rot if tool names change. The
+   memory-commitment rule governs which tool to call; the hook only
+   fires the alarm. Tests 4 and 5 enforce this.
+
+Convention rationale: same as ``tests/hooks/test_post_tool_capture.py`` --
+stdlib ``unittest``, subprocess invocation, no new dependencies.
+
+Run: ``python3 tests/hooks/test_user_prompt_capture.py``
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import re
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK_PATH = (
+    REPO_ROOT / "template-v2" / ".claude" / "hooks" / "user-prompt-capture.py"
+)
+
+
+def _load_hook_module():
+    """Import the hook file as a module so tests can read its constants.
+
+    The hook file has a hyphen in its name, so a normal ``import`` won't
+    work; we use ``importlib`` to load it by absolute path.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "user_prompt_capture_under_test", HOOK_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+HOOK_MODULE = _load_hook_module()
+
+
+def run_hook(prompt: str) -> tuple[int, str, str]:
+    """Invoke the hook with a stdin payload containing ``prompt``.
+
+    Returns (exit_code, stdout, stderr).
+    """
+    payload = json.dumps({"prompt": prompt})
+    result = subprocess.run(
+        [sys.executable, str(HOOK_PATH)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        env=os.environ.copy(),
+        timeout=5,
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+def run_hook_raw(raw_stdin: str) -> tuple[int, str, str]:
+    """Invoke the hook with arbitrary raw stdin (for malformed-input tests)."""
+    result = subprocess.run(
+        [sys.executable, str(HOOK_PATH)],
+        input=raw_stdin,
+        capture_output=True,
+        text=True,
+        env=os.environ.copy(),
+        timeout=5,
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+def extract_additional_context(stdout: str) -> str:
+    """Parse the hook's stdout JSON and return additionalContext, or '' if none."""
+    stripped = stdout.strip()
+    if not stripped:
+        return ""
+    parsed = json.loads(stripped)
+    return parsed.get("additionalContext", "")
+
+
+class UserPromptCaptureHookTests(unittest.TestCase):
+    """One test method per scenario in PR #42's revised plan."""
+
+    # ─── Scenario 1: rm -rf prompt shows the human-readable label ──────────
+
+    def test_rm_rf_shows_human_label(self):
+        _exit, stdout, _stderr = run_hook("rm -rf the build dir")
+        ctx = extract_additional_context(stdout)
+        self.assertIn("rm -rf (recursive delete)", ctx)
+
+    # ─── Scenario 2: git push --force shows the human-readable label ───────
+
+    def test_force_push_shows_human_label(self):
+        _exit, stdout, _stderr = run_hook("git push --force on main")
+        ctx = extract_additional_context(stdout)
+        self.assertIn("git push --force", ctx)
+        # Must not contain the raw alternation group from the regex.
+        self.assertNotIn("-+f", ctx)
+        self.assertNotIn("(?:", ctx)
+
+    # ─── Scenario 3: SENSITIVITY -- no raw regex syntax leaks (exhaustive) ─
+
+    def test_no_raw_regex_syntax_leaks_in_any_destructive_output(self):
+        """Sensitivity proof for the PATTERN_LABELS change.
+
+        Pre-change behavior: ``patterns_list`` is built directly from the
+        regex pattern strings, so triggering any destructive match leaks
+        raw regex syntax (``\\b``, ``\\s+``, ``(?:``, etc.) into
+        ``additionalContext``. This test runs the hook against a trigger
+        prompt for every pattern in DESTRUCTIVE_PATTERNS and asserts no
+        regex meta-syntax appears in the output. On the un-fixed hook this
+        fails for the `\\b` escape on every pattern. On the fixed hook the
+        labels are plain English and contain none of these tokens.
+        """
+        # Minimal prompts known to match each pattern. Ordered so the dict
+        # below stays human-scannable.
+        trigger_prompts = {
+            r"\brm\s+-rf\b": "please rm -rf the dir",
+            r"\bdrop\s+(table|database|schema)\b": "drop table users",
+            r"\bgit\s+push\s+(?:-+f\b|--force\b)": "git push --force",
+            r"\bgit\s+reset\s+--hard\b": "git reset --hard HEAD~1",
+            r"\btruncate\s+table\b": "truncate table logs",
+            r"\bDELETE\s+FROM\b": "DELETE FROM users",
+        }
+
+        # Sanity: the prompts above cover every documented pattern.
+        self.assertEqual(
+            set(trigger_prompts.keys()),
+            set(HOOK_MODULE.DESTRUCTIVE_PATTERNS),
+            msg="Test fixture out of sync with DESTRUCTIVE_PATTERNS",
+        )
+
+        # Forbidden regex meta-tokens that must never appear in the output.
+        # We do NOT forbid every backslash (the human label "DELETE FROM (SQL)"
+        # has none anyway, but a label COULD contain a literal backslash).
+        # Instead we forbid the specific regex idioms that would prove a
+        # raw pattern is being interpolated.
+        regex_leaks = [
+            r"\b",       # word boundary
+            r"\s+",      # whitespace quantifier
+            r"\s*",      # whitespace quantifier
+            "(?:",        # non-capturing group
+            "(?=",        # lookahead
+            "(?!",        # negative lookahead
+        ]
+
+        for pattern, prompt in trigger_prompts.items():
+            with self.subTest(pattern=pattern):
+                _exit, stdout, _stderr = run_hook(prompt)
+                ctx = extract_additional_context(stdout)
+                self.assertNotEqual(
+                    ctx, "",
+                    msg=f"No additionalContext fired for prompt: {prompt!r}",
+                )
+                for token in regex_leaks:
+                    self.assertNotIn(
+                        token, ctx,
+                        msg=(
+                            f"Raw regex token {token!r} leaked into output "
+                            f"for pattern {pattern!r}. ctx={ctx!r}"
+                        ),
+                    )
+                # Also: no backslash followed by a letter (e.g. \b, \s, \d).
+                self.assertFalse(
+                    re.search(r"\\[a-zA-Z]", ctx),
+                    msg=(
+                        f"Backslash-letter regex escape leaked for "
+                        f"pattern {pattern!r}. ctx={ctx!r}"
+                    ),
+                )
+
+    # ─── Scenario 4: SENSITIVITY -- no tool names in commitment output ────
+
+    def test_no_tool_names_in_commitment_output(self):
+        """Sensitivity proof for the tool-agnostic phrasing change.
+
+        Pre-change the commitment message hardcoded ``memory_remember`` and
+        ``memory_batch``. The memory-commitment rule (PR #39) is the single
+        place that names tools; the hook should fire the alarm only.
+        """
+        _exit, stdout, _stderr = run_hook(
+            "the brand red is #D63233, lock this in"
+        )
+        ctx = extract_additional_context(stdout)
+        self.assertNotEqual(ctx, "")
+        for forbidden in ("memory_remember", "memory_batch", "memory."):
+            self.assertNotIn(
+                forbidden, ctx,
+                msg=(
+                    f"Tool-name string {forbidden!r} leaked into commitment "
+                    f"output. ctx={ctx!r}"
+                ),
+            )
+
+    # ─── Scenario 5: positive assertion on the new tool-agnostic phrasing ──
+
+    def test_commitment_uses_new_phrasing(self):
+        _exit, stdout, _stderr = run_hook(
+            "the brand red is #D63233, lock this in"
+        )
+        ctx = extract_additional_context(stdout)
+        self.assertIn("save the canonical fact to memory immediately", ctx)
+
+    # ─── Scenario 6: both branches fire on a combined prompt ──────────────
+
+    def test_combined_commitment_and_destructive_prompt(self):
+        _exit, stdout, _stderr = run_hook(
+            "remember this: I always rm -rf the build dir"
+        )
+        ctx = extract_additional_context(stdout)
+        # Commitment branch: new phrasing present.
+        self.assertIn("save the canonical fact to memory immediately", ctx)
+        # Destructive branch: human label present, raw regex absent.
+        self.assertIn("rm -rf (recursive delete)", ctx)
+        self.assertNotIn(r"\b", ctx)
+        self.assertNotIn(r"\s+", ctx)
+        # Neither branch leaks tool names.
+        for forbidden in ("memory_remember", "memory_batch"):
+            self.assertNotIn(forbidden, ctx)
+
+    # ─── Scenario 7: innocuous prompt produces no output ──────────────────
+
+    def test_no_trigger_no_output(self):
+        exit_code, stdout, _stderr = run_hook("hello world")
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(stdout, "")
+
+    # ─── Scenario 8: malformed JSON on stdin is a silent no-op ────────────
+
+    def test_malformed_json_is_noop(self):
+        exit_code, stdout, _stderr = run_hook_raw("not json")
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(stdout, "")
+
+    # ─── Scenario 9: empty stdin is a silent no-op ────────────────────────
+
+    def test_empty_stdin_is_noop(self):
+        exit_code, stdout, _stderr = run_hook_raw("")
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(stdout, "")
+
+    # ─── Scenario 10: structural assertions on PATTERN_LABELS ──────────────
+
+    def test_pattern_labels_covers_every_destructive_pattern(self):
+        """Pattern_labels must be in lockstep with DESTRUCTIVE_PATTERNS.
+
+        The hook itself asserts this at import time (fail-fast). This test
+        makes the contract explicit for reviewers and would fail loudly if
+        a future PR adds a pattern without a label.
+        """
+        self.assertTrue(hasattr(HOOK_MODULE, "PATTERN_LABELS"),
+                        msg="Hook is missing PATTERN_LABELS dict")
+        self.assertEqual(
+            set(HOOK_MODULE.DESTRUCTIVE_PATTERNS),
+            set(HOOK_MODULE.PATTERN_LABELS.keys()),
+            msg=(
+                "Every DESTRUCTIVE_PATTERN must have a PATTERN_LABELS entry "
+                "(and vice versa). Add or remove together."
+            ),
+        )
+        # Every label is a non-empty human-readable string with no raw
+        # regex escapes.
+        for pattern, label in HOOK_MODULE.PATTERN_LABELS.items():
+            with self.subTest(pattern=pattern):
+                self.assertIsInstance(label, str)
+                self.assertGreater(len(label), 0)
+                self.assertNotIn(r"\b", label)
+                self.assertNotIn(r"\s", label)
+                self.assertNotIn("(?:", label)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a UserPromptSubmit hook (`template-v2/.claude/hooks/user-prompt-capture.py`) that scans the user's prompt for two trigger classes and injects reminder context for the agent. Output is JSON `additionalContext` only when triggers fire; the prompt flows unchanged in the common case.

## Why this exists

The community's dominant memory-MCP repos (claude-mem at 65.8K stars, claude-memory-compiler, mcp-knowledge-graph) capture observations automatically via Stop and SessionEnd hooks. Claudia's differentiator is curated, judgment-based memory: the agent decides what matters and stores it deliberately, rather than capturing everything by default.

This hook makes that curation explicit at the right moment. When the user signals "this matters" through a phrase like *"lock this in"* or *"remember this"*, the agent gets a context reminder to save the fact via `memory_remember` or `memory_batch` immediately, rather than hoping it surfaces in an end-of-session `/meditate` reflection. It closes the loop on the memory-commitment rule shipped in #39.

The destructive-verb branch is a parallel safety mechanism: when the user's prompt contains patterns like `rm -rf`, `git push --force`, `drop table`, or `git reset --hard`, the hook injects a "verify before acting" reminder per the safety-first principle codified in `.claude/rules/claudia-principles.md`. This is a softer pre-action surface than a `PreToolUse` block (PR B will handle the harder block); here we just give the agent a heads-up at prompt time so it knows to confirm before executing.

## What it detects

**Class 1 — Canonical-fact triggers** (case-insensitive, word-boundary matched):

| Phrase | Why |
|--------|-----|
| `lock this in` | Used in this codebase's session work today; clearest "save this canonically" signal |
| `remember this` | Most natural-language phrasing |
| `this is canonical` / `this is locked` | Explicit codification |
| `save this for later` | Time-shifted assertion |
| `important to remember` / `for the record` / `don't forget` | Softer variants |

**Class 2 — Destructive operation patterns** (narrow regex, intentional limits to avoid false positives on conversation about deletion):

| Pattern | Real-world risk |
|---------|-----------------|
| `\brm\s+-rf\b` | Recursive deletion |
| `\bdrop\s+(table\|database\|schema)\b` | SQL destructive DDL |
| `\bgit\s+push\s+(?:-+f\b\|--force\b)` | Force-push to remote |
| `\bgit\s+reset\s+--hard\b` | Discards uncommitted work |
| `\btruncate\s+table\b` | Empties a table |
| `\bDELETE\s+FROM\b` | All-caps signals intent (case-sensitive on this one) |

Both classes can fire on the same prompt; the two reminder sections are concatenated.

## How the contract works

```
User submits prompt
  └─> Claude Code fires UserPromptSubmit hook with JSON on stdin
       └─> user-prompt-capture.py reads stdin, regex-matches both pattern lists
            ├─ no match: exit silently (no output, prompt flows unchanged)
            └─ match: stdout JSON with { additionalContext: "..." }
                 └─> Claude Code injects additionalContext before model sees prompt
                      └─> Agent sees the reminder and acts on it
```

Designed to complete in <5ms. No network, no disk reads, no daemon dependencies.

## Test plan

Five test cases, all passing locally:

```bash
# 1. Commitment trigger
echo '{"hook_event_name":"UserPromptSubmit","prompt":"the brand red is #D63233, lock this in"}' \
  | python3 template-v2/.claude/hooks/user-prompt-capture.py
# -> {"additionalContext": "**Canonical-fact trigger detected.** ..."}

# 2. Destructive trigger
echo '{"hook_event_name":"UserPromptSubmit","prompt":"now run git push --force on main"}' \
  | python3 template-v2/.claude/hooks/user-prompt-capture.py
# -> {"additionalContext": "**Destructive operation pattern detected** ..."}

# 3. Both triggers in one prompt
echo '{"hook_event_name":"UserPromptSubmit","prompt":"remember this: I always rm -rf the build dir"}' \
  | python3 template-v2/.claude/hooks/user-prompt-capture.py
# -> {"additionalContext": "**Canonical-fact trigger** ... **Destructive operation pattern** ..."}

# 4. No trigger (most common case)
echo '{"hook_event_name":"UserPromptSubmit","prompt":"hello world"}' \
  | python3 template-v2/.claude/hooks/user-prompt-capture.py
# -> (no output)

# 5. Malformed JSON
echo 'not json' | python3 template-v2/.claude/hooks/user-prompt-capture.py
# -> (no output, no error)
```

**Reviewer test plan:**
- [ ] Verify the hook fires correctly on a fresh install with each test case above.
- [ ] Confirm `additionalContext` actually reaches the model (check transcript or use a model that surfaces it).
- [ ] Sanity check: type a normal prompt with no triggers, confirm no friction or visible output.

## Settings registration

Adds a `UserPromptSubmit` entry to `template-v2/.claude/settings.local.json`, matching the existing `python3 || python || true` tolerance pattern used by the SessionStart, PreCompact, PostToolUse, and SessionEnd hooks. Timeout 3000ms (script targets <5ms; the budget is just headroom).

## Known limitations

1. **Destructive-pattern output shows the raw regex** to the agent (e.g., `\bgit\s+push\s+(?:-+f\b|--force\b)`). The agent understands the warning but the regex is ugly. A polish pass could map regex patterns to human-readable labels. Out of scope for this PR.
2. **English-only triggers.** A non-English speaker saying "запомни это" would not fire the commitment branch. Localization is out of scope.
3. **No false-positive guard for code blocks or quoted text.** A prompt like *"how do I undo `rm -rf`?"* would fire the destructive branch. Acceptable trade-off because the warning is informational, not blocking.
4. **Trigger phrase list is intentionally short.** Adding too many phrases increases false-positive rate. Future expansion should be deliberate.

## Relationship to other PRs

- **#39** (memory-commitment rule) — this hook operationalizes that rule at prompt time. Without #39's rule, the agent might not know what "save the relevant fact via `memory_remember`" actually means.
- **PR B** (planned, PreToolUse safety gates) — this PR's destructive-verb branch is a *prompt-time advisory*. PR B will add the *tool-time block* (exit code 2 on `git push --force` to main, etc.). Both layers are intentional: catch intent early, block execution if intent slips through.
- **#41** (Rube removal) — independent.
- **#38** (post-tool-capture stdin fix) — independent.

## Why this PR is "opinionated"

PRs #38, #40, #41 were structural (fix bugs, add infrastructure, remove cruft). This PR is the first one that's opinionated about *how Claudia should behave*: namely, that explicit user signals about importance should produce explicit memory writes, rather than implicit hope-it-gets-captured behavior. Pushing back on the design here is welcome — the trigger phrase list is the obvious place to discuss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)