### PR TITLE
feat(installer): explicit upgrade messaging about preserved memory

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -877,7 +877,10 @@ async function main() {
     }
 
     console.log('');
-    console.log(` ${colors.cyan}✓${colors.reset} Framework updated (data preserved)`);
+    console.log(` ${colors.cyan}✓${colors.reset} Framework updated`);
+    console.log(`   • Your memory at ${colors.bold}~/.claudia/${colors.reset} is preserved (entities, relationships, reflections, embeddings).`);
+    console.log(`   • Skills and hooks refreshed; any modifications you chose to keep were respected.`);
+    console.log(`   • Restart Claude Code for changes to take effect.`);
   }
 
   // Self-heal: strip CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS from settings (#24)


### PR DESCRIPTION
## Summary

After the four-PR curated-memory chain landed (#38, #39, #40, #42), the upgrade flow's success message still says only:

> ✓ Framework updated (data preserved)

Users care about their accumulated memory graph (entities, relationships, embeddings) more than abstract "framework" files. The message change makes the database-preservation guarantee explicit and names the canonical path users would recognize.

## What changes

Single edit in `bin/index.js` around line 880 (the post-upgrade success block):

```
✓ Framework updated
   • Your memory at ~/.claudia/ is preserved (entities, relationships, reflections, embeddings).
   • Skills and hooks refreshed; any modifications you chose to keep were respected.
   • Restart Claude Code for changes to take effect.
```

No behavior change. Pure user-facing wording.

## Why this exists

Section 9 of the curated-memory chain brief identified this as a small follow-up: the installer's existing `efce9f2` preservation policy is correct, but a user reading "data preserved" doesn't know it specifically means their accumulated knowledge graph survives.

## Test plan

- [x] `node -c bin/index.js` passes (syntax)
- [ ] Visual: trigger an upgrade in a test directory and confirm the new message renders correctly across light/dark terminals

🤖 Generated with [Claude Code](https://claude.com/claude-code)