### PR TITLE
feat(wiki): new default vault projection (replaces PARA for new installs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to Claudia will be documented in this file.
 
+## 1.60.0 (2026-05-15)
+
+### Wiki layer (new default vault projection)
+
+Inspired by Andrej Karpathy's [llm-wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) pattern, adapted to Claudia's working-set discipline. The wiki is the third tier of Claudia's memory: raw memories live in the database, derived signals (entities, reflections, patterns) live in the daemon, and **synthesized topic pages** now live in the user's vault at `~/.claudia/vault/Wiki/`. Each page is written by Claudia from raw memories, cites every load-bearing claim with `[mem:NNN]`, flags contradictions at the top, and grows incrementally with use.
+
+### Added
+- **`wiki` skill** at `template-v2/.claude/skills/wiki/SKILL.md` with two reference docs (page template, citations/contradictions discipline). The skill defines when to write pages, the page structure, the citation format, and the read workflow (consult the wiki page first, fall back to memory query if stale).
+
+### Changed
+- **Vault default for new installs is now wiki, not PARA.** New installs write synthesized pages at `~/.claudia/vault/Wiki/` instead of mechanical entity dumps.
+- **`vault-awareness` skill** updated with a "Wiki vs PARA" section at the top and a detection rule, with a pointer to the new wiki skill for specifics.
+
+### Compatibility
+- **Existing PARA vaults are preserved untouched.** Users with vaults from v1.42 to v1.59 keep their existing structure. Detection rule: if `~/.claudia/vault/Active/` or `Relationships/` exists without `Wiki/`, treat as PARA. The mechanical dump continues to function for them.
+- **A future `claudia-memory --migrate-to-wiki` CLI** will copy PARA aside and rebuild wiki pages from raw memories. Not in this release; PARA users stay on PARA until they explicitly migrate.
+
+### Not yet in this release
+- Automatic wiki-refresh queue (mark entities as "dirty" on ingest, batch refresh later). Today, wiki writes are explicit, driven by the skill.
+- Daemon-side MCP tools for wiki page metadata (`memory_wiki_get`, `memory_wiki_save`, `memory_wiki_dirty`). Today the wiki skill uses Read/Write directly.
+
+These are planned for a follow-up release once the wiki format proves itself in real use.
+
+No CLI surface change, no MCP tool removal, no database schema change.
+
+---
+
 ## 1.59.1 (2026-05-15)
 
 ### Docs uplift

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-claudia",
-  "version": "1.59.1",
+  "version": "1.60.0",
   "description": "An AI assistant who learns how you work.",
   "keywords": [
     "claudia",

--- a/template-v2/.claude/skills/vault-awareness.md
+++ b/template-v2/.claude/skills/vault-awareness.md
@@ -1,6 +1,6 @@
 ---
 name: vault-awareness
-description: Teaches Claudia about the Obsidian vault projection of her memory, how to reference it, trigger syncs, and handle user edits.
+description: Reference for the Obsidian vault at ~/.claudia/vault/. The vault is a read projection of Claudia's memory. New installs default to the wiki layout (synthesized topic pages, see the `wiki` skill). Existing installs may still use the PARA layout (Active/, Relationships/, Reference/, Archive/, Claudia's Desk/) and that is preserved. This skill covers vault paths, when to read from vault vs. query memory directly, and how to trigger sync.
 user-invocable: false
 effort-level: low
 ---
@@ -8,6 +8,23 @@ effort-level: low
 # Vault Awareness Skill
 
 **Triggers:** User mentions Obsidian, vault, graph view, browsing memories, or asks about vault sync status.
+
+---
+
+## Wiki vs PARA: which layout is in use
+
+Claudia ships two vault layouts. Both write to `~/.claudia/vault/`:
+
+| Layout | What gets written | When it's the default |
+|--------|-------------------|-----------------------|
+| **Wiki** (new default) | Synthesized topic pages by Claudia, citing source memories, with contradiction flagging. See the `wiki` skill. | All installs from v1.60.0 onward, unless the vault already has PARA folders |
+| **PARA** (legacy) | Mechanical dump of entity rows into `Active/`, `Relationships/`, `Reference/`, `Archive/`, `Claudia's Desk/` | Installs from v1.42 to v1.59 that started syncing before the wiki shipped |
+
+**Detection rule.** If `~/.claudia/vault/Wiki/` exists, wiki mode is active. If `~/.claudia/vault/Active/` or `Relationships/` exists without `Wiki/`, the user is on PARA. If both exist, the user is mid-migration; treat both as readable, but write only to `Wiki/`.
+
+**Migration is not automatic.** Existing PARA vaults are preserved untouched. The `claudia-memory --migrate-to-wiki` CLI flag (when it ships in a future release) will copy PARA aside and rebuild wiki pages from raw memories. Until then, PARA users stay on PARA; new users get wiki.
+
+For wiki specifics (page structure, when to write, citations, contradiction flagging), see the `wiki` skill. The rest of this file documents the older PARA layout, kept here for backward compatibility.
 
 ---
 

--- a/template-v2/.claude/skills/wiki/SKILL.md
+++ b/template-v2/.claude/skills/wiki/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: wiki
+description: Maintain Claudia's wiki, a directory of synthesized Markdown pages about your active entities (people, projects, organizations, topics). Each page is written by Claudia from raw memories, cites its sources, flags contradictions, and grows over time. Use when user says "write a wiki page for [entity]", "what do you know about [entity]" (returns the wiki page if it exists), "update the wiki on [entity]", or after ingesting substantial new content about an active entity. Replaces PARA as the default vault structure for new installs.
+effort-level: medium
+invocation: contextual
+---
+
+# Wiki
+
+A persistent, navigable, LLM-maintained reference. The wiki is the third tier of Claudia's memory: raw memories live in SQLite, derived signals (entities, reflections, patterns) live in the daemon, and **synthesized topic pages** live here, in the user's Obsidian vault at `~/.claudia/vault/Wiki/`.
+
+This skill is how I write those pages.
+
+## What the wiki is for
+
+| Today (without wiki) | With wiki |
+|----------------------|-----------|
+| "What's going on with Sarah?" forces me to re-synthesize from raw memories every time. | I check `Wiki/Sarah-Chen.md`. If it's fresh, the answer is already there. |
+| Important entities accumulate scattered memories with no narrative. | Each active entity has one page that grows with use. |
+| Contradictions in what I've been told sit silently. | Contradictions get flagged at the top of the page when I write it. |
+| Memory dumps for important entities are unreadable. | Wiki pages are readable; the user can open them in Obsidian. |
+
+The wiki is **synthesized once at ingest time**, not re-derived at every query. That's the key contrast with raw memory recall.
+
+## Where wiki pages live
+
+`~/.claudia/vault/Wiki/<entity-name>.md`
+
+The vault root is the user's existing Obsidian vault (or it gets created on first wiki write). Each page is a single Markdown file. Filename matches the canonical entity name with spaces converted to hyphens (`Sarah Chen` → `Sarah-Chen.md`).
+
+The `Wiki/` subdirectory sits alongside any existing PARA folders (`Active/`, `Relationships/`, etc.) for users already syncing to PARA. New installs default to wiki-only. Existing PARA users keep PARA running until they opt to migrate.
+
+## When I write a wiki page
+
+I write a wiki page proactively in these situations:
+
+1. **After capturing a meeting** with a key person, organization, or project mentioned. If the wiki page for the entity doesn't exist or is stale, I update it.
+2. **After filing a document** that contains substantive new information about an active entity.
+3. **After ingesting multiple sources** that touch the same entity.
+4. When the user **explicitly asks** ("write a wiki page for [entity]", "update the wiki on [entity]").
+
+I write a wiki page **on-demand** when:
+
+5. The user asks "what's going on with [entity]?" or "what do you know about [entity]?" and either no page exists or the existing page is older than the most recent memory about the entity.
+
+**I do NOT write a wiki page when:**
+
+- The entity is dormant (no mentions in the last 60 days). Dormant entities stay in raw memory only.
+- I would only have one or two memories to work from. The page would be too thin to earn its keep.
+- The entity is sensitive in a way that suggests the user wouldn't want a synthesized page (medical, deeply personal). Stay in raw memory.
+
+## Page structure
+
+Every wiki page follows this template:
+
+```markdown
+---
+entity: "Sarah Chen"
+entity_type: person
+last_updated: 2026-05-15
+source_memories: [142, 278, 391, 412, 487]
+contradiction_count: 0
+---
+
+# Sarah Chen
+
+> One-sentence TLDR for Claudia and the user to read first.
+
+## At a glance
+
+- **Role:** VP of Engineering at Acme Corp [mem:278]
+- **First contact:** 2025-11-12 via James [mem:142]
+- **Last interaction:** 2026-05-08, intro call with the design team [mem:487]
+- **Communication style:** Email over Slack, mornings only [mem:391]
+
+## What matters to her
+
+(Synthesized prose from accumulated memories. Each meaningful claim cites the memory it came from. Aim for clarity, not completeness; this is a working reference, not a dossier.)
+
+## Current threads
+
+- **Acme rebrand engagement:** waiting on her sign-off on the proposal [mem:487]
+- **(other open threads)**
+
+## History
+
+- 2026-05-08: Intro call with design team [mem:487]
+- 2026-03-22: Sent the engagement scope [mem:412]
+- (more history, newest first)
+
+## Related
+
+- [[Acme Corp]]
+- [[James (introducer)]]
+- [[Acme rebrand engagement]]
+```
+
+Required elements:
+- **YAML frontmatter** with `entity`, `entity_type`, `last_updated`, `source_memories` (list of memory IDs that contributed to this version of the page), `contradiction_count`.
+- **TLDR** in a blockquote at the top. One sentence that answers "what's the deal with this entity?"
+- **Citations** as `[mem:NNN]` after each load-bearing claim. The user can trace any fact back to its source.
+- **Cross-references** as `[[Entity Name]]` Obsidian wikilinks. These power the graph view.
+
+Optional sections (use what fits):
+- "At a glance" for quick facts
+- "What matters to them" for preferences, motivations, values
+- "Current threads" for open commitments and projects
+- "History" reverse-chronological log of interactions
+- "Contradictions" at the top, if any (see below)
+
+## Contradictions
+
+When two memories about the same entity disagree, the wiki page must surface it. Add a section directly after the TLDR:
+
+```markdown
+## ⚠ Contradictions to resolve
+
+- **Role:** Listed as "VP of Engineering" in the kickoff notes [mem:142] but "CTO" in the org chart shared 2026-04-01 [mem:412]. Ask user which is current.
+```
+
+Update `contradiction_count` in the frontmatter to match. When a contradiction is resolved (user clarifies), strike through the obsolete claim in the relevant section and add a note.
+
+## Writing process (workflow)
+
+When I'm asked to write or update a wiki page for an entity:
+
+1. **Check if a page already exists.** Use the Read tool on `~/.claudia/vault/Wiki/<entity-name>.md`. If it exists, read it. Note the `source_memories` list in the frontmatter, those are the memories already incorporated.
+2. **Query memories about the entity.** Use the `memory_about` or `memory_recall` MCP tool to get all memories tagged to this entity. Note which memory IDs are NEW relative to the existing page.
+3. **Decide: incremental update or full rewrite.**
+   - If there's an existing page and only 1-3 new memories: incremental. Add new facts to relevant sections, append to "History", update the TLDR if warranted.
+   - If there's no page, or 5+ new memories since the last update, or the page is older than 60 days: full rewrite. Build the page from scratch using all memories.
+4. **Synthesize the page** following the template. Cite every meaningful claim. Flag contradictions explicitly.
+5. **Save** using the Write tool to `~/.claudia/vault/Wiki/<entity-name>.md`. Update `last_updated`, append new memory IDs to `source_memories`, refresh `contradiction_count`.
+6. **Cross-link.** If the page references other entities, ensure those entities have wiki pages too. If not and they're active, queue them for later (don't recursively write the whole graph).
+
+## Read workflow (when user asks about an entity)
+
+When the user asks "what do you know about X?", "what's going on with X?", etc:
+
+1. Check if `Wiki/<X>.md` exists.
+2. If yes and `last_updated` is within 7 days of the most recent memory about X: read the page, answer from it, mention you're reading from the wiki page (so the user knows it's a synthesized view).
+3. If yes but stale: read the existing page, query for new memories, summarize what's new, and offer to update the wiki page.
+4. If no page exists: do a regular memory query as before, AND offer to write a wiki page now if the entity is active enough to warrant one.
+
+## Replaces PARA as the default
+
+For new Claudia installs, the wiki is the canonical projection of memory into the vault. The old PARA mechanical-dump (entity rows extracted to `Active/`, `Relationships/`, etc.) is deprecated.
+
+**For users with existing PARA vaults:** the old PARA structure is preserved. Both `Wiki/` and the existing PARA folders coexist. The user can migrate (or not) at their own pace. The `claudia-memory --migrate-to-wiki` CLI flag (when it ships in a future release) will copy the PARA structure aside and regenerate wiki pages from raw memories.
+
+**Config:** A single setting in `~/.claudia/config.json`:
+
+```json
+{
+  "vault_mode": "wiki"
+}
+```
+
+Values:
+- `"wiki"` (default for new installs): wiki pages get written on ingest. PARA sync is skipped.
+- `"para"`: PARA mechanical dump runs as before (for backward compatibility). Wiki pages are not auto-written but can be invoked manually.
+- `"both"`: PARA runs AND wiki writes happen on ingest. Higher cost, redundant. Mostly useful during migration.
+
+If `vault_mode` is unset and the existing vault has PARA folders, treat as `"para"`. Otherwise treat as `"wiki"`.
+
+## What the wiki is NOT
+
+- **Not Wikipedia.** Pages are about *the user's* working set, not the general world. "Sarah Chen" is the Sarah the user actually works with, not the public figure.
+- **Not a comprehensive dossier.** Pages should be useful at a glance. Aim for 300 to 1500 words per page, with longer pages reserved for entities the user interacts with daily.
+- **Not a replacement for raw memory.** Every wiki page is *derived from* raw memories. The raw memories are still the source of truth. Wiki pages are the synthesized view.
+- **Not a place for sensitive personal information.** If a memory contains sensitive content (medical, deeply personal), keep it in raw memory only and do not surface it in the wiki page unless the user explicitly asks.
+
+## Style
+
+Wiki pages should:
+- Be readable as standalone Markdown. The user might open them in Obsidian without my mediation.
+- Cite every load-bearing claim with `[mem:NNN]`. Trust requires traceability.
+- Use plain language. No em dashes (project style rule). Direct sentences.
+- Stay scoped to what's useful, not what's comprehensive.
+
+See also: `vault-awareness` for the vault path conventions; `memory-manager` for the underlying memory lifecycle that feeds the wiki; `file-document`, `capture-meeting`, and `ingest-sources` for the ingestion paths that should trigger wiki writes.
+
+## Open questions for future versions
+
+- Automatic refresh queue (mark entities as "dirty" on ingest, batch refresh later) is not in this skill. Today, wiki writes are explicit. A future PR may add daemon-side auto-triggering.
+- Wiki search (find pages by topic, not just entity name) is not yet a thing. Today, Obsidian's own search handles this.
+- The `--migrate-to-wiki` CLI is named but not yet implemented. Users on PARA stay on PARA until that CLI ships.

