### PR TITLE
docs: subpackage READMEs and a first-PR walkthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Claudia will be documented in this file.
 
+## 1.59.1 (2026-05-15)
+
+### Docs uplift
+
+Pure documentation. No code change.
+
+### Documentation
+- Added subpackage READMEs under `memory-daemon/claudia_memory/`: `services/`, `daemon/`, `extraction/`, `mcp/`. Each names the public entry points, lists the most relevant files, and captures the conventions a contributor needs to know before editing.
+- Expanded `CONTRIBUTING.md` with a "Your first PR" walkthrough covering the seven-step path from picking a starter issue to opening the PR.
+
+No user-visible behavior change.
+
+---
+
 ## 1.59.0 (2026-05-15)
 
 ### Removed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,82 @@ claude
 - Test with `curl http://localhost:3848/health`
 - Check logs: `tail -f ~/.claudia/daemon-stderr.log`
 
+## Your first PR: a walkthrough
+
+If you've never contributed before, this is the path the maintainers walk. It should take 30 to 60 minutes for a small change.
+
+### 1. Pick a starter issue
+
+Browse the [issues list](https://github.com/kbanc85/claudia/issues) and look for the `good first issue` or `help wanted` labels. If nothing jumps out, the safest first contributions are:
+
+- A typo or wording fix in `template-v2/CLAUDE.md`, a skill file, or `README.md`.
+- A clearer description on a skill that's currently vague (see the audit in `template-v2/.claude/skills/README.md` for examples of good descriptions).
+- A new test case for a recurring bug class (see `memory-daemon/tests/test_regression_classes.py` for the pattern).
+
+### 2. Fork and clone
+
+```bash
+gh repo fork kbanc85/claudia --clone
+cd claudia
+```
+
+### 3. Branch
+
+Name the branch after the change, conventional-commits-style:
+
+```bash
+git checkout -b fix/typo-in-onboarding
+# or
+git checkout -b feat/morning-brief-shows-pinned-projects
+```
+
+### 4. Make the change
+
+Match the existing style of whichever file you're editing. The hardest part of a small PR is *not* doing more than the issue asks. Resist the urge to also refactor adjacent code.
+
+### 5. Verify locally
+
+Run whatever test surface your change touches:
+
+```bash
+# For installer changes (bin/)
+npm test
+
+# For memory daemon changes (memory-daemon/)
+cd memory-daemon && ./test.sh
+```
+
+For a template-only change (markdown skill files, rules, hooks), there's no automated test surface. Verify by installing locally:
+
+```bash
+node bin/index.js ../scratch --skip-memory --yes
+cd ../scratch && claude
+# exercise the affected skill or behavior
+```
+
+### 6. Commit
+
+One commit per concern. Conventional Commits format:
+
+```bash
+git commit -m "docs: clarify onboarding trigger for context/me.md"
+```
+
+### 7. Open the PR
+
+```bash
+gh pr create --base main
+```
+
+A reviewer (often within a day or two) will reply. They're usually looking for:
+
+- Does the change match the issue's intent?
+- Does it follow project conventions (no em dashes, ESM imports, file naming)?
+- Are existing tests still passing?
+- For shipped-surface changes: does `CHANGELOG.md` have a new entry, and does the package version need a bump?
+
+That's the whole loop. The bar is not "perfect"; the bar is "fits the codebase and doesn't break what works."
+
 ## Code Style
 
 ### General Principles

--- a/memory-daemon/claudia_memory/daemon/README.md
+++ b/memory-daemon/claudia_memory/daemon/README.md
@@ -1,0 +1,16 @@
+# daemon/
+
+Long-running side of the memory daemon: scheduled background jobs and a local HTTP health endpoint. Only used when the daemon runs in standalone mode (`--standalone`); the MCP-server path (stdio transport, default) does not run these.
+
+## Where to look first
+
+| Concern | File | Notes |
+|---------|------|-------|
+| Scheduled background work | `scheduler.py` | APScheduler with three jobs: `daily_decay` at 02:00, `pattern_detection` every 6 hours, `full_consolidation` at 03:00. Optional `vault_sync` at 03:15 if `vault_sync_enabled` is set. |
+| Health endpoint | `health.py` | HTTP server bound to `localhost:3848`. The `/health` route is what the npm installer probes during Step 5 of install. The `/status` route powers the `memory_system_health` MCP tool. |
+
+## Conventions
+
+- **Bind localhost only.** Never `0.0.0.0`. The health server exposes internal state and is not auth-gated.
+- **New scheduled jobs go through the same path as existing ones.** Add to `scheduler.py`'s job registration. Don't spawn ad-hoc background threads from service modules.
+- **Service code stays in `services/`.** The daemon module is for *scheduling and exposing* that work, not implementing it. If you find yourself writing business logic here, move it to a service.

--- a/memory-daemon/claudia_memory/extraction/README.md
+++ b/memory-daemon/claudia_memory/extraction/README.md
@@ -1,0 +1,16 @@
+# extraction/
+
+Pulling structured signal out of free-form text. Used by the remember pipeline (to identify which entities a memory is about) and by the ingest flow (to extract entities, commitments, and dates from longer documents).
+
+## Where to look first
+
+| Concern | File | Notes |
+|---------|------|-------|
+| Named-entity recognition | `entity_extractor.py` | Detects people, organizations, projects, concepts. Uses spaCy when the optional `[nlp]` extra is installed; falls back to pattern-based heuristics otherwise. |
+| Date and time parsing | `temporal.py` | Resolves relative phrases (e.g., "next Thursday") to absolute dates in the user's timezone. Used by commitment detection and event extraction. |
+
+## Conventions
+
+- **spaCy is optional.** Anything in `extraction/` must work without it. Test the no-spaCy path. If you require it, gate behind a clear `ImportError` message that tells the user to install `claudia-memory[nlp]`.
+- **Return structured results, never raw text.** Extractors emit typed dicts or dataclasses; the caller decides how to render them. This keeps the boundary clean and the call sites testable.
+- **Idempotent on re-extraction.** If a document is re-ingested, extractors must produce the same result. No hidden state.

--- a/memory-daemon/claudia_memory/mcp/README.md
+++ b/memory-daemon/claudia_memory/mcp/README.md
@@ -1,0 +1,17 @@
+# mcp/
+
+The Model Context Protocol surface: how Claude Code talks to the memory daemon. Stdio transport, configured in the user's `.mcp.json` after install.
+
+## Where to look first
+
+| Concern | File | Notes |
+|---------|------|-------|
+| Tool registration | `server.py` | Single file defining all ~33 `memory_*` MCP tools. Each tool is a handler function paired with a JSONSchema-style parameter declaration. |
+
+## Conventions
+
+- **Tool names are a public API.** Never rename a `memory_*` tool. Users have skills and workflows that invoke them by name. Add new tools rather than renaming old ones.
+- **Tool docstrings are how Claude Code decides when to call.** Like skill descriptions, they need a clear verb, expected inputs, and example trigger phrases. Vague tool docs cause inconsistent invocation.
+- **Each tool is a thin wrapper.** The real work lives in `services/`. Handlers in `server.py` parse the MCP request, call into a service, format the response. No business logic here.
+- **Parameter aliases are supported for ergonomics.** `memory_about`, `memory_relate`, and `memory_recall` accept multiple parameter names (e.g., `entity` and `name`) so users can call them naturally. See PR #57 for the canonical example.
+- **Errors should be actionable.** When a handler raises, the error message reaches the user verbatim. Say what went wrong and what to try, not just "failed."

--- a/memory-daemon/claudia_memory/services/README.md
+++ b/memory-daemon/claudia_memory/services/README.md
@@ -1,0 +1,25 @@
+# services/
+
+Business logic for the memory daemon. One module per concern. Every MCP tool exposed by `mcp/server.py` ultimately calls into a function here.
+
+## Where to look first
+
+| Concern | File | Public entry points |
+|---------|------|--------------------|
+| Write a memory, entity, or relationship | `remember.py` | `remember_fact`, `remember_entity`, `relate_entities`, `invalidate_memory` |
+| Recall memories or find entities | `recall.py` | `recall`, `recall_about`, `search_entities`, `deep_recall` |
+| Background decay + dedup + pattern detection | `consolidate.py` | `run_full_consolidation`, decay/dedup helpers, prediction lifecycle |
+| Entity type inference and naming | `entities.py` | `infer_entity_type` |
+| Memory and input validation rules | `guards.py` | `validate_memory`, `validate_entity`, `validate_relationship` |
+| File storage for filed source material | `filestore.py`, `documents.py` | `LocalFileStore`, document filing pipeline |
+| Provenance and audit trail | `audit.py` | source links, correction history |
+| Bulk historical fixes | `backfill.py` | one-shot maintenance utilities |
+| Compact session summaries for greeting | `context_builder.py` | `build_briefing_context` and friends |
+| Multi-document intake pipeline | `ingest.py` | the Extract-Then-Aggregate flow |
+| Obsidian vault projection | `vault_sync.py`, `canvas_generator.py` | PARA-layout write of entities, MOC canvases |
+
+## Conventions
+
+- **Soft-delete columns differ by table.** `memories.invalidated_at` vs. `entities.deleted_at`. Always check the schema before writing recall queries that filter "active" rows.
+- **Embedding storage is JSON text** (via `json.dumps`), not binary `struct.pack` blobs. Match this when writing new embedding paths.
+- Functions exported from a service module are the unit of testability. Tests for `recall.py` live at `tests/test_recall*.py` and call the module's public functions directly. Don't add internal coupling that bypasses those entry points.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-claudia",
-  "version": "1.59.0",
+  "version": "1.59.1",
   "description": "An AI assistant who learns how you work.",
   "keywords": [
     "claudia",


### PR DESCRIPTION
## Summary

Pure docs. Final PR of the four-PR craft refactor. Aimed at making the codebase faster to navigate for new contributors.

## What changes

### Four subpackage READMEs in \`memory-daemon/claudia_memory/\`

A new \`README.md\` in each of:

- \`services/\` — names public entry points per file, calls out conventions like \`memories.invalidated_at\` vs \`entities.deleted_at\` (the source of more than one past bug).
- \`daemon/\` — covers the three scheduled jobs (daily_decay 02:00, pattern_detection 6h, full_consolidation 03:00) and the localhost health endpoint.
- \`extraction/\` — documents the spaCy-optional pattern and the idempotency contract for extractors.
- \`mcp/\` — names tool-naming as a public API, the parameter-alias convention (PR #57), and the "handlers are thin wrappers, business logic is in services" rule.

Each file is a single page. Tables where useful, conventions where contributors keep tripping.

### CONTRIBUTING.md "Your first PR" walkthrough

Seven steps from picking a starter issue through opening the PR, with verify-locally commands tailored to which subsystem the change touches. Aimed at someone who has never contributed before; should take 30 to 60 minutes for a small change.

## What is NOT in this PR

- No code change. No tests touched.
- No CLI surface change.
- No memory daemon schema change.
- No skill changes.
- ARCHITECTURE.md's file-tree section still shows the pre-PR2 \`bin/\` layout. That update depends on PR #60 (\`bin/\` modularization) landing first and is deferred to a follow-up patch.

## Stability contract honored

This PR is documentation only. Every contract in the original refactor design is honored trivially.

## Context

Fourth and final PR of the craft refactor. Closes out the work described in PR #58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)