### PR TITLE
feat(mcp): accept parameter-name aliases for memory_about/relate/recall (v1.58.0 PR E)

### DIFF
--- a/memory-daemon/claudia_memory/mcp/server.py
+++ b/memory-daemon/claudia_memory/mcp/server.py
@@ -141,6 +141,79 @@ def _require(arguments: dict, key: str, tool_name: str):
     return value
 
 
+# ── Parameter-name aliases (v1.58.0 PR E) ──
+#
+# The memory MCP tools historically used different parameter conventions
+# (entity vs source/target/relationship vs query). The aliases below let
+# callers use a consistent variant while every existing caller continues
+# to work unchanged. Normalization happens here at the MCP boundary;
+# service-layer signatures in claudia_memory/services/ are untouched.
+#
+# Rules:
+#   1. Purely additive. The canonical name continues to work as before.
+#   2. If both the canonical name and an alias are provided in the same
+#      call, the canonical name wins (the alias is left in place and is
+#      not consulted by the handler).
+#   3. Otherwise, the first matching alias is renamed to the canonical
+#      key and the alias key is removed from the arguments dict so the
+#      handler only ever sees the canonical name.
+
+_PARAM_ALIASES: Dict[str, Dict[str, List[str]]] = {
+    "memory_about": {
+        "entity": ["entity_name", "name"],
+    },
+    "memory_relate": {
+        "source": ["source_entity"],
+        "target": ["target_entity"],
+        "relationship": ["relationship_type"],
+    },
+    "memory_recall": {
+        "query": ["q", "search"],
+    },
+}
+
+
+def _normalize_params(arguments: dict, canonical: str, aliases: List[str]) -> dict:
+    """Resolve alias parameter names to the canonical name.
+
+    If the canonical name is already present in `arguments`, it wins and
+    `arguments` is returned unchanged. Otherwise, the first alias from
+    `aliases` that is present is renamed to the canonical key, and the
+    alias key is removed. If no alias matches either, `arguments` is
+    returned unchanged.
+
+    The function never mutates the caller's dict: when a rewrite is
+    needed it returns a shallow copy with the alias key replaced.
+    """
+    if canonical in arguments:
+        return arguments
+    for alias in aliases:
+        if alias in arguments:
+            arguments = dict(arguments)
+            arguments[canonical] = arguments.pop(alias)
+            return arguments
+    return arguments
+
+
+def _apply_parameter_aliases(tool_name: str, arguments: dict) -> dict:
+    """Apply all registered aliases for the given tool, if any.
+
+    Tools without an entry in `_PARAM_ALIASES` (the vast majority) get
+    their arguments back unchanged. Dot-notation aliases (e.g.
+    'memory.about') are routed to the same canonical tool name for the
+    purposes of alias lookup.
+    """
+    # Dot-notation aliases (memory.about, etc.) share the same canonical
+    # alias map as their underscore counterparts.
+    lookup_name = tool_name.replace(".", "_", 1) if "." in tool_name else tool_name
+    aliases_for_tool = _PARAM_ALIASES.get(lookup_name)
+    if not aliases_for_tool:
+        return arguments
+    for canonical, alias_list in aliases_for_tool.items():
+        arguments = _normalize_params(arguments, canonical, alias_list)
+    return arguments
+
+
 MAX_RESPONSE_BYTES = 50_000
 
 
@@ -3142,6 +3215,10 @@ async def call_tool(name: str, arguments: Dict[str, Any]) -> CallToolResult:
     """Handle tool calls via dispatch registry."""
     db = get_db()
     try:
+        # Normalize parameter-name aliases at the MCP boundary so handlers
+        # only ever see canonical parameter names. Purely additive: tools
+        # without registered aliases are unchanged. See _PARAM_ALIASES.
+        arguments = _apply_parameter_aliases(name, arguments)
         with db.transaction():
             handler = _TOOL_HANDLERS.get(name)
             if handler:

--- a/memory-daemon/tests/test_parameter_aliases.py
+++ b/memory-daemon/tests/test_parameter_aliases.py
@@ -1,0 +1,351 @@
+"""Tests for MCP parameter-name aliases (v1.58.0 PR E).
+
+The memory MCP tools historically used different parameter conventions:
+    memory_about     -> entity
+    memory_relate    -> source / target / relationship
+    memory_recall    -> query
+
+Four tools, four conventions. This PR adds canonical aliases so the tools
+accept either the original parameter name or a consistent variant. The
+normalization happens at the MCP request-handler entry point. The
+service-layer signatures are unchanged.
+
+Aliases registered:
+    memory_about   : entity  <- entity_name, name
+    memory_relate  : source       <- source_entity
+                     target       <- target_entity
+                     relationship <- relationship_type
+    memory_recall  : query   <- q, search
+
+Invariants tested:
+    1. Existing parameter names continue to work unchanged.
+    2. Each alias resolves to the same handler with the same semantics.
+    3. If both the canonical and an alias are passed, the canonical wins.
+    4. After normalization, only the canonical name reaches the handler;
+       alias keys are removed from the arguments dict.
+    5. Unknown extra parameters do not cause the handler to crash.
+"""
+
+import asyncio
+import json
+
+import pytest
+
+import claudia_memory.database as db_mod
+from claudia_memory.mcp.server import call_tool
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors test_recurring_regressions.py rebinding pattern)
+# ---------------------------------------------------------------------------
+
+
+def _get_remember_service(db):
+    """Build a RememberService bound to the provided test database."""
+    from claudia_memory.services.remember import RememberService
+    from claudia_memory.extraction.entity_extractor import get_extractor
+
+    svc = RememberService.__new__(RememberService)
+    svc.db = db
+    svc._embedder = None
+    svc.extractor = get_extractor()
+    svc.embedding_service = None
+    return svc
+
+
+def _run(coro):
+    """Run an async coroutine to completion."""
+    return asyncio.run(coro)
+
+
+def _payload(result):
+    """Extract the JSON payload from a CallToolResult, asserting no error."""
+    assert not getattr(result, "isError", False), (
+        f"call_tool returned an error result: "
+        f"{result.content[0].text if result.content else result!r}"
+    )
+    return json.loads(result.content[0].text)
+
+
+@pytest.fixture
+def wired_db(db):
+    """Rebind the global _db to the test DB for the duration of the test.
+
+    The MCP handlers call get_db() internally, which returns the module-level
+    global. We swap that pointer so handlers see our isolated test database.
+
+    We also reset the module-level service caches in recall.py / remember.py
+    because each service caches its own get_db() reference at __init__ time.
+    Without this reset, service objects from a previous test would hold a
+    stale Database whose tempfile has already been cleaned up.
+    """
+    import claudia_memory.services.recall as recall_mod
+    import claudia_memory.services.remember as remember_mod
+
+    old_db = db_mod._db
+    old_recall_service = recall_mod._service
+    old_remember_service = remember_mod._service
+
+    db_mod._db = db
+    recall_mod._service = None
+    remember_mod._service = None
+    try:
+        yield db
+    finally:
+        db_mod._db = old_db
+        recall_mod._service = old_recall_service
+        remember_mod._service = old_remember_service
+
+
+@pytest.fixture
+def seeded(wired_db):
+    """Seed a memory linked to 'Sarah Chen' for memory_about / memory_recall tests."""
+    svc = _get_remember_service(wired_db)
+    memory_id = svc.remember_fact(
+        content="Sarah Chen prefers email over Slack and likes concise updates.",
+        about_entities=["Sarah Chen"],
+    )
+    assert memory_id is not None, "seed memory must be created"
+    return wired_db
+
+
+# ---------------------------------------------------------------------------
+# Test 1: memory_about accepts entity, entity_name, name
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryAboutAliases:
+    """memory_about must accept 'entity' (canonical), 'entity_name', or 'name'."""
+
+    def test_canonical_entity_param(self, seeded):
+        result = _run(call_tool("memory_about", {"entity": "Sarah Chen"}))
+        payload = _payload(result)
+        # The canonical call must produce a usable response (entity found,
+        # or a structured 'not found' style payload, but never an error).
+        assert isinstance(payload, dict), "memory_about must return a dict payload"
+
+    def test_alias_entity_name(self, seeded):
+        canonical = _payload(_run(call_tool("memory_about", {"entity": "Sarah Chen"})))
+        alias = _payload(_run(call_tool("memory_about", {"entity_name": "Sarah Chen"})))
+        assert alias == canonical, (
+            "memory_about(entity_name=...) must produce the same result as "
+            "memory_about(entity=...)"
+        )
+
+    def test_alias_name(self, seeded):
+        canonical = _payload(_run(call_tool("memory_about", {"entity": "Sarah Chen"})))
+        alias = _payload(_run(call_tool("memory_about", {"name": "Sarah Chen"})))
+        assert alias == canonical, (
+            "memory_about(name=...) must produce the same result as "
+            "memory_about(entity=...)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: memory_relate accepts source/target/relationship and *_entity / *_type
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryRelateAliases:
+    """memory_relate must accept either the original triplet or the consistent
+    *_entity / *_type variants."""
+
+    def test_canonical_triplet(self, wired_db):
+        # Pre-seed both entities so relate_entities does not have to auto-create
+        # them (keeps assertions focused on parameter normalization).
+        svc = _get_remember_service(wired_db)
+        svc.remember_fact(content="A is a person.", about_entities=["A"])
+        svc.remember_fact(content="B is a person.", about_entities=["B"])
+
+        result = _run(call_tool("memory_relate", {
+            "source": "A",
+            "target": "B",
+            "relationship": "knows",
+        }))
+        payload = _payload(result)
+        assert payload.get("success") is True, (
+            f"memory_relate canonical form should succeed; got {payload!r}"
+        )
+
+    def test_alias_triplet(self, wired_db):
+        svc = _get_remember_service(wired_db)
+        svc.remember_fact(content="C is a person.", about_entities=["C"])
+        svc.remember_fact(content="D is a person.", about_entities=["D"])
+
+        result = _run(call_tool("memory_relate", {
+            "source_entity": "C",
+            "target_entity": "D",
+            "relationship_type": "knows",
+        }))
+        payload = _payload(result)
+        assert payload.get("success") is True, (
+            f"memory_relate alias form should succeed; got {payload!r}"
+        )
+
+    def test_both_forms_create_equivalent_relationship(self, wired_db):
+        """Two memory_relate calls (one canonical, one alias) on equivalent
+        inputs must both create a relationship row."""
+        svc = _get_remember_service(wired_db)
+        for name in ["E", "F", "G", "H"]:
+            svc.remember_fact(content=f"{name} is a person.", about_entities=[name])
+
+        r1 = _payload(_run(call_tool("memory_relate", {
+            "source": "E", "target": "F", "relationship": "knows",
+        })))
+        r2 = _payload(_run(call_tool("memory_relate", {
+            "source_entity": "G", "target_entity": "H", "relationship_type": "knows",
+        })))
+
+        assert r1.get("success") is True
+        assert r2.get("success") is True
+        # Both must return a relationship_id; the values differ because they
+        # link different entity pairs, but both must exist.
+        assert r1.get("relationship_id") is not None
+        assert r2.get("relationship_id") is not None
+
+
+# ---------------------------------------------------------------------------
+# Test 3: memory_recall accepts query, q, search
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryRecallAliases:
+    """memory_recall must accept 'query' (canonical), 'q', or 'search'."""
+
+    def test_canonical_query(self, seeded):
+        result = _run(call_tool("memory_recall", {"query": "Sarah"}))
+        payload = _payload(result)
+        assert "results" in payload, "memory_recall must return a results list"
+
+    def test_alias_q(self, seeded):
+        canonical = _payload(_run(call_tool("memory_recall", {"query": "Sarah"})))
+        alias = _payload(_run(call_tool("memory_recall", {"q": "Sarah"})))
+        assert alias == canonical, (
+            "memory_recall(q=...) must produce the same result as "
+            "memory_recall(query=...)"
+        )
+
+    def test_alias_search(self, seeded):
+        canonical = _payload(_run(call_tool("memory_recall", {"query": "Sarah"})))
+        alias = _payload(_run(call_tool("memory_recall", {"search": "Sarah"})))
+        assert alias == canonical, (
+            "memory_recall(search=...) must produce the same result as "
+            "memory_recall(query=...)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Canonical wins when both canonical and alias are provided
+# ---------------------------------------------------------------------------
+
+
+class TestCanonicalWins:
+    """When both the canonical name and an alias are supplied, the canonical
+    value must be used. This is the documented disambiguation rule."""
+
+    def test_about_canonical_beats_alias(self, wired_db):
+        """memory_about(entity='Sarah', entity_name='OTHER') -> looks up 'Sarah'."""
+        svc = _get_remember_service(wired_db)
+        svc.remember_fact(
+            content="Sarah is the canonical target.",
+            about_entities=["Sarah"],
+        )
+        # 'OTHER' is intentionally never created.
+
+        from_canonical_only = _payload(
+            _run(call_tool("memory_about", {"entity": "Sarah"}))
+        )
+        from_both = _payload(
+            _run(call_tool("memory_about", {"entity": "Sarah", "entity_name": "OTHER"}))
+        )
+
+        assert from_both == from_canonical_only, (
+            "When both 'entity' and 'entity_name' are passed, the canonical "
+            "'entity' value must win. Got divergent payloads:\n"
+            f"  canonical-only: {from_canonical_only!r}\n"
+            f"  both:           {from_both!r}"
+        )
+
+    def test_recall_canonical_beats_alias(self, seeded):
+        from_canonical_only = _payload(
+            _run(call_tool("memory_recall", {"query": "Sarah"}))
+        )
+        from_both = _payload(
+            _run(call_tool("memory_recall", {"query": "Sarah", "q": "ZZZZZ"}))
+        )
+        assert from_both == from_canonical_only, (
+            "When both 'query' and 'q' are passed, the canonical 'query' "
+            "value must win."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Alias keys are removed from arguments dict after normalization
+# ---------------------------------------------------------------------------
+
+
+class TestAliasKeysDoNotLeak:
+    """After normalization, only the canonical parameter name reaches the
+    handler. The alias key is removed from the arguments dict so the handler
+    is never confused by duplicated state."""
+
+    def test_normalize_removes_alias_key(self):
+        from claudia_memory.mcp.server import _normalize_params
+
+        args = {"entity_name": "Sarah Chen"}
+        normalized = _normalize_params(args, "entity", ["entity_name", "name"])
+        assert "entity" in normalized, "canonical key must be present"
+        assert normalized["entity"] == "Sarah Chen"
+        assert "entity_name" not in normalized, (
+            "alias key must be removed after normalization; "
+            f"got: {sorted(normalized)}"
+        )
+        assert "name" not in normalized
+
+    def test_normalize_canonical_wins_and_alias_ignored(self):
+        from claudia_memory.mcp.server import _normalize_params
+
+        args = {"entity": "Sarah", "entity_name": "OTHER"}
+        normalized = _normalize_params(args, "entity", ["entity_name", "name"])
+        assert normalized["entity"] == "Sarah", "canonical value must be preserved"
+        # When canonical is already present, the helper returns the args
+        # unchanged (no need to rewrite anything). Either form is acceptable
+        # so long as the canonical value is the one consulted; here we test
+        # the documented contract that no rewriting happens.
+        # The handler reads arguments["entity"], so the alias key being
+        # present or absent has no behavioural effect.
+
+    def test_normalize_no_alias_passes_through(self):
+        from claudia_memory.mcp.server import _normalize_params
+
+        args = {"unrelated": "x"}
+        normalized = _normalize_params(args, "entity", ["entity_name", "name"])
+        # Nothing to rewrite -- arguments come back unchanged.
+        assert normalized == {"unrelated": "x"}
+
+
+# ---------------------------------------------------------------------------
+# Test 6: Unknown parameter does not crash the handler
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownParameterIgnored:
+    """Existing MCP server behaviour: unknown parameters are silently ignored
+    (the handlers only read the keys they know about). This test pins that
+    behaviour so the alias normalization layer does not accidentally change it.
+    """
+
+    def test_memory_about_with_unknown_param_does_not_crash(self, seeded):
+        result = _run(call_tool("memory_about", {
+            "entity": "Sarah Chen",
+            "weird_param": "ignored",
+        }))
+        # Whatever the payload, the call must not produce an error result.
+        _payload(result)  # asserts isError is False
+
+    def test_memory_recall_with_unknown_param_does_not_crash(self, seeded):
+        result = _run(call_tool("memory_recall", {
+            "query": "Sarah",
+            "weird_param": "ignored",
+        }))
+        _payload(result)


### PR DESCRIPTION
## Summary

The memory MCP tools historically used different parameter conventions across the read-side surface:

| Tool | Existing parameter shape |
|---|---|
| `memory_about` | `entity` |
| `memory_relate` | `source`, `target`, `relationship` |
| `memory_recall` | `query` |

Four tools, four conventions. Each is a small learning cost; together they meaningfully slow agent fluency. This PR adds canonical aliases so the tools accept either the original parameter name or a consistent variant. Normalization happens at the MCP request-handler entry point (`call_tool` in `memory-daemon/claudia_memory/mcp/server.py`); service-layer signatures in `claudia_memory/services/` are untouched.

### Aliases registered

| Tool | Canonical | Aliases added |
|---|---|---|
| `memory_about` | `entity` | `entity_name`, `name` |
| `memory_relate` | `source`, `target`, `relationship` | `source_entity`, `target_entity`, `relationship_type` |
| `memory_recall` | `query` | `q`, `search` |

### Invariants

- **Purely additive.** Every existing caller continues to work unchanged. No breaking changes.
- **MCP layer only.** Service-layer signatures in `claudia_memory/services/` are not modified.
- **Canonical wins.** If both the canonical name and an alias are provided in the same call, the canonical value is used (the alias is ignored).
- **Alias keys do not leak.** When only an alias is provided, it is renamed to the canonical key and the alias key is removed from the arguments dict so the handler only ever sees the canonical name.
- **Dot-notation aliases route correctly.** Tools called as `memory.about`, `memory.relate`, or `memory.recall` (backward-compat dot form) flow through the same alias map.

## Sensitivity proof (test failed on main, passes on branch)

Before the implementation, running `tests/test_parameter_aliases.py::TestMemoryAboutAliases::test_alias_entity_name` against `origin/main` produced:

```
AssertionError: call_tool returned an error result:
'{"error": "Required parameter \'entity\' missing for memory_about"}'
ValueError: Required parameter 'entity' missing for memory_about
```

After the implementation, the same test passes. The normalization layer rewrites `entity_name` -> `entity` before dispatch, so the existing `_require(arguments, "entity", ...)` call inside `_handle_about` finds the value.

## Tests added

- Path: `memory-daemon/tests/test_parameter_aliases.py`
- 16 tests across 6 classes covering every required scenario from the PR brief:
  1. `memory_about` accepts `entity`, `entity_name`, `name` (3 tests)
  2. `memory_relate` accepts both triplet conventions (3 tests)
  3. `memory_recall` accepts `query`, `q`, `search` (3 tests)
  4. Canonical wins when both passed (2 tests, one each for `memory_about` and `memory_recall`)
  5. Alias keys do not leak into the arguments dict (3 unit tests on `_normalize_params`)
  6. Unknown extra parameters do not crash (2 tests, behavior unchanged)
- All 16 pass.

## Daemon suite

- Pre-PR: 789 passed, 12 skipped
- Post-PR: 805 passed, 12 skipped
- Regressions: 0

## Files modified

- `memory-daemon/claudia_memory/mcp/server.py` (+77 lines: helpers + one-line wiring into `call_tool`)
- `memory-daemon/tests/test_parameter_aliases.py` (new, +351 lines)

## Test plan

- [x] `python3 -m pytest tests/test_parameter_aliases.py -v` (16 passed)
- [x] `python3 -m pytest tests/` (805 passed, 12 skipped, no regressions)
- [x] Sensitivity test verified to fail on main before implementation, pass on branch after

## Chain context

This is **PR E (final)** of the v1.58.0 release chain:

- [x] #54 entity linking + backfill (MERGED)
- [x] #41 Rube removal (MERGED)
- [x] #55 `claudia/` cleanup (MERGED)
- [x] #56 regression tests (MERGED)
- [ ] This PR: ready for merge