--- a/template-v2/.claude/skills/wiki/references/citations-and-contradictions.md
+++ b/template-v2/.claude/skills/wiki/references/citations-and-contradictions.md
@@ -1,0 +1,99 @@
+# Citations and Contradictions
+
+The two disciplines that make wiki pages trustworthy.
+
+## Citations
+
+Every load-bearing claim on a wiki page must cite the memory it came from. Format: `[mem:NNN]` where NNN is the memory ID returned by `memory_recall` or `memory_about`.
+
+### What counts as load-bearing
+
+Cite:
+- Facts about the entity (role, location, preferences, history)
+- Decisions or commitments
+- Quoted preferences or statements
+- Dates and timelines
+- Relationships between entities
+
+Don't cite (no memory ID exists):
+- Synthesis sentences that combine multiple facts (the facts themselves are cited)
+- Stylistic glue ("As mentioned above", "On the other hand")
+- Generic background that isn't specific to the entity
+
+### Where to put the citation
+
+Inline, at the end of the sentence or claim:
+
+```markdown
+Sarah is VP of Engineering at Acme Corp [mem:278].
+```
+
+Multiple sources for one claim:
+
+```markdown
+The Acme rebrand kickoff was on 2026-03-15 [mem:412, mem:438].
+```
+
+### Reading citations back
+
+When the user asks "where did you learn that?" or "show me the source", I use the memory ID to call `memory_recall` with the specific ID and surface the original memory content.
+
+## Contradictions
+
+The wiki must surface contradictions, not hide them.
+
+### Detection
+
+A contradiction exists when two or more memories about the same entity claim mutually exclusive things. Examples:
+
+- Role mismatch: "VP Engineering" in one memory, "CTO" in another, no resolving memory in between.
+- Date mismatch: meeting date listed differently in two sources.
+- Preference flip: user said person prefers email, then said they prefer Slack, with no "they changed their mind" memory.
+
+The detection rule: if I can write both `X is true [mem:A]` and `X is false [mem:B]` from the same memory pool, that's a contradiction.
+
+### Surfacing
+
+Add a `## ⚠ Contradictions to resolve` section directly after the TLDR. Each contradiction is one bullet:
+
+```markdown
+## ⚠ Contradictions to resolve
+
+- **Role title:** Listed as "VP of Engineering" in kickoff notes [mem:142] but "CTO" in the org chart [mem:412]. The org chart is more recent; recommend updating but the user should confirm.
+- **Preferred channel:** Said "email only" in onboarding [mem:201] but accepted a Slack invite that's been active since [mem:489]. Probably both work; ask user if they want the preference updated.
+```
+
+Update `contradiction_count` in the frontmatter to match the number of bullets.
+
+### Resolving
+
+When the user clarifies a contradiction, I:
+1. Strike through the obsolete claim in its original section.
+2. Add the resolved fact.
+3. Remove the bullet from the contradictions section.
+4. Decrement `contradiction_count`.
+5. Note the resolution in the History section with the date and the user's clarification cited.
+
+Example after resolution:
+
+```markdown
+## At a glance
+
+- **Role:** ~~VP of Engineering~~ CTO at Acme Corp (user confirmed 2026-05-15) [mem:142, mem:412, mem:521]
+```
+
+### When NOT to flag
+
+Don't flag minor wording differences ("software engineer" vs "engineer", "team lead" vs "tech lead") unless the user has previously noted they care about the distinction. The contradictions section is for things that actually create confusion if uncovered later.
+
+## Why this matters
+
+Wiki pages without citations are indistinguishable from confabulation. The user has to trust the synthesis without being able to verify it. That violates Claudia's Trust North Star.
+
+Wiki pages that hide contradictions are worse than no pages at all. They give the user false confidence in a fact that's actually disputed. Surfacing contradictions is what makes the wiki *honest* synthesis instead of *plausible* synthesis.
+
+## See also
+
+- The Trust North Star rule for the broader principle
+- `memory-audit` for tracing a fact back across all its source memories
+- `fix-duplicates` for cases where the "contradiction" is actually two entities that should be merged into one

--- a/template-v2/.claude/skills/wiki/references/page-template.md
+++ b/template-v2/.claude/skills/wiki/references/page-template.md
@@ -1,0 +1,84 @@
+# Wiki Page Template
+
+Copy this when creating a new wiki page. Fill the placeholders with synthesized content from memories. Cite every load-bearing claim with `[mem:NNN]` where NNN is the memory ID.
+
+```markdown
+---
+entity: "ENTITY NAME"
+entity_type: person | organization | project | concept | location
+last_updated: YYYY-MM-DD
+source_memories: [NNN, NNN, NNN]
+contradiction_count: 0
+---
+
+# ENTITY NAME
+
+> One-sentence TLDR. What's the essential fact about this entity that Claudia should know on first glance.
+
+## At a glance
+
+- **Role / Type:** what they are or do [mem:NNN]
+- **First contact / appeared:** when they entered the user's world [mem:NNN]
+- **Last interaction:** most recent meaningful touchpoint [mem:NNN]
+- **Communication / Operational style:** how they prefer to work, if known [mem:NNN]
+
+## What matters to them
+
+Synthesized prose. What are their goals, preferences, concerns? What context shapes how they show up? Cite every claim. Keep this section to the load-bearing facts; not everything you know belongs here.
+
+## Current threads
+
+- **Thread name:** status, what's open, who owes what [mem:NNN]
+- (more threads, one bullet each)
+
+If no open threads, omit this section.
+
+## History
+
+Reverse chronological. Most recent first. One bullet per significant interaction or fact-update.
+
+- YYYY-MM-DD: what happened [mem:NNN]
+- YYYY-MM-DD: what happened [mem:NNN]
+
+Cap at ~10 entries per page. Older history is in raw memory; the page surfaces what's still relevant.
+
+## Related
+
+- [[Other Entity 1]]
+- [[Other Entity 2]]
+
+Use Obsidian wikilink format. The graph view picks these up.
+
+## Notes
+
+Anything that doesn't fit the structured sections above. Use sparingly. If this section grows past one or two paragraphs, the content probably belongs in one of the structured sections.
+```
+
+## If contradictions exist
+
+Insert this section directly after the TLDR, before "At a glance":
+
+```markdown
+## ⚠ Contradictions to resolve
+
+- **Topic:** Description of the contradiction. Memory A says X [mem:NNN], memory B says Y [mem:NNN]. Recommended resolution or open question for the user.
+```
+
+Increment the `contradiction_count` in the frontmatter accordingly.
+
+## If the entity is dormant or sensitive
+
+Don't write a wiki page. Stay in raw memory only. See the parent SKILL.md for the rules.
+
+## Page size discipline
+
+- Minimum: ~300 words. Below that, the page isn't earning its keep over a memory recall.
+- Typical: 500 to 1000 words.
+- Maximum: ~1500 words. If a page is growing past that, split into multiple pages (e.g., `Sarah-Chen.md` + `Sarah-Chen-Engagement-2026.md`) and link them with `[[wikilinks]]`.
+
+## Style reminders
+
+- No em dashes. Use commas, periods, colons, or parentheses.
+- Plain language. Direct sentences.
+- Cite every meaningful claim with `[mem:NNN]`.
+- Cross-link related entities with `[[Entity Name]]`.


### PR DESCRIPTION
## Summary

Introduces a **wiki layer** as the new default Obsidian vault projection. Inspired by [Karpathy's llm-wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f), adapted to Claudia's working-set discipline.

Wiki pages are synthesized, navigable, and citation-traceable. They sit between raw memories (database) and the user (Obsidian). The user opens \`~/.claudia/vault/Wiki/Sarah-Chen.md\` and reads a curated page about Sarah, with every load-bearing claim citing the source memory ID.

## What ships

- **New skill** at \`template-v2/.claude/skills/wiki/SKILL.md\` plus two reference docs (page template, citations and contradictions discipline). The skill defines:
  - When to write a wiki page (proactive on ingest of active entities, on-demand when user asks about an entity)
  - When NOT to write (dormant entities, sensitive content, thin source material)
  - Page structure (YAML frontmatter, TLDR, At a glance, What matters, Current threads, History, Related)
  - Citation format (\`[mem:NNN]\` after every meaningful claim)
  - Contradiction flagging (\`⚠ Contradictions to resolve\` section directly after the TLDR)
  - Read workflow (consult wiki page first, fall back to memory query if stale)
- **\`vault-awareness\` skill** updated with a "Wiki vs PARA" detection rule at the top and a pointer to the new wiki skill for specifics.

## Compatibility (the critical part)

| User cohort | What happens on upgrade |
|-------------|------------------------|
| New install (v1.60.0+) | Wiki is the default. PARA folders are not created. |
| Existing PARA user (vault from v1.42 to v1.59) | **PARA preserved untouched.** Their existing folders remain. Wiki is not automatically populated. They stay on PARA until they explicitly migrate. |
| Mixed (both Wiki/ and PARA/ exist) | Treated as mid-migration. Both readable. Writes go to Wiki/. |

Detection rule: if \`~/.claudia/vault/Wiki/\` exists, wiki mode. If \`~/.claudia/vault/Active/\` or \`Relationships/\` exists without Wiki/, the user is on PARA.

A future \`claudia-memory --migrate-to-wiki\` CLI flag (not in this release) will let PARA users migrate explicitly.

## Deliberately deferred to a follow-up

To keep this PR's blast radius small:

- **Daemon-side wiki MCP tools** (\`memory_wiki_get\`, \`memory_wiki_save\`, \`memory_wiki_dirty\`). Today the wiki skill uses standard Read/Write tools directly.
- **Automatic dirty-queue refresh on ingest.** Today wiki writes are explicit (driven by the skill). A future PR will mark entities as "dirty" on ingest and batch refresh them.
- **The \`--migrate-to-wiki\` CLI.** Migration logic lives in a follow-up.

These deferrals are intentional: they let the wiki format prove itself in real use before we add daemon machinery around it.

## Stability contract honored

- CLI surface unchanged
- MCP tool names unchanged (no new tools added, no existing tools removed)
- Skill names and trigger phrases unchanged for existing skills
- Database schema unchanged
- Vault structure for existing PARA users unchanged

## Verification

- \`npm test\`: 25 passed, 0 failed.
- Manual review of vault-awareness skill: PARA documentation preserved below the new Wiki vs PARA section.
- New skill file follows project style: no em dashes, clear trigger description, see-also pointers to adjacent skills (vault-awareness, memory-manager, file-document, capture-meeting, ingest-sources).

## Why this is the bigger of the two skills proposed

In a prior strategic review, this layer was identified as having more impact for Claudia's described users (consultants, executives, founders, solo professionals, content creators) than autoresearch alone. Reasoning: wiki pages compound with use. The first time you mention a client, ingest is heavy; the hundredth time you ask "where are we with X?", the answer is the page Claudia has been iterating on since first mention, not a re-derivation from raw memories.

The wiki is also the visible proof of Claudia's tagline ("AI that learns how you work"). Users can open their vault and read what Claudia knows. Today's memory layer stores; the wiki *synthesizes*.

## Context

First of three PRs in a follow-on initiative after v1.59.x. Companions:
- PR-B (auto-research skill, workspace-scoped, with safety guarantees)
- PR-C (skill router for discovery and disambiguation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)