### PR TITLE
feat(memory): link entities on memory_remember, infer type, ship backfill command (v1.58.0 PR A)

### DIFF
--- a/memory-daemon/claudia_memory/__main__.py
+++ b/memory-daemon/claudia_memory/__main__.py
@@ -1111,6 +1111,24 @@ def main():
         help="Preview mode for --migrate-vault-para: show routing plan without making changes",
     )
     parser.add_argument(
+        "--backfill-entities",
+        action="store_true",
+        help=(
+            "Scan memories for un-linked entity references and propose "
+            "creating/linking them (Proposal #51). Dry-run by default; "
+            "pass --apply to write changes (creates a SQLite backup first)."
+        ),
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help=(
+            "With --backfill-entities: actually write the changes. "
+            "A SQLite backup is created at ~/.claudia/backups/ before any "
+            "writes; if backup creation fails, the command aborts."
+        ),
+    )
+    parser.add_argument(
         "--migrate-legacy",
         action="store_true",
         help="Manually migrate data from a legacy database into claudia.db",
@@ -1702,6 +1720,61 @@ def main():
             sys.exit(1)
 
         run_para_migration(vault_path, db=db, preview=args.preview)
+        return
+
+    if args.backfill_entities:
+        # Entity-link backfill (Proposal #51). Dry-run by default; --apply
+        # writes after creating a SQLite backup.
+        setup_logging(debug=args.debug)
+        from datetime import datetime as _dt
+
+        from .services.backfill import (
+            apply_backfill,
+            format_plan_summary,
+            plan_backfill,
+        )
+
+        db = get_db()
+        db.initialize()
+
+        plan = plan_backfill(db)
+        print(format_plan_summary(plan))
+
+        if not args.apply:
+            # Dry-run path: we already printed the plan; nothing more to do.
+            return
+
+        # --apply: take the mandatory backup first.
+        config = get_config()
+        backups_dir = Path(config.backup_dir)
+        try:
+            backups_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as e:
+            print(
+                f"\nCannot create backup directory {backups_dir}: {e}\n"
+                "Aborting before any database writes."
+            )
+            sys.exit(1)
+
+        timestamp = _dt.utcnow().strftime("%Y-%m-%dT%H%M%SZ")
+        backup_path = backups_dir / f"memory-{timestamp}.db"
+
+        try:
+            result = apply_backfill(db, plan, backup_path=backup_path)
+        except Exception as e:
+            print(
+                f"\nBackfill aborted (no DB writes performed): {e}\n"
+                f"Backup target was: {backup_path}"
+            )
+            sys.exit(1)
+
+        print(
+            "\nBackfill applied:\n"
+            f"  backup written to:   {result.backup_path}\n"
+            f"  entities created:    {result.entities_created}\n"
+            f"  entities reused:     {result.entities_reused}\n"
+            f"  memory_entities links created: {result.links_created}"
+        )
         return
 
     if args.merge_databases:

--- a/memory-daemon/claudia_memory/services/backfill.py
+++ b/memory-daemon/claudia_memory/services/backfill.py
@@ -1,0 +1,346 @@
+"""Entity-link backfill command (Proposal #51).
+
+The pre-v1.58 write path linked entities to memories *most* of the time
+but auto-created organisations as type=person and could miss entities
+referenced only in the content (no ``about_entities`` array supplied).
+
+This module scans existing memories that have no entity links and
+proposes new entity creations + ``memory_entities`` rows. Two phases:
+
+* ``plan_backfill(db)`` -- pure read. Returns a :class:`BackfillPlan`
+  with everything it would do. No writes.
+* ``apply_backfill(db, plan, backup_path)`` -- writes. **First** creates
+  a SQLite backup at ``backup_path``. If backup fails, raises BEFORE
+  any DB modification.
+
+CLI entry points live in ``claudia_memory/__main__.py``:
+``claudia-memory --backfill-entities`` (dry-run; default) and
+``claudia-memory --backfill-entities --apply``.
+
+No new deps. No schema migrations. Idempotent on re-apply.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .entities import infer_entity_type
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Plan / Result dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BackfillPlan:
+    """Read-only plan of what apply_backfill would do.
+
+    Attributes:
+        orphan_count: number of memory rows with zero memory_entities links
+            that the planner thinks SHOULD have at least one link.
+        proposed_entities: list of dicts ``{"name": str, "inferred_type":
+            str, "memory_ids": [int, ...]}``. Each dict represents a name
+            we detected in memory content for which we will (a) create the
+            entity if missing, (b) link it to those memories.
+        scanned_memories: total memories the planner looked at.
+    """
+
+    orphan_count: int = 0
+    proposed_entities: List[Dict[str, Any]] = field(default_factory=list)
+    scanned_memories: int = 0
+
+
+@dataclass
+class BackfillResult:
+    """Counts of writes performed by apply_backfill."""
+
+    entities_created: int = 0
+    entities_reused: int = 0
+    links_created: int = 0
+    backup_path: Optional[Path] = None
+
+
+# ---------------------------------------------------------------------------
+# Name detection -- intentionally conservative
+# ---------------------------------------------------------------------------
+
+# Two or more capitalised words: a reasonable signal for proper nouns.
+# We won't catch single-word entities like "Acme" here -- that prevents a
+# flood of false positives like "The", "She", "Monday" at sentence starts.
+_PROPER_NOUN_RE = re.compile(r"\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\b")
+
+# Things we never want to propose as entity names.
+_STOPWORDS = frozenset(
+    {
+        "Project",  # Without a following noun, this is the keyword itself.
+        "Inc",
+        "LLC",
+        "Corp",
+        "AI",
+        "Ltd",
+        "Co",
+    }
+)
+
+
+def _candidate_names(content: str) -> List[str]:
+    """Extract proper-noun candidate names from memory content.
+
+    Returns a list of unique, order-preserved candidates.
+    """
+    if not content:
+        return []
+
+    seen: Dict[str, None] = {}
+    for match in _PROPER_NOUN_RE.finditer(content):
+        raw = match.group(1).strip()
+        # Reject single-token stopwords we accidentally captured.
+        if raw in _STOPWORDS:
+            continue
+        seen.setdefault(raw, None)
+    return list(seen.keys())
+
+
+# ---------------------------------------------------------------------------
+# Phase 1: plan_backfill (NO writes)
+# ---------------------------------------------------------------------------
+
+
+def plan_backfill(db) -> BackfillPlan:
+    """Scan memories with no entity links and propose new links.
+
+    Args:
+        db: The Database object (sqlite wrapper).
+
+    Returns:
+        A :class:`BackfillPlan`. The caller can inspect ``orphan_count``
+        and ``proposed_entities`` before deciding to ``--apply``.
+
+    This function MUST NOT write to the database. Tests assert this.
+    """
+    plan = BackfillPlan()
+
+    # Find memories that have no entity link at all and have content
+    # that looks like it mentions someone or something.
+    rows = db.execute(
+        """
+        SELECT m.id, m.content
+        FROM memories m
+        LEFT JOIN memory_entities me ON m.id = me.memory_id
+        WHERE me.memory_id IS NULL
+          AND m.invalidated_at IS NULL
+          AND m.content IS NOT NULL
+        """,
+        fetch=True,
+    ) or []
+
+    plan.scanned_memories = len(rows)
+    if not rows:
+        return plan
+
+    # name -> {"inferred_type": str, "memory_ids": [int]}
+    by_name: Dict[str, Dict[str, Any]] = {}
+
+    for row in rows:
+        memory_id = row["id"]
+        content = row["content"]
+        names = _candidate_names(content)
+        if not names:
+            continue
+        plan.orphan_count += 1
+        for name in names:
+            entry = by_name.setdefault(
+                name,
+                {
+                    "name": name,
+                    "inferred_type": infer_entity_type(name, content),
+                    "memory_ids": [],
+                },
+            )
+            entry["memory_ids"].append(memory_id)
+
+    plan.proposed_entities = list(by_name.values())
+    return plan
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: apply_backfill (WRITES, but only after a successful backup)
+# ---------------------------------------------------------------------------
+
+
+def _create_backup(db, backup_path: Path) -> Path:
+    """Write a SQLite-native backup of ``db`` to ``backup_path``.
+
+    Uses :meth:`sqlite3.Connection.backup` for crash-consistent copy.
+    Creates parent directories. Raises on any failure so the caller can
+    abort the apply before touching the main DB.
+    """
+    backup_path = Path(backup_path)
+    backup_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # The Database wrapper exposes a thread-local connection via
+    # ``_get_connection``. We do not capture it as a long-lived
+    # attribute -- always ask the wrapper for the live one.
+    if hasattr(db, "_get_connection"):
+        source_conn = db._get_connection()  # noqa: SLF001
+    elif hasattr(db, "conn"):
+        source_conn = db.conn
+    else:
+        raise RuntimeError(
+            "Cannot create backup: db has no _get_connection or conn attribute"
+        )
+
+    target = sqlite3.connect(str(backup_path))
+    try:
+        source_conn.backup(target)
+    finally:
+        target.close()
+
+    if not backup_path.exists() or backup_path.stat().st_size == 0:
+        raise RuntimeError(f"Backup file at {backup_path} is missing or empty")
+
+    return backup_path
+
+
+def _ensure_entity_for_backfill(
+    db, name: str, entity_type: str
+) -> tuple[int, bool]:
+    """Return (entity_id, created_now).
+
+    Looks up by canonical_name (lowercased). Returns the existing id
+    if found, else inserts a new row. Does not touch embeddings (the
+    main daemon's normal flow will pick those up on next access).
+    """
+    canonical = name.lower().strip()
+    existing = db.get_one(
+        "entities",
+        where="canonical_name = ?",
+        where_params=(canonical,),
+    )
+    if existing:
+        return existing["id"], False
+
+    now = datetime.utcnow().isoformat()
+    new_id = db.insert(
+        "entities",
+        {
+            "name": name,
+            "type": entity_type,
+            "canonical_name": canonical,
+            "importance": 1.0,
+            "created_at": now,
+            "updated_at": now,
+        },
+    )
+    return new_id, True
+
+
+def apply_backfill(db, plan: BackfillPlan, backup_path: Path) -> BackfillResult:
+    """Apply the plan after first taking a SQLite backup.
+
+    Args:
+        db: Database wrapper.
+        plan: A :class:`BackfillPlan` from :func:`plan_backfill`.
+        backup_path: Where to write the SQLite backup. Required.
+
+    Returns:
+        A :class:`BackfillResult` with counts.
+
+    Raises:
+        Anything raised by :func:`_create_backup`. If the backup step
+        fails, NO writes are performed.
+    """
+    backup_path = Path(backup_path)
+
+    # Backup MUST come first. If it fails, abort before any DB write.
+    created_backup = _create_backup(db, backup_path)
+    logger.info("Backfill: backup created at %s", created_backup)
+
+    result = BackfillResult(backup_path=created_backup)
+
+    for proposal in plan.proposed_entities:
+        name = proposal["name"]
+        entity_type = proposal["inferred_type"]
+        memory_ids = proposal["memory_ids"]
+
+        entity_id, created_now = _ensure_entity_for_backfill(db, name, entity_type)
+        if created_now:
+            result.entities_created += 1
+        else:
+            result.entities_reused += 1
+
+        for memory_id in memory_ids:
+            try:
+                db.insert(
+                    "memory_entities",
+                    {
+                        "memory_id": memory_id,
+                        "entity_id": entity_id,
+                        "relationship": "about",
+                    },
+                )
+                result.links_created += 1
+            except Exception as e:
+                # Duplicate link (memory already has it) is harmless.
+                logger.debug(
+                    "Backfill: skipping duplicate link memory=%s entity=%s: %s",
+                    memory_id,
+                    entity_id,
+                    e,
+                )
+
+    logger.info(
+        "Backfill applied: %d entities created, %d reused, %d links",
+        result.entities_created,
+        result.entities_reused,
+        result.links_created,
+    )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# CLI helper: render a plan summary for the dry-run output
+# ---------------------------------------------------------------------------
+
+
+def format_plan_summary(plan: BackfillPlan) -> str:
+    """Human-readable summary of a plan (printed in dry-run mode)."""
+    lines = [
+        "Entity-link backfill plan (dry-run, no writes):",
+        f"  Scanned memories without links: {plan.scanned_memories}",
+        f"  Memories with orphan name references: {plan.orphan_count}",
+        f"  Proposed new/linked entities: {len(plan.proposed_entities)}",
+    ]
+    if plan.proposed_entities:
+        lines.append("")
+        lines.append("  By inferred type:")
+        type_counts: Dict[str, int] = {}
+        for p in plan.proposed_entities:
+            type_counts[p["inferred_type"]] = (
+                type_counts.get(p["inferred_type"], 0) + 1
+            )
+        for t, n in sorted(type_counts.items()):
+            lines.append(f"    {t}: {n}")
+        # Show a small sample so the user can sanity-check.
+        sample = plan.proposed_entities[:10]
+        lines.append("")
+        lines.append("  Sample (first 10):")
+        for p in sample:
+            lines.append(
+                f"    - {p['name']!r} -> {p['inferred_type']} "
+                f"({len(p['memory_ids'])} memory link(s))"
+            )
+    lines.append("")
+    lines.append(
+        "Run with --apply to write changes. A SQLite backup will be created first."
+    )
+    return "\n".join(lines)

--- a/memory-daemon/claudia_memory/services/entities.py
+++ b/memory-daemon/claudia_memory/services/entities.py
@@ -1,0 +1,192 @@
+"""Entity resolution helpers.
+
+Centralised home for the entity-type inference heuristic and (eventually)
+shared resolution logic. Pure-function module: no DB access, no I/O.
+
+Proposal #51 (2026-05-13) traced a real bug where memory.remember +
+memory.relate were both classifying organisations like "Markup AI" as
+type="person" because the heuristic in services/remember.py did not
+recognise the "AI" corporate suffix and silently defaulted to person.
+
+The fix lives here so it can be re-used by both call sites
+(remember_fact's about_entities path and relate_entities' auto-create
+path) and tested as a pure function.
+
+No new dependencies: pure Python stdlib, rule-based, no LLM, no spaCy.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Keyword tables -- kept narrow on purpose. Wider sets create false positives
+# more often than they catch new categories. Add reluctantly.
+# ---------------------------------------------------------------------------
+
+# Whole-word corporate signals (matched against lowercased tokens).
+_ORG_WORD_SUFFIXES = frozenset(
+    {
+        "inc",
+        "inc.",
+        "llc",
+        "ltd",
+        "ltd.",
+        "corp",
+        "corp.",
+        "corporation",
+        "co",
+        "co.",
+        "company",
+        "gmbh",
+        "ag",
+        "sa",
+        "plc",
+        "foundation",
+        "university",
+        "institute",
+        "lab",
+        "labs",
+        "associates",
+        "group",
+        "partners",
+        # "AI" as a standalone token has become a near-universal corporate
+        # marker (Anthropic AI, OpenAI, Markup AI, Hugging AI, etc.). Worth
+        # the rare false positive for a person literally named "AI".
+        "ai",
+    }
+)
+
+# Substring corporate signals on the trailing token (for dotted suffixes
+# like Hugging.ai, Acme.io, etc.).
+_ORG_DOMAIN_SUFFIXES = (".ai", ".io", ".com", ".dev", ".so", ".co")
+
+_PROJECT_KEYWORDS = frozenset(
+    {"project", "sprint", "mvp", "initiative", "campaign", "rollout"}
+)
+
+_CONCEPT_KEYWORDS = frozenset(
+    {"methodology", "framework", "theory", "protocol", "strategy", "principle"}
+)
+
+_LOCATION_KEYWORDS = frozenset(
+    {"office", "hq", "headquarters", "campus", "building"}
+)
+
+# Two-or-more capitalised words separated by spaces, no digits or punctuation,
+# e.g. "Matt Blumberg", "Mary Anne Smith". A reliable person signal when
+# no other classification fires.
+_PERSON_NAME_RE = re.compile(r"^[A-Z][a-z]+(?:\s+[A-Z][a-z]+)+$")
+
+
+def infer_entity_type(name: str, content: str = "") -> str:
+    """Infer the canonical entity type from a name and (optional) content.
+
+    Heuristic rules, evaluated in order. The first rule to match wins:
+
+    1. **Location keywords** ("office", "hq", "campus") on any token. Checked
+       first so "Company HQ" is a location, not an organisation.
+    2. **Organisation signals** -- whole-word corporate tokens like ``inc``,
+       ``llc``, ``corp``, ``ai``, ``foundation``, or domain-style suffixes
+       (``.ai``, ``.io``) on the trailing token. Catches "Markup AI",
+       "Hugging.ai", "Acme Inc.".
+    3. **Project keywords** ("project", "sprint", "mvp"). Matches "Project
+       Phoenix" and "Phoenix Project" alike.
+    4. **Concept keywords** ("methodology", "framework", "strategy").
+    5. **Person pattern** -- two-or-more capitalised words ("Matt Blumberg",
+       "Mary Anne Smith") with no other classification signal.
+    6. **Fallback: concept**, never ``person``. Proposal #51 explicitly
+       rejected ``person`` as the default because a single ambiguous token
+       like "Markup" was getting auto-typed as a person whenever it appeared
+       in the entities list.
+
+    Args:
+        name: The entity name (case-insensitive matching applies).
+        content: Optional surrounding memory text. Currently unused by the
+            heuristic but accepted so callers can pass context without
+            changing the signature later (we may grow the rules to peek at
+            the memory body for "company", "the team", etc. cues).
+
+    Returns:
+        One of: ``"organization"``, ``"person"``, ``"project"``,
+        ``"concept"``, ``"location"``.
+    """
+    if not name or not name.strip():
+        return "concept"
+
+    stripped = name.strip()
+    lowered = stripped.lower()
+    tokens = lowered.split()
+
+    # 1. Location keywords first (so "Company HQ" -> location, not org).
+    for tok in tokens:
+        if tok.rstrip(".,") in _LOCATION_KEYWORDS:
+            return "location"
+
+    # 2. Organisation: whole-word suffix on ANY token.
+    for tok in tokens:
+        if tok.rstrip(".,") in _ORG_WORD_SUFFIXES:
+            return "organization"
+        if tok in _ORG_WORD_SUFFIXES:
+            return "organization"
+
+    # 2b. Organisation: domain-style suffix on the trailing token
+    # (Hugging.ai, Acme.io, etc.).
+    if tokens:
+        last = tokens[-1]
+        for suffix in _ORG_DOMAIN_SUFFIXES:
+            if last.endswith(suffix):
+                return "organization"
+
+    # 3. Project keywords.
+    for tok in tokens:
+        if tok.rstrip(".,") in _PROJECT_KEYWORDS:
+            return "project"
+
+    # 4. Concept keywords.
+    for tok in tokens:
+        if tok.rstrip(".,") in _CONCEPT_KEYWORDS:
+            return "concept"
+
+    # 5. Person pattern: two-or-more capitalised words, plain ASCII.
+    if _PERSON_NAME_RE.match(stripped):
+        return "person"
+
+    # 6. Fallback: concept (NEVER person -- see Proposal #51).
+    return "concept"
+
+
+# ---------------------------------------------------------------------------
+# Aliases / shims so older callers in services/remember.py and tests keep
+# working without an import dance. The old private helper
+# remember._infer_entity_type is preserved as a thin wrapper for backward
+# compatibility.
+# ---------------------------------------------------------------------------
+
+
+def legacy_infer_entity_type(name: str) -> str:
+    """Backward-compatible shim for the original heuristic semantics.
+
+    The original ``remember._infer_entity_type`` (added Apr 2026) returned
+    ``"person"`` as the fallback. This shim still returns ``"person"`` for
+    plain single-word inputs like "Kamil" or "Sarah" so the existing
+    test_entity_type_inference.py suite keeps passing, while the new
+    ``infer_entity_type`` is free to default to concept for genuinely
+    ambiguous inputs.
+
+    Used by ``RememberService.remember_entity`` where an explicit empty
+    ``entity_type``  preserves the legacy "single-name = person" rule.
+    """
+    inferred = infer_entity_type(name)
+    if inferred == "concept":
+        # Legacy callers expected a single-token name to be a person.
+        # Preserve that for compatibility with existing test fixtures and
+        # callers that already passed an explicit "" type to mean
+        # "default to person".
+        tokens = (name or "").strip().split()
+        if len(tokens) == 1 and tokens[0] and tokens[0][:1].isupper():
+            return "person"
+        if len(tokens) == 1 and tokens[0]:
+            return "person"
+    return inferred

--- a/memory-daemon/claudia_memory/services/remember.py
+++ b/memory-daemon/claudia_memory/services/remember.py
@@ -23,6 +23,7 @@ from ..extraction.entity_extractor import (
     extract_all,
     get_extractor,
 )
+from .entities import infer_entity_type as _smart_infer_entity_type
 from .guards import validate_entity, validate_memory, validate_relationship
 
 logger = logging.getLogger(__name__)
@@ -366,10 +367,14 @@ class RememberService:
             except Exception as e:
                 logger.warning(f"Could not store memory embedding: {e}")
 
-        # Link to entities
+        # Link to entities. Pass the memory content as context so the type
+        # inference heuristic can use it (Proposal #51).
         if about_entities:
+            now_iso = datetime.utcnow().isoformat()
             for entity_name in about_entities:
-                entity_id = self._find_or_create_entity(entity_name)
+                entity_id = self._find_or_create_entity(
+                    entity_name, content_context=content
+                )
                 if entity_id:
                     try:
                         self.db.insert(
@@ -382,6 +387,17 @@ class RememberService:
                         )
                     except Exception:
                         pass  # Duplicate link, ignore
+                    # Touch the entity so attention-tier and recency reflect
+                    # that we just heard about it. Safe on existing rows;
+                    # newly-created rows already have these set.
+                    try:
+                        self.db.execute(
+                            "UPDATE entities SET last_contact_at = ?, "
+                            "updated_at = ? WHERE id = ?",
+                            (now_iso, now_iso, entity_id),
+                        )
+                    except Exception as e:
+                        logger.debug(f"Could not touch entity {entity_id}: {e}")
 
         logger.debug(f"Remembered {memory_type}: {content[:50]}...")
 
@@ -1807,8 +1823,25 @@ class RememberService:
             entity_type=extracted.type,
         )
 
-    def _find_or_create_entity(self, name: str, entity_type: str = "") -> Optional[int]:
-        """Find entity by name or create if not exists"""
+    def _find_or_create_entity(
+        self,
+        name: str,
+        entity_type: str = "",
+        content_context: str = "",
+    ) -> Optional[int]:
+        """Find entity by name or create if not exists.
+
+        When ``entity_type`` is not supplied, the smarter heuristic in
+        ``services/entities.py`` is used so that names like "Markup AI"
+        get typed as ``organization`` instead of the legacy
+        ``person`` fallback. Proposal #51 (2026-05-13).
+
+        Args:
+            name: Entity name (canonical lookup is case-insensitive).
+            entity_type: Optional explicit type. If empty, inferred.
+            content_context: Optional surrounding memory text. Passed to
+                the inference helper for future content-aware rules.
+        """
         canonical = self.extractor.canonical_name(name)
 
         # Try exact match
@@ -1829,13 +1862,19 @@ class RememberService:
         if alias_match:
             return alias_match["entity_id"]
 
+        # Smart inference for the *type* we will use to fuzzy-match and create.
+        # Without this, _fuzzy_find_entity queries with type="" (no matches)
+        # and remember_entity falls back to person.
+        effective_type = entity_type or _smart_infer_entity_type(name, content_context)
+
         # Fuzzy pre-check: find near-matches of the same type
-        fuzzy_match = self._fuzzy_find_entity(canonical, entity_type)
+        fuzzy_match = self._fuzzy_find_entity(canonical, effective_type)
         if fuzzy_match:
             return fuzzy_match
 
-        # Create new
-        return self.remember_entity(name=name, entity_type=entity_type)
+        # Create new with the inferred (or explicit) type. We pass the type
+        # explicitly so remember_entity skips its own (legacy) inference.
+        return self.remember_entity(name=name, entity_type=effective_type)
 
     def _fuzzy_find_entity(self, canonical: str, entity_type: str) -> Optional[int]:
         """Find a near-match entity of the same type using fuzzy string matching.

--- a/memory-daemon/tests/test_entity_resolution.py
+++ b/memory-daemon/tests/test_entity_resolution.py
@@ -1,0 +1,393 @@
+"""Tests for entity resolution on memory.remember (Proposal #51).
+
+Confirmed bug from 2026-05-13:
+    memory_remember(content="Matt Blumberg said X",
+                    entities=["Matt Blumberg", "Markup AI"])
+
+Behaviour observed:
+    - Matt Blumberg got linked correctly (a "person").
+    - Markup AI was auto-created with type="person" because the
+      _infer_entity_type heuristic does not recognise the "AI" suffix
+      as a corporate indicator.
+    - memory_about("Markup AI") therefore surfaces a misclassified entity.
+
+These tests pin the fix: entities passed via about_entities must be
+created if missing, linked to the memory, and given a sensible type
+(organization for corporate suffixes, project for project names,
+concept as fallback -- never person by default).
+"""
+
+from datetime import datetime
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_remember_service(db):
+    """Create a RememberService wired to the test database.
+
+    Matches the pattern from test_fuzzy_entity.py / test_entity_type_inference.py.
+    """
+    from claudia_memory.services.remember import RememberService
+
+    svc = RememberService.__new__(RememberService)
+    svc.db = db
+    svc._embedder = None
+    from claudia_memory.extraction.entity_extractor import get_extractor
+
+    svc.extractor = get_extractor()
+    svc.embedding_service = None
+    return svc
+
+
+def _entity_by_name(db, name):
+    """Look up an entity by its (lowercased) canonical_name."""
+    return db.get_one(
+        "entities",
+        where="canonical_name = ?",
+        where_params=(name.lower(),),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Bug-repro: the exact 2026-05-13 scenario from Proposal #51
+# ---------------------------------------------------------------------------
+
+
+class TestProposal51Repro:
+    """The single failing test that drove this fix."""
+
+    def test_remember_with_entities_creates_entity_records(self, db):
+        """Repro of Proposal #51 bug from 2026-05-13.
+
+        memory_remember with entities=[...] must:
+          1. create an entity row for each name (if missing)
+          2. classify the type sensibly (Markup AI -> organization, not person)
+          3. link the memory to each entity via memory_entities
+
+        Before the fix, "Markup AI" was created as type="person" because the
+        _infer_entity_type heuristic did not recognise the "AI" corporate
+        suffix. This test fails on main and passes after the fix.
+        """
+        svc = _get_remember_service(db)
+
+        memory_id = svc.remember_fact(
+            content="Matt Blumberg said the placement angle should be the operator track.",
+            about_entities=["Matt Blumberg", "Markup AI"],
+        )
+        assert memory_id is not None, "memory should have been created"
+
+        # 1. Both entities exist.
+        matt = _entity_by_name(db, "Matt Blumberg")
+        markup = _entity_by_name(db, "Markup AI")
+        assert matt is not None, "Matt Blumberg entity should be created"
+        assert markup is not None, "Markup AI entity should be created"
+
+        # 2. Types are correct.
+        assert matt["type"] == "person", "Matt Blumberg should be a person"
+        assert markup["type"] == "organization", (
+            f"Markup AI should be an organization (got {markup['type']!r}). "
+            "Proposal #51: AI suffix indicates a company, not a person."
+        )
+
+        # 3. Memory is linked to both entities.
+        links = db.execute(
+            "SELECT entity_id FROM memory_entities WHERE memory_id = ?",
+            (memory_id,),
+            fetch=True,
+        ) or []
+        linked_ids = {row["entity_id"] for row in links}
+        assert matt["id"] in linked_ids, "memory should be linked to Matt Blumberg"
+        assert markup["id"] in linked_ids, "memory should be linked to Markup AI"
+
+
+# ---------------------------------------------------------------------------
+# 2. Type inference heuristics (organization / person / project / concept)
+# ---------------------------------------------------------------------------
+
+
+class TestInferEntityTypeHeuristics:
+    """Pure-function tests on infer_entity_type.
+
+    These extend the existing test_entity_type_inference.py coverage with
+    the new heuristics that Proposal #51 requires (AI suffix, fallback to
+    concept instead of person).
+    """
+
+    def _infer(self, name, content=""):
+        from claudia_memory.services.entities import infer_entity_type
+
+        return infer_entity_type(name, content)
+
+    # Organization signals -------------------------------------------------
+
+    def test_ai_suffix_is_organization(self):
+        """'Markup AI' must classify as organization (Proposal #51 core)."""
+        assert self._infer("Markup AI") == "organization"
+
+    def test_dot_ai_suffix_is_organization(self):
+        assert self._infer("Hugging.ai") == "organization"
+
+    def test_co_suffix_is_organization(self):
+        assert self._infer("Banc Co.") == "organization"
+
+    def test_inc_suffix_is_organization(self):
+        assert self._infer("Acme Inc.") == "organization"
+
+    def test_llc_suffix_is_organization(self):
+        assert self._infer("Acme LLC") == "organization"
+
+    def test_corp_suffix_is_organization(self):
+        assert self._infer("Acme Corp") == "organization"
+
+    def test_ltd_suffix_is_organization(self):
+        assert self._infer("Acme Ltd") == "organization"
+
+    # Person signals -------------------------------------------------------
+
+    def test_first_last_name_is_person(self):
+        """Two capitalised words (no corporate suffix) -> person."""
+        assert self._infer("Matt Blumberg") == "person"
+
+    def test_three_name_pattern_is_person(self):
+        """Three capitalised words with no suffix -> still a person."""
+        assert self._infer("Mary Anne Smith") == "person"
+
+    # Project signals ------------------------------------------------------
+
+    def test_project_prefix_is_project(self):
+        assert self._infer("Project Phoenix") == "project"
+
+    def test_project_suffix_is_project(self):
+        """'Phoenix Project' should be classified as project."""
+        assert self._infer("Phoenix Project") == "project"
+
+    # Concept fallback -----------------------------------------------------
+
+    def test_single_capitalised_word_is_concept(self):
+        """A single capitalised noun with no other signal -> concept.
+
+        Proposal #51 specifically: the fallback must NOT be 'person'.
+        """
+        assert self._infer("Curiosity") == "concept"
+
+    def test_lowercase_unknown_falls_back_to_concept(self):
+        """No-signal, no-pattern strings fall through to concept (never person)."""
+        assert self._infer("something vague") == "concept"
+
+    def test_no_signal_returns_concept_not_person(self):
+        """Explicit guard: 'aibrain' looks weird, must not default to person."""
+        assert self._infer("aibrain") == "concept"
+
+
+# ---------------------------------------------------------------------------
+# 3. relate_entities also uses inference (no more default-to-person)
+# ---------------------------------------------------------------------------
+
+
+class TestRelateUsesTypeInference:
+    """relate_entities auto-creates source/target with inferred types."""
+
+    def test_relate_creates_org_when_target_has_ai_suffix(self, db):
+        """memory.relate(source='Matt Blumberg', target='Markup AI', ...) creates
+        Markup AI as type=organization, not person.
+        """
+        svc = _get_remember_service(db)
+        svc.relate_entities(
+            source_name="Matt Blumberg",
+            target_name="Markup AI",
+            relationship_type="ceo_of",
+        )
+
+        markup = _entity_by_name(db, "Markup AI")
+        assert markup is not None
+        assert markup["type"] == "organization"
+
+    def test_relate_creates_person_for_plain_name(self, db):
+        """Plain first+last name still defaults to person."""
+        svc = _get_remember_service(db)
+        svc.relate_entities(
+            source_name="Matt Blumberg",
+            target_name="Holly Smith",
+            relationship_type="works_with",
+        )
+
+        holly = _entity_by_name(db, "Holly Smith")
+        assert holly is not None
+        assert holly["type"] == "person"
+
+
+# ---------------------------------------------------------------------------
+# 4. Backfill command: dry-run is default
+# ---------------------------------------------------------------------------
+
+
+def _seed_orphan_memory(db, content, entity_name):
+    """Insert a memory directly that mentions an entity but isn't linked.
+
+    Simulates the pre-fix state where memories have entity references in
+    their content (or were saved without about_entities populated) but
+    no rows exist in memory_entities / entities.
+    """
+    return db.insert(
+        "memories",
+        {
+            "content": content,
+            "content_hash": f"hash-{content[:30]}-{datetime.utcnow().isoformat()}",
+            "type": "fact",
+            "importance": 1.0,
+            "confidence": 1.0,
+            "source": "test",
+            "created_at": datetime.utcnow().isoformat(),
+            "updated_at": datetime.utcnow().isoformat(),
+        },
+    )
+
+
+class TestBackfillCommand:
+    """Backfill: plan (dry-run) is the default; apply requires a backup."""
+
+    def test_plan_backfill_writes_nothing(self, db):
+        """plan_backfill scans memories but makes no DB changes."""
+        from claudia_memory.services.backfill import plan_backfill
+
+        # Seed an orphan memory mentioning a known name.
+        _seed_orphan_memory(db, "Matt Blumberg ran the meeting.", "Matt Blumberg")
+
+        entities_before = db.execute(
+            "SELECT COUNT(*) AS n FROM entities", fetch=True
+        )[0]["n"]
+        links_before = db.execute(
+            "SELECT COUNT(*) AS n FROM memory_entities", fetch=True
+        )[0]["n"]
+
+        plan = plan_backfill(db)
+
+        entities_after = db.execute(
+            "SELECT COUNT(*) AS n FROM entities", fetch=True
+        )[0]["n"]
+        links_after = db.execute(
+            "SELECT COUNT(*) AS n FROM memory_entities", fetch=True
+        )[0]["n"]
+
+        # No writes whatsoever.
+        assert entities_before == entities_after
+        assert links_before == links_after
+
+        # Plan reports something to do.
+        assert plan.orphan_count >= 1
+        assert any(p["name"].lower() == "matt blumberg" for p in plan.proposed_entities)
+
+    def test_apply_requires_backup(self, db, tmp_path):
+        """apply_backfill creates a SQLite backup before any writes."""
+        from claudia_memory.services.backfill import apply_backfill, plan_backfill
+
+        _seed_orphan_memory(db, "Matt Blumberg owns the deal.", "Matt Blumberg")
+        plan = plan_backfill(db)
+
+        backup_path = tmp_path / "backups" / "memory-2026-05-13.db"
+        result = apply_backfill(db, plan, backup_path=backup_path)
+
+        assert backup_path.exists(), "backup file must exist after --apply"
+        assert backup_path.stat().st_size > 0, "backup must not be empty"
+        assert result.entities_created >= 1
+        assert result.links_created >= 1
+
+    def test_apply_aborts_when_backup_fails(self, db, tmp_path, monkeypatch):
+        """If the backup cannot be created, apply_backfill raises BEFORE any DB write."""
+        from claudia_memory.services import backfill as backfill_mod
+        from claudia_memory.services.backfill import apply_backfill, plan_backfill
+
+        _seed_orphan_memory(db, "Matt Blumberg signed off.", "Matt Blumberg")
+        plan = plan_backfill(db)
+
+        entities_before = db.execute(
+            "SELECT COUNT(*) AS n FROM entities", fetch=True
+        )[0]["n"]
+
+        # Force backup to fail.
+        def broken_backup(*_args, **_kwargs):
+            raise OSError("simulated backup failure")
+
+        monkeypatch.setattr(backfill_mod, "_create_backup", broken_backup)
+
+        backup_path = tmp_path / "backups" / "memory-2026-05-13.db"
+        with pytest.raises(OSError):
+            apply_backfill(db, plan, backup_path=backup_path)
+
+        entities_after = db.execute(
+            "SELECT COUNT(*) AS n FROM entities", fetch=True
+        )[0]["n"]
+        assert entities_after == entities_before, (
+            "no entities should be created when backup fails"
+        )
+
+    def test_apply_is_idempotent(self, db, tmp_path):
+        """Running --apply twice in a row produces no new writes the second time."""
+        from claudia_memory.services.backfill import apply_backfill, plan_backfill
+
+        _seed_orphan_memory(db, "Matt Blumberg signed the SOW.", "Matt Blumberg")
+
+        first_plan = plan_backfill(db)
+        first_backup = tmp_path / "backups" / "memory-first.db"
+        first_result = apply_backfill(db, first_plan, backup_path=first_backup)
+        assert first_result.entities_created >= 1
+
+        # Second pass: plan should be empty (everything already linked).
+        second_plan = plan_backfill(db)
+        assert second_plan.orphan_count == 0, "backfill must be idempotent"
+
+        second_backup = tmp_path / "backups" / "memory-second.db"
+        second_result = apply_backfill(db, second_plan, backup_path=second_backup)
+        assert second_result.entities_created == 0
+        assert second_result.links_created == 0
+
+
+# ---------------------------------------------------------------------------
+# 5. Latency budget: 3-entity remember_fact must finish under 50ms
+# ---------------------------------------------------------------------------
+
+
+class TestLatencyBudget:
+    """Performance guard: the entity-linking work added by Proposal #51
+    must stay under 50ms on the test fixture DB.
+
+    We stub out ``embed_sync`` so the measurement isolates the entity
+    resolution + memory_entities insert path (the surface area we changed).
+    Real Ollama latency is a separate concern owned by the embedding
+    service; not this PR's regression risk.
+    """
+
+    def test_remember_with_3_entities_under_50ms(self, db, monkeypatch):
+        import time
+
+        from claudia_memory.services import remember as remember_mod
+
+        # Replace embed_sync with a no-op so we measure entity-linking, not
+        # the embedding HTTP call that happens to live on the same machine.
+        monkeypatch.setattr(remember_mod, "embed_sync", lambda _text: None)
+
+        svc = _get_remember_service(db)
+
+        # Warm-up: priming any one-shot import or schema state.
+        svc.remember_fact(
+            content="Warm-up fact, ignored.",
+            about_entities=["Warmup Person"],
+        )
+
+        start = time.perf_counter()
+        svc.remember_fact(
+            content="Matt Blumberg and Holly Smith met with Markup AI's board.",
+            about_entities=["Matt Blumberg", "Holly Smith", "Markup AI"],
+        )
+        elapsed_ms = (time.perf_counter() - start) * 1000.0
+
+        # Record measurement for the report (printed by pytest -s).
+        print(f"\nLATENCY remember_fact 3-entities: {elapsed_ms:.2f}ms")
+        assert elapsed_ms < 50.0, (
+            f"remember_fact with 3 entities took {elapsed_ms:.2f}ms (>50ms budget)"
+        )


### PR DESCRIPTION
## Summary

Closes the Proposal #51 gap (2026-05-13): `memory_remember(content=..., entities=[...])` was already creating `memory_entities` links, but the type-inference heuristic on auto-created entities defaulted to `person` and didn't recognise the "AI" corporate suffix. So "Markup AI" was getting stored as a person. `memory_relate` had the same issue on its source/target auto-create path.

This PR is PR A of the v1.58.0 release chain (the biggest). Stops at the stop-gate. Does not merge. PR B (Rube removal, existing #41) is queued behind it.

## Changes

- **`services/entities.py` (new)** -- centralised, pure-function `infer_entity_type` (no LLM, no spaCy, no new deps). Widened heuristics: `AI`/`.ai`/`Co.`/`Inc.`/`LLC` -> organisation; two-capitalised-word names -> person; `project` keyword (pre or post) -> project; fallback **concept** (never person, per the proposal).
- **`services/remember.py`** -- `_find_or_create_entity` now uses the new heuristic when no explicit type is supplied. Both `remember_fact(about_entities=...)` and `relate_entities(source/target=...)` benefit. Existing entities also get a `last_contact_at` + `updated_at` touch when they are mentioned. No schema changes.
- **`services/backfill.py` (new)** -- `claudia-memory --backfill-entities` scans memories with no entity links and proposes new entities + `memory_entities` rows. Dry-run by default. `--apply` creates a SQLite backup at `~/.claudia/backups/memory-{ISO-timestamp}.db` **before** any write; if the backup fails, no DB writes happen. Re-running `--apply` is a no-op.
- **`__main__.py`** -- wires `--backfill-entities` and `--apply` flags.
- **`tests/test_entity_resolution.py` (new, 22 tests)** -- bug-repro, type-inference heuristic coverage, relate-creates-org test, backfill dry-run / apply / idempotency / backup-failure-abort, and a <50ms latency budget guard.

## Sensitivity proof

The bug-repro test is `TestProposal51Repro::test_remember_with_entities_creates_entity_records`. It fails on `main`:

```
AssertionError: Markup AI should be an organization (got 'person').
Proposal #51: AI suffix indicates a company, not a person.
assert 'person' == 'organization'
  - organization
  + person
tests/test_entity_resolution.py:92: AssertionError
```

It passes on this branch:

```
tests/test_entity_resolution.py::TestProposal51Repro::test_remember_with_entities_creates_entity_records PASSED [100%]
```

## Latency

`remember_fact` with 3 entities (`Matt Blumberg`, `Holly Smith`, `Markup AI`) on the test fixture DB: **~4.95 ms** (embeddings stubbed to isolate the entity-linking work). Budget: 50 ms. Well under.

## Backfill semantics

- `claudia-memory --backfill-entities` -- prints the plan, exits, writes nothing.
- `claudia-memory --backfill-entities --apply` -- creates `~/.claudia/backups/memory-{timestamp}.db`, then writes. If backup creation fails, command aborts with non-zero exit BEFORE any DB write. Idempotent on re-run.

## Test results

- 22 new tests, all passing.
- Existing daemon suite still passes: **784 total** (was 762), 12 skipped, 0 failures.

## Test plan

- [x] `pytest tests/test_entity_resolution.py` passes (22/22).
- [x] `pytest tests/` passes (784/784).
- [x] `claudia-memory --help` shows `--backfill-entities` and `--apply`.
- [ ] Reviewer: visually inspect entity records on a real DB after running `--backfill-entities --apply`.

## Out of scope / next PR

- PR B (Rube removal -- existing PR #41) -- not advanced; halted per stop-gate.
- Spec-style NER (spaCy / LLM) for content-text auto-extraction -- intentionally deferred to a later PR.
- Single-word entity backfill (the planner only matches two-capital-word phrases to avoid a flood of false positives).