### PR TITLE
docs(skills): catalogue overlap markers and contributor guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to Claudia will be documented in this file.
 
+## 1.61.0 (2026-05-15)
+
+### Skill catalog: "see also" overlap markers + contributor guide
+
+No skills renamed, removed, or behavior-changed. Pure documentation and metadata work.
+
+### Documentation
+- Augmented `template-v2/.claude/skills/README.md` with four new sections: "Writing a good skill description", "The see also convention", "Disambiguation notes", and "Proactive vs contextual: when to make a skill auto-fire". Each section grounds itself in existing-catalog examples rather than abstract guidelines.
+
+### Changed
+- 27 skill descriptions get a final "See also: ..." line pointing at adjacent skills. Affected clusters: outbound message composition, memory introspection, memory visualization, reflective cadences, meeting lifecycle, risks and blind spots, people and relationships, patterns and judgment, inbound document processing.
+
+No user-visible behavior change. Skill names, trigger phrases, and behaviors are identical to v1.58.0. The added "See also" content extends descriptions to nudge skill triggering toward the more canonical name when an ambiguous request arrives.
+
+---
+
 ## 1.58.0 (2026-05-13)
 
 ### The Memory Reliability Release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-claudia",
-  "version": "1.58.0",
+  "version": "1.61.0",
   "description": "An AI assistant who learns how you work.",
   "keywords": [
     "claudia",

--- a/template-v2/.claude/skills/README.md
+++ b/template-v2/.claude/skills/README.md
@@ -248,6 +248,54 @@ Include:
 - **Output Format** - Expected output structure
 - **Judgment Points** - Where to ask for confirmation
 
+## Writing a good skill description
+
+The `description:` field in a skill's frontmatter is what Claude Code uses to decide when to trigger the skill. A vague description fires inconsistently; a tight description fires reliably. Three patterns from the existing catalog earn their keep:
+
+**Verb + object + outcome + trigger phrases.** Lead with what the skill does, then list the exact phrases users say. From `capture-meeting`:
+
+> Process meeting notes or transcript to extract decisions, commitments, and insights. Use when user shares transcript or says "capture this meeting", "here are my notes from the call".
+
+**Quantify the work.** Numerical bounds disambiguate the skill from neighbors. From `deep-context`:
+
+> Full-context deep analysis for meeting prep, relationship analysis, or strategic planning. Pulls up to 180 memories across multiple dimensions for comprehensive synthesis.
+
+**State the proactive trigger threshold.** For proactive skills, name the count that fires them. From `pattern-recognizer`:
+
+> Activates when the same topic, frustration, or behavior appears across 3+ interactions.
+
+Avoid descriptions that read as aspirational ("helps you think strategically"), circular ("manages memory operations"), or multi-purpose without a clear trigger.
+
+## The "see also" convention
+
+When two skills could plausibly fire on the same situation, both should point at each other in their descriptions so a user who picked the less-canonical name finds the alternative. Pattern: append a final line to the `description:` field of the form:
+
+> See also: `<skill-name>` for <what differs>.
+
+Common overlap clusters in the current catalog:
+
+- **Outbound messages**: `draft-reply` (general) ↔ `follow-up-draft` (post-meeting)
+- **Memory**: `memory-audit` (content) ↔ `memory-health` (system) ↔ `diagnose` (connectivity)
+- **Visualization**: `brain` (3D web) ↔ `brain-monitor` (terminal)
+- **Reflective cadences**: `morning-brief` (daily) → `weekly-review` (weekly) → `growth-check` (monthly+) → `meditate` (per session)
+- **Meeting lifecycle**: `meeting-prep` (before) → `capture-meeting` (during/after notes) → `follow-up-draft` (after, outbound)
+- **Inbound processing**: `ingest-sources` (multi-doc) ↔ `file-document` (single) ↔ `capture-meeting` (meeting only) ↔ `summarize-doc` (no filing)
+
+## Disambiguation notes
+
+- `connector-discovery` is about connecting external services (Gmail, Calendar, Slack). It is not about people or human connections. For people, see `relationship-tracker`, `new-person`, and `map-connections`.
+- `pattern-recognizer` notices what's recurring. `judgment-awareness` applies the user's decision rules to a recurring situation. `capability-suggester` proposes a new command when the same task is repeated by hand. Three skills, three different stages of "we keep doing this."
+
+## Proactive vs contextual: when to make a skill auto-fire
+
+A skill with `invocation: proactive` runs without the user asking. This is powerful but expensive: every proactive skill loaded into context is a tax on every conversation. Use proactive only when:
+
+1. The trigger condition is **specific enough that false positives are rare** (e.g., commitment-detector watches for explicit promise phrasing, not vague intentions).
+2. The action is **observational**, not mutative (surface a pattern, not send an email).
+3. The output is **brief**, ideally one line, deferring detail to a follow-up question.
+
+Contextual skills (no `invocation` set, or `invocation: contextual`) are cheaper. They wait for the user to invoke them by name or phrase. Default to contextual; promote to proactive only after observing repeated manual invocations of the same skill.
+
 ## Archetype Templates
 
 The `archetypes/` folder contains structure and command templates for each user type:

--- a/template-v2/.claude/skills/brain-monitor/SKILL.md
+++ b/template-v2/.claude/skills/brain-monitor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: brain-monitor
-description: Launch the Brain Monitor TUI, a real-time terminal dashboard for watching Claudia's memory system. Triggers on "brain monitor", "show dashboard", "memory dashboard", "terminal brain".
+description: Launch the Brain Monitor TUI, a real-time terminal dashboard for watching Claudia's memory system. Triggers on "brain monitor", "show dashboard", "memory dashboard", "terminal brain". See also: `brain` for a 3D graph view in the browser.
 effort-level: low
 ---
 

--- a/template-v2/.claude/skills/brain/SKILL.md
+++ b/template-v2/.claude/skills/brain/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: brain
-description: Launch the Brain Visualizer, a real-time 3D view of memory and relationships. Triggers on "show your brain", "visualize memory", "open the brain", "memory graph".
+description: Launch the Brain Visualizer, a real-time 3D view of memory and relationships. Triggers on "show your brain", "visualize memory", "open the brain", "memory graph". See also: `brain-monitor` for a terminal dashboard alternative.
 effort-level: medium
 ---
 

--- a/template-v2/.claude/skills/capability-suggester.md
+++ b/template-v2/.claude/skills/capability-suggester.md
@@ -1,6 +1,6 @@
 ---
 name: capability-suggester
-description: Notice repeated user behaviors and suggest new commands, workflows, structure, or integrations to streamline work. Also detects when the user's setup has outgrown its current structure and suggests targeted upgrades. Activates when repeated task patterns, workflow friction, structural gaps, or business growth signals are detected.
+description: Notice repeated user behaviors and suggest new commands, workflows, structure, or integrations to streamline work. Also detects when the user's setup has outgrown its current structure and suggests targeted upgrades. Activates when repeated task patterns, workflow friction, structural gaps, or business growth signals are detected. See also: `pattern-recognizer` for theme detection upstream; `hire-agent` for adding specialized subagents.
 user-invocable: false
 invocation: proactive
 effort-level: high

--- a/template-v2/.claude/skills/capture-meeting/SKILL.md
+++ b/template-v2/.claude/skills/capture-meeting/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: capture-meeting
-description: Process meeting notes or transcript to extract decisions, commitments, and insights. Use when user shares transcript or says "capture this meeting", "here are my notes from the call".
+description: Process meeting notes or transcript to extract decisions, commitments, and insights. Use when user shares transcript or says "capture this meeting", "here are my notes from the call". See also: `meeting-prep` for pre-call briefings; `follow-up-draft` for post-meeting emails.
 effort-level: medium
 ---
 

--- a/template-v2/.claude/skills/connector-discovery.md
+++ b/template-v2/.claude/skills/connector-discovery.md
@@ -1,6 +1,6 @@
 ---
 name: connector-discovery
-description: Help users connect their external tools in a gentle, non-technical way. Recommend solutions based on what works best, explain everything in plain language.
+description: Help users connect their external tools in a gentle, non-technical way. Recommend solutions based on what works best, explain everything in plain language. Note: this is about external service connectors (Gmail, Calendar), not human connections. See `relationship-tracker` and `map-connections` for person and relationship features.
 effort-level: high
 ---
 

--- a/template-v2/.claude/skills/diagnose/SKILL.md
+++ b/template-v2/.claude/skills/diagnose/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: diagnose
-description: Check memory system health and troubleshoot connectivity issues. Use when memory commands aren't working, at session start if something seems wrong, or when user asks about memory status.
+description: Check memory system health and troubleshoot connectivity issues. Use when memory commands aren't working, at session start if something seems wrong, or when user asks about memory status. See also: `memory-health` for the data-quality dashboard once connectivity is confirmed.
 effort-level: low
 ---
 

--- a/template-v2/.claude/skills/draft-reply/SKILL.md
+++ b/template-v2/.claude/skills/draft-reply/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: draft-reply
-description: Draft an email response with tone matching the relationship context. Shows draft for approval before sending. Use when user says "draft a reply", "respond to this email", "write a response to [person]", or shares an email and asks for help replying.
+description: Draft an email response with tone matching the relationship context. Shows draft for approval before sending. Use when user says "draft a reply", "respond to this email", "write a response to [person]", or shares an email and asks for help replying. See also: `follow-up-draft` for post-meeting thank-yous with meeting context.
 effort-level: medium
 ---
 

--- a/template-v2/.claude/skills/file-document/SKILL.md
+++ b/template-v2/.claude/skills/file-document/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: file-document
-description: Store a document, email, or text for future reference with entity linking and provenance.
+description: Store a document, email, or text for future reference with entity linking and provenance. See also: `ingest-sources` for multiple files; `capture-meeting` if it's meeting notes; `summarize-doc` to get a summary without filing.
 effort-level: medium
 ---
 

--- a/template-v2/.claude/skills/follow-up-draft/SKILL.md
+++ b/template-v2/.claude/skills/follow-up-draft/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: follow-up-draft
-description: Create a post-meeting thank-you or follow-up email with key points and next steps. Use when user says "follow-up email", "thank you note", "post-meeting email", "send a follow-up to [person]", or after a meeting capture when next steps need communicating.
+description: Create a post-meeting thank-you or follow-up email with key points and next steps. Use when user says "follow-up email", "thank you note", "post-meeting email", "send a follow-up to [person]", or after a meeting capture when next steps need communicating. See also: `draft-reply` for general email responses unrelated to a meeting.
 argument-hint: "[person name]"
 effort-level: medium
 ---

--- a/template-v2/.claude/skills/growth-check/SKILL.md
+++ b/template-v2/.claude/skills/growth-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: growth-check
-description: Periodic reflection on development, skills, learning, and progress toward goals. Triggers on "am I growing?", "development check", "personal growth review".
+description: Periodic reflection on development, skills, learning, and progress toward goals. Triggers on "am I growing?", "development check", "personal growth review". See also: `weekly-review` for tactical week recap; `meditate` for session-level reflection.
 effort-level: low
 ---
 

--- a/template-v2/.claude/skills/hire-agent.md
+++ b/template-v2/.claude/skills/hire-agent.md
@@ -1,6 +1,6 @@
 ---
 name: hire-agent
-description: Suggests new agents based on repeated task patterns.
+description: Suggests new agents based on repeated task patterns. See also: `capability-suggester` for skill or command-level additions; `agent-dispatcher` for routing logic.
 user-invocable: false
 invocation: proactive
 effort-level: high

--- a/template-v2/.claude/skills/inbox-check/SKILL.md
+++ b/template-v2/.claude/skills/inbox-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: inbox-check
-description: Lightweight inbox triage across all configured email accounts. Dispatches fast subagent to fetch, then reviews with judgment. Use when user says "check my inbox", "any new emails?", "check email".
+description: Lightweight inbox triage across all configured email accounts. Dispatches fast subagent to fetch, then reviews with judgment. Use when user says "check my inbox", "any new emails?", "check email". See also: `draft-reply` once you pick an email to respond to.
 effort-level: low
 ---
 

--- a/template-v2/.claude/skills/ingest-sources/SKILL.md
+++ b/template-v2/.claude/skills/ingest-sources/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ingest-sources
-description: Process multiple source documents with Extract-Then-Aggregate discipline. Use when user shares multiple transcripts, emails, or documents for batch processing.
+description: Process multiple source documents with Extract-Then-Aggregate discipline. Use when user shares multiple transcripts, emails, or documents for batch processing. See also: `capture-meeting` for a single meeting transcript; `file-document` for a single document; `summarize-doc` when you only need a summary.
 argument-hint: [folder-path]
 effort-level: max
 ---

--- a/template-v2/.claude/skills/judgment-awareness.md
+++ b/template-v2/.claude/skills/judgment-awareness.md
@@ -1,6 +1,6 @@
 ---
 name: judgment-awareness
-description: Load and apply user-defined judgment rules from context/judgment.yaml to inform priority conflicts, escalation decisions, surfacing, and delegation.
+description: Load and apply user-defined judgment rules from context/judgment.yaml to inform priority conflicts, escalation decisions, surfacing, and delegation. See also: `pattern-recognizer` for theme detection; `meditate` updates judgment rules at session end.
 user-invocable: false
 invocation: proactive
 effort-level: low

--- a/template-v2/.claude/skills/map-connections/SKILL.md
+++ b/template-v2/.claude/skills/map-connections/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: map-connections
-description: Scan context files to extract entities and relationships into the memory system. Triggers on "who knows who?", "network graph", "map my connections", "extract relationships".
+description: Scan context files to extract entities and relationships into the memory system. Triggers on "who knows who?", "network graph", "map my connections", "extract relationships". See also: `brain` for graph visualization once relationships are extracted.
 argument-hint: "[--incremental] [file-path]"
 effort-level: high
 ---

--- a/template-v2/.claude/skills/meditate/SKILL.md
+++ b/template-v2/.claude/skills/meditate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: meditate
-description: End-of-session reflection generating persistent learnings about user preferences, communication patterns, and cross-session insights. Activates when wrapping up a session, or when user says "let's wrap up", "end the session", "time to reflect", or "meditate". Also extracts judgment rules from decisions made during the session.
+description: End-of-session reflection generating persistent learnings about user preferences, communication patterns, and cross-session insights. Activates when wrapping up a session, or when user says "let's wrap up", "end the session", "time to reflect", or "meditate". Also extracts judgment rules from decisions made during the session. See also: `weekly-review` and `growth-check` for time-based reflection cadences.
 effort-level: high
 ---
 

--- a/template-v2/.claude/skills/meeting-prep/SKILL.md
+++ b/template-v2/.claude/skills/meeting-prep/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: meeting-prep
-description: One-page briefing before a call or meeting with person context, open items, and talking points. Use when user says "prep me for my call with [person]", "meeting prep", "brief me before my meeting", "get ready for my call", or mentions an upcoming meeting where context would help.
+description: One-page briefing before a call or meeting with person context, open items, and talking points. Use when user says "prep me for my call with [person]", "meeting prep", "brief me before my meeting", "get ready for my call", or mentions an upcoming meeting where context would help. See also: `capture-meeting` for processing notes after the call; `follow-up-draft` for thank-yous.
 argument-hint: [person or meeting name]
 effort-level: medium
 ---

--- a/template-v2/.claude/skills/memory-audit/SKILL.md
+++ b/template-v2/.claude/skills/memory-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memory-audit
-description: Show everything Claudia knows with provenance tracing and entity counts. Triggers on "what do you know?", "show memories", "memory audit", "what do you remember about".
+description: Show everything Claudia knows with provenance tracing and entity counts. Triggers on "what do you know?", "show memories", "memory audit", "what do you remember about". See also: `memory-health` for system-level stats and data quality; `diagnose` for connectivity troubleshooting.
 argument-hint: "[entity name]"
 effort-level: medium
 ---

--- a/template-v2/.claude/skills/memory-health/SKILL.md
+++ b/template-v2/.claude/skills/memory-health/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memory-health
-description: Check memory system health and data quality. Use when user asks "how's my memory?", "system health", "memory stats", "data quality", "how's my brain?", or for periodic self-diagnostics.
+description: Check memory system health and data quality. Use when user asks "how's my memory?", "system health", "memory stats", "data quality", "how's my brain?", or for periodic self-diagnostics. See also: `memory-audit` for content-level provenance; `diagnose` for daemon connectivity issues.
 effort-level: medium
 ---
 

--- a/template-v2/.claude/skills/morning-brief/SKILL.md
+++ b/template-v2/.claude/skills/morning-brief/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: morning-brief
-description: Daily digest of commitments, warnings, and relationship health. Use when starting your day or asking "what's on my plate".
+description: Daily digest of commitments, warnings, and relationship health. Use when starting your day or asking "what's on my plate". See also: `weekly-review` (end of week), `growth-check` (monthly+), `meditate` (end of session).
 effort-level: low
 ---
 

--- a/template-v2/.claude/skills/new-person/SKILL.md
+++ b/template-v2/.claude/skills/new-person/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: new-person
-description: Create a relationship tracking file for a person with contact info, history, and communication preferences. Use when user says "new person", "add [name]", "create a file for [name]", "track this person", or mentions someone important who doesn't have a file yet.
+description: Create a relationship tracking file for a person with contact info, history, and communication preferences. Use when user says "new person", "add [name]", "create a file for [name]", "track this person", or mentions someone important who doesn't have a file yet. See also: `relationship-tracker` for ongoing health; `meeting-prep` when you have a call coming up.
 argument-hint: "[name]"
 effort-level: medium
 ---

--- a/template-v2/.claude/skills/pattern-recognizer.md
+++ b/template-v2/.claude/skills/pattern-recognizer.md
@@ -1,6 +1,6 @@
 ---
 name: pattern-recognizer
-description: Notice trends, recurring themes, and patterns across conversations and surface them when relevant. Activates when the same topic, frustration, or behavior appears across 3+ interactions. Use for "I've noticed you keep...", "this is the third time...", recurring scheduling issues, or avoidance patterns.
+description: Notice trends, recurring themes, and patterns across conversations and surface them when relevant. Activates when the same topic, frustration, or behavior appears across 3+ interactions. Use for "I've noticed you keep...", "this is the third time...", recurring scheduling issues, or avoidance patterns. See also: `judgment-awareness` for applying user-set decision rules; `capability-suggester` for converting patterns into new commands.
 user-invocable: false
 invocation: proactive
 effort-level: high

--- a/template-v2/.claude/skills/relationship-tracker.md
+++ b/template-v2/.claude/skills/relationship-tracker.md
@@ -1,6 +1,6 @@
 ---
 name: relationship-tracker
-description: Surface relevant context when people are mentioned in conversation, and track relationship health over time.
+description: Surface relevant context when people are mentioned in conversation, and track relationship health over time. See also: `new-person` to create a file for someone important; `map-connections` to extract relationships across files.
 user-invocable: false
 invocation: proactive
 effort-level: high

--- a/template-v2/.claude/skills/risk-surfacer.md
+++ b/template-v2/.claude/skills/risk-surfacer.md
@@ -1,6 +1,6 @@
 ---
 name: risk-surfacer
-description: Proactively identify and surface potential problems before they become crises.
+description: Proactively identify and surface potential problems before they become crises. See also: `what-am-i-missing` for a user-invoked, full-sweep version.
 user-invocable: false
 invocation: proactive
 effort-level: high

--- a/template-v2/.claude/skills/summarize-doc/SKILL.md
+++ b/template-v2/.claude/skills/summarize-doc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: summarize-doc
-description: Create an executive summary of any document at the appropriate level of detail. Triggers on "summarize this", "main points", "give me the gist".
+description: Create an executive summary of any document at the appropriate level of detail. Triggers on "summarize this", "main points", "give me the gist". See also: `file-document` if you also want to save it; `capture-meeting` if it's meeting notes.
 effort-level: medium
 ---
 

--- a/template-v2/.claude/skills/weekly-review/SKILL.md
+++ b/template-v2/.claude/skills/weekly-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: weekly-review
-description: Guided weekly reflection across all relationships, commitments, and projects with pattern analysis. Use at end of week, or when user says "weekly review", "end of week", "reflect on this week", "weekly check-in", or "how did my week go".
+description: Guided weekly reflection across all relationships, commitments, and projects with pattern analysis. Use at end of week, or when user says "weekly review", "end of week", "reflect on this week", "weekly check-in", or "how did my week go". See also: `morning-brief` (daily), `growth-check` (zoom out), `meditate` (session reflection).
 effort-level: high
 ---
 

--- a/template-v2/.claude/skills/what-am-i-missing/SKILL.md
+++ b/template-v2/.claude/skills/what-am-i-missing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: what-am-i-missing
-description: Surface risks, blind spots, overlooked items, and accountability across commitments and relationships. Triggers on "what am I overlooking?", "blind spots", "what's falling through the cracks", "what do I owe?", "am I overdue?", "check my commitments".
+description: Surface risks, blind spots, overlooked items, and accountability across commitments and relationships. Triggers on "what am I overlooking?", "blind spots", "what's falling through the cracks", "what do I owe?", "am I overdue?", "check my commitments". See also: `risk-surfacer` for the proactive auto-firing version on overdue items and cooling relationships.
 argument-hint: "[person name or 'overdue']"
 effort-level: high
 ---


### PR DESCRIPTION
## Summary

No skills renamed, removed, or behavior-changed. Pure metadata and docs work that makes the catalog more navigable for users and contributors.

## What changes

### 1. "See also" markers on overlap clusters

The shipped skill set has natural overlap. A user who says "summarize this meeting" might want \`summarize-doc\`, \`capture-meeting\`, or \`file-document\` depending on what they plan to do next. To help them land on the right skill, each overlapping skill now points at its neighbors with one trailing sentence in its \`description:\` field.

**9 overlap clusters covered**, 27 skill files touched:

| Cluster | Skills |
|---------|--------|
| Outbound messages | \`draft-reply\`, \`follow-up-draft\`, \`inbox-check\` |
| Memory introspection | \`memory-audit\`, \`memory-health\`, \`diagnose\` |
| Memory visualization | \`brain\`, \`brain-monitor\` |
| Reflective cadences | \`morning-brief\`, \`weekly-review\`, \`growth-check\`, \`meditate\` |
| Meeting lifecycle | \`meeting-prep\`, \`capture-meeting\`, \`follow-up-draft\` |
| Risks, blind spots | \`what-am-i-missing\`, \`risk-surfacer\` |
| People and relationships | \`relationship-tracker\`, \`new-person\`, \`map-connections\`, \`connector-discovery\` |
| Patterns, judgment, capability | \`pattern-recognizer\`, \`judgment-awareness\`, \`capability-suggester\`, \`hire-agent\` |
| Inbound processing | \`ingest-sources\`, \`file-document\`, \`summarize-doc\`, \`capture-meeting\` |

Example diff (one of 27, all are minimal):

\`\`\`diff
 ---
 name: draft-reply
-description: Draft an email response... Use when user says "draft a reply"...
+description: Draft an email response... Use when user says "draft a reply"... See also: \`follow-up-draft\` for post-meeting thank-yous with meeting context.
 effort-level: medium
 ---
\`\`\`

### 2. Contributor's guide additions to template-v2/.claude/skills/README.md

The existing README already documents the schema, the per-skill catalog, and a "Creating Custom Skills" walkthrough. PR3 adds four sections that fill the gap between "here's the schema" and "here's a skill that fires reliably":

- **Writing a good skill description** — three patterns from the existing catalog (verb + object + outcome + trigger phrases; quantify the work; state proactive trigger thresholds), each with an exemplar from a shipped skill.
- **The "see also" convention** — the pattern, plus a compact map of the nine overlap clusters in the current catalog.
- **Disambiguation notes** — clarifies traps like "\`connector-discovery\` is about external services, not human connections."
- **Proactive vs contextual** — three criteria for promoting a skill from contextual (cheap) to proactive (auto-fire). Defaults to contextual.

## What is NOT in this PR

- **No skill renames.** Trigger phrases users have built habits around are preserved exactly.
- **No skill deletions.** Every shipped skill continues to ship.
- **No tightening of vague descriptions.** The audit flagged six skills with aspirational or circular descriptions. Rewriting those could subtly shift the skill-matcher's behavior in ways we'd need to test deliberately, so it's deferred to a separate PR.
- **No archetype or rule changes.** \`template-v2/.claude/rules/\` and the archetype configs are untouched.

## Verification

- \`npm test\`: 25 passed, 0 failed.
- Audit covered all 42 user-facing shipped skills (13 single-file + 29 directory-style).
- Each "See also" line is appended to the existing \`description:\` field as a final sentence. No new fields, no reformatting, no headers shifted.

## Stability contract honored

- CLI surface unchanged
- MCP tool names unchanged
- Skill names and trigger phrases unchanged (only descriptions extended, additively)
- Database schema unchanged
- Vault layout unchanged

## Context

Third PR of four in the craft refactor. Builds on PR #58 (design), PR #59 (dead code removal), PR #60 (installer modularization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)