### PR TITLE
Proposal: Pattern review surface (accept / dismiss / promote)

### DIFF
--- a/docs/proposals/07-pattern-review-surface.md
+++ b/docs/proposals/07-pattern-review-surface.md
@@ -1,0 +1,77 @@
+# Proposal 07: Pattern review surface
+
+**Status**: Proposal · **Effort**: ~1 week · **Batch**: Architectural (ship with #03 and #05)
+
+## TL;DR
+
+Auto-detected patterns accumulate without review (a few hundred in a moderate-sized DB is typical). Add a `claudia patterns review` CLI command plus a weekly digest auto-memory that surface un-reviewed patterns for accept / dismiss / promote-importance. Same UX shape as `meditate` reflection review.
+
+## The problem
+
+The daemon's `pattern_detection` job runs on an interval and auto-creates patterns from accumulated memories. Useful for surfacing trends, but unreviewed patterns become noise in recall. The user has no surface to see what was detected, accept what's true, dismiss what isn't, or promote what's important.
+
+The existing `predictions` table is similar in spirit and also lacks a review surface.
+
+## The fix
+
+Schema additions:
+
+```sql
+ALTER TABLE patterns ADD COLUMN reviewed_at TIMESTAMP;
+ALTER TABLE patterns ADD COLUMN review_status TEXT;
+-- 'pending', 'accepted', 'dismissed', 'promoted'
+
+CREATE INDEX idx_patterns_review ON patterns(review_status, reviewed_at);
+```
+
+New MCP tool: `memory_patterns_review(limit, since)` returns un-reviewed patterns with their supporting evidence (memories and entity links).
+
+New CLI command:
+
+```
+claudia patterns review
+```
+
+Interactive: walks through un-reviewed patterns, shows evidence, asks accept / dismiss / promote / skip. Promoted patterns get `importance` bumped to a configured high band so they surface prominently in recall.
+
+Weekly digest: at Sunday 09:00 the daemon writes a low-importance auto-memory listing un-reviewed patterns from the past week. Shows up in Kamil's morning brief; he can run `claudia patterns review` when ready.
+
+## Surface area
+
+```
+memory-daemon/claudia_memory/schema.sql                          # schema migration
+memory-daemon/claudia_memory/services/patterns.py                # add review_status filter
+memory-daemon/claudia_memory/mcp/server.py                       # register memory_patterns_review
+memory-daemon/claudia_memory/daemon/scheduler.py                 # add weekly digest job
+claudia/bin/commands/patterns-review.js                          # interactive CLI
+docs/patterns-review.md
+```
+
+## Why elegant
+
+- Mirrors the existing `meditate` reflection review workflow (proven UX in this repo)
+- Backwards-compatible: existing pattern queries filter to `review_status IN ('accepted', 'promoted')` OR `review_status IS NULL` by default; dismissed patterns are excluded but preserved
+- One new scheduler job, one new CLI command, one schema migration with two columns
+- Lays groundwork for similar review surfaces on `predictions` and `reflections`
+
+## Testing plan
+
+- Migration test on existing pattern table completes without errors
+- Interactive CLI: keyboard-navigable, supports "go back" within a session
+- Verify dismissed patterns no longer surface in `memory_recall` results
+- Verify promoted patterns rank higher than equivalent un-promoted ones
+
+## Open questions
+
+- Should `dismissed` patterns be hard-deleted after some retention period? Soft-delete preserves audit but accumulates over time. Recommend soft-delete with a 12-month retention.
+- Should the daemon use the existing `meditate` UX (a presented batch with one approval) instead of a separate review surface? Faster to ship, but patterns are typically more numerous than meditation reflections, so the per-pattern workflow is better.
+- Slack/Discord delivery of the weekly digest? Out of scope for v1; surface only via morning brief auto-memory.
+
+## Related
+
+- Pairs with Proposal #03 (conflict gate) and Proposal #05 (bi-temporal validity windows) as the Architectural release. Together they form a "memory that knows it's wrong sometimes" feature set.
+- Independent enough to ship standalone if the others are delayed.
+
+## References
+
+- The existing `meditate` skill flow for reflection approval is the closest internal analog. See `meditate/SKILL.md` for the per-item approval UX.


### PR DESCRIPTION
## Summary

Auto-detected patterns accumulate without curation. Add a `claudia patterns review` interactive CLI and a weekly digest auto-memory that surface un-reviewed patterns for accept / dismiss / promote. Same UX shape as `meditate` reflection review.

## Full proposal

See [`docs/proposals/07-pattern-review-surface.md`](./docs/proposals/07-pattern-review-surface.md) in this PR for the complete design: problem, fix, surface area (specific files to touch), why elegant, testing plan, open questions, and related work.

## Effort and sequencing

- **Effort estimate**: ~1 week
- **Release batch**: Architectural (with #03 and #05)

This PR is intentionally a **design proposal** rather than an implementation. Marking as draft so the dev team can review, discuss in the PR thread, and either implement directly on this branch or open a separate implementation PR that references this one and lands the spec doc alongside the code.

## Why open as a PR rather than an issue

- The spec doc itself belongs in the repo at `docs/proposals/` for future reference
- PR thread is a more natural place for the implementation review than an issue is
- Status tracking via the PRs list is more visible than issues

## How to take it from here

1. Review the design doc in this PR thread; raise concerns or open questions
2. When ready to implement: branch from main, build on top, push to this branch (or open a new PR that references this one)
3. Either merge this PR first (lands the spec doc, then implement) or close it after the implementation PR lands (which itself includes the updated spec doc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)