### PR TITLE
feat(auto-research): workspace-scoped iteration loop for local artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,28 +4,48 @@ All notable changes to Claudia will be documented in this file.
 
 ## 1.60.0 (2026-05-15)
 
+### Three new skills inspired by Karpathy's recent work, adapted to Claudia's principles
+
+This release adds the wiki layer (new default vault projection, inspired by Karpathy's [llm-wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)), the auto-research skill (workspace-scoped iteration loop, inspired by Karpathy's [autoresearch](https://github.com/karpathy/autoresearch)), and the skill router (discovery and disambiguation meta-skill for the catalog).
+
 ### Wiki layer (new default vault projection)
 
-Inspired by Andrej Karpathy's [llm-wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) pattern, adapted to Claudia's working-set discipline. The wiki is the third tier of Claudia's memory: raw memories live in the database, derived signals (entities, reflections, patterns) live in the daemon, and **synthesized topic pages** now live in the user's vault at `~/.claudia/vault/Wiki/`. Each page is written by Claudia from raw memories, cites every load-bearing claim with `[mem:NNN]`, flags contradictions at the top, and grows incrementally with use.
+The wiki is the third tier of Claudia's memory: raw memories live in the database, derived signals (entities, reflections, patterns) live in the daemon, and **synthesized topic pages** now live in the user's vault at `~/.claudia/vault/Wiki/`. Each page is written by Claudia from raw memories, cites every load-bearing claim with `[mem:NNN]`, flags contradictions at the top, and grows incrementally with use.
 
-### Added
-- **`wiki` skill** at `template-v2/.claude/skills/wiki/SKILL.md` with two reference docs (page template, citations/contradictions discipline). The skill defines when to write pages, the page structure, the citation format, and the read workflow (consult the wiki page first, fall back to memory query if stale).
+- New `wiki` skill at `template-v2/.claude/skills/wiki/SKILL.md` with two reference docs (page template, citations/contradictions discipline). The skill defines when to write pages, the page structure, the citation format, and the read workflow (consult the wiki page first, fall back to memory query if stale).
+- Vault default for new installs is now wiki, not PARA. New installs write synthesized pages at `~/.claudia/vault/Wiki/` instead of mechanical entity dumps.
+- `vault-awareness` skill updated with a "Wiki vs PARA" section at the top and a detection rule, with a pointer to the new wiki skill for specifics.
 
-### Changed
-- **Vault default for new installs is now wiki, not PARA.** New installs write synthesized pages at `~/.claudia/vault/Wiki/` instead of mechanical entity dumps.
-- **`vault-awareness` skill** updated with a "Wiki vs PARA" section at the top and a detection rule, with a pointer to the new wiki skill for specifics.
+**Compatibility:** Existing PARA vaults are preserved untouched. Users with vaults from v1.42 to v1.59 keep their existing structure. Detection rule: if `~/.claudia/vault/Active/` or `Relationships/` exists without `Wiki/`, treat as PARA. The mechanical dump continues to function for them. A future `claudia-memory --migrate-to-wiki` CLI will copy PARA aside and rebuild wiki pages from raw memories. Not in this release; PARA users stay on PARA until they explicitly migrate.
 
-### Compatibility
-- **Existing PARA vaults are preserved untouched.** Users with vaults from v1.42 to v1.59 keep their existing structure. Detection rule: if `~/.claudia/vault/Active/` or `Relationships/` exists without `Wiki/`, treat as PARA. The mechanical dump continues to function for them.
-- **A future `claudia-memory --migrate-to-wiki` CLI** will copy PARA aside and rebuild wiki pages from raw memories. Not in this release; PARA users stay on PARA until they explicitly migrate.
+### Auto-research skill (workspace-scoped iteration loop)
+
+Workspace-scoped hill-climbing loop for iterating on local artifacts. Adapted to Claudia's safety principles (workspace-only edits, no external actions during the loop, bounded budget, baseline-score gate, per-iteration revertability).
+
+- New `auto-research` skill at `template-v2/.claude/skills/auto-research/SKILL.md` with two reference docs: `references/program-template.md` for the governance file each run uses, and `references/safety-rules.md` documenting the 8 mandatory safety rules.
+- Workspace at `~/.claudia/auto-research/<task-id>/`. Each run gets its own directory with a fresh git repo, an immutable copy of the original artifact, a working copy that gets edited, a `results.tsv` history, and per-iteration snapshots.
+- Loop: read state, propose one specific change, implement, score against rubric, ratchet if better OR revert if worse, report to user as one line per iteration.
+- Default budget: 20 iterations. Plateau detection: stops early if 5 consecutive iterations show no improvement.
+- The user's original file is **never** modified during the loop. Hand-off at the end requires explicit user confirmation of destination.
+- Refuse-to-start conditions are explicit: external-action artifacts, sensitive content, no clear evaluator, already-good baseline, or cases where bold structural change is the actual need (not iteration).
+- Karpathy named the conservatism ceiling himself: RLHF-trained iteration is "cagy and scared." Iterations tend toward safe edits, not bold reframing. The skill surfaces this honestly when the loop plateaus, so the user knows when to stop iterating and start a fresh draft instead.
+
+### Skill router (discovery + disambiguation)
+
+A meta-skill that helps both users and Claudia navigate the ~42-skill catalog. Addresses two long-standing problems: users not knowing what's available, and Claudia firing the wrong skill when a request straddles two.
+
+- New `skill-router` skill at `template-v2/.claude/skills/skill-router/SKILL.md` with `references/overlap-clusters.md` documenting all 10 known overlap clusters with canonical picks and disambiguation patterns.
+- **Discovery surface.** `/skills` returns a categorized list (daily flow, reviews, pipeline, knowledge, drafting, setup). `/skills <topic>` filters by keyword.
+- **Disambiguation surface.** When a request matches 2+ skills, Claudia names the candidates briefly and proceeds with the canonical one. Pattern: "Sounds like X or Y. I'll do X. Say so if you wanted Y."
 
 ### Not yet in this release
-- Automatic wiki-refresh queue (mark entities as "dirty" on ingest, batch refresh later). Today, wiki writes are explicit, driven by the skill.
-- Daemon-side MCP tools for wiki page metadata (`memory_wiki_get`, `memory_wiki_save`, `memory_wiki_dirty`). Today the wiki skill uses Read/Write directly.
+- Automatic wiki-refresh queue (mark entities as "dirty" on ingest, batch refresh later).
+- Daemon-side MCP tools for wiki page metadata.
+- Shell-command evaluators for auto-research (today: rubric-based scoring only).
+- Token-spend and wall-clock budgets for auto-research (today: iteration count only).
+- Telemetry for skill router.
 
-These are planned for a follow-up release once the wiki format proves itself in real use.
-
-No CLI surface change, no MCP tool removal, no database schema change.
+No CLI surface change, no MCP tool change, no database schema change. Existing skill names and trigger phrases unchanged. Existing PARA vaults preserved.
 
 ---
 

--- a/template-v2/.claude/skills/auto-research/SKILL.md
+++ b/template-v2/.claude/skills/auto-research/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: auto-research
+description: Iteratively improve a local artifact (draft, document, page) by running a hill-climbing loop. The user names the artifact, the evaluator, and the budget. Claudia edits the artifact, scores it, keeps it if better or reverts if worse, repeats. Use when user says "iterate on this", "loop on this until it's better", "run experiments on this draft", "auto-research this", "make this better and don't stop until it's good". Workspace-scoped, never touches live files, no external actions during the loop.
+effort-level: high
+invocation: contextual
+---
+
+# Auto-Research
+
+A hill-climber for any local artifact with a rubric. Inspired by [Karpathy's autoresearch pattern](https://github.com/karpathy/autoresearch), adapted to Claudia's safety principles.
+
+## Mental model
+
+Three primitives, one governance file:
+
+1. **The artifact** — what gets iterated on (a draft email, a brief, a wiki page, a one-pager). Lives in the workspace, never touches the user's original file during the loop.
+2. **The evaluator** — a scalar rubric Claudia scores against. Plain English. Must produce a number for the original artifact before the loop starts.
+3. **The budget** — iteration count (default 20). Loop stops when budget is exhausted or score plateaus.
+4. **The program** (governance file) — what the user wants, what's off-limits, what counts as "better." Claudia helps the user write this if they don't volunteer it.
+
+Loop: read program + artifact + results history → propose one specific change → implement → score → if better, ratchet (commit); if worse, revert (git reset). Report each iteration as a one-line update. Repeat until budget is hit.
+
+## When to invoke this skill
+
+User explicitly asks:
+- "Iterate on this until it's [adjective]"
+- "Loop on this draft"
+- "Run experiments on this"
+- "Auto-research this"
+- "Hill-climb this against [criterion]"
+- "Make this better, don't stop until it's good"
+
+User implicitly invokes when:
+- They've shared an artifact and a quality bar in the same message
+- They've tried 2-3 manual revisions of the same draft in the same session and are still unsatisfied
+
+## When NOT to invoke
+
+Refuse to start the loop if:
+
+1. **External-action artifact.** The artifact is, or directly drives, an external action (an email about to be sent, a Slack message in the compose window, a calendar invite). Auto-research on these is too easy to misuse. Hand-iterate with the user instead.
+2. **No clear evaluator.** The user can't articulate what "better" means even after one pass of helping. Without an evaluator, the loop hill-climbs the wrong hill.
+3. **Sensitive content.** Medical, deeply personal, legal-defensible artifacts. Iteration risks introducing fabricated detail that looks plausible. Decline and explain.
+4. **The artifact is already good.** If you score the baseline and it's above the user's stated threshold, tell them and offer one quick polish instead of N iterations.
+5. **Bold structural change is the actual need.** Karpathy's own limitation: RLHF-trained iteration is "cagy and scared." Iterations tend toward safe edits, not bold reframings. If the user wants a fundamentally different angle, iteration will not get them there. Suggest a fresh draft instead.
+
+## Workspace layout
+
+Each run gets its own workspace at `~/.claudia/auto-research/<task-id>/`:
+
+```
+~/.claudia/auto-research/<task-id>/
+├── program.md           the brief (user-authored with Claudia's help)
+├── artifact.md          (or .txt, the working copy that gets edited)
+├── original.md          immutable copy of the input, for reference and diff
+├── results.tsv          one row per iteration: timestamp, score, kept/reverted, change-summary
+├── best.md              symlink (or copy on Windows) to the highest-scoring version
+└── iterations/
+    ├── 01/artifact.md
+    ├── 02/artifact.md
+    └── ...
+```
+
+The task-id is the slugified user phrase plus a short timestamp: `iterate-board-update-20260515-1430`.
+
+**Critical:** The loop edits `artifact.md` inside the workspace. The user's original file (wherever it lives in their file system) is **NEVER** modified during the loop. At the end, Claudia asks the user where to put `best.md`; the user decides.
+
+## program.md template
+
+```markdown
+# Program for: <one-line description of the task>
+
+## Goal
+
+(1-3 sentences. What is the end state Claudia is iterating toward?)
+
+## Evaluator (rubric)
+
+Each iteration is scored 0-10 on each dimension. Total score = sum. Higher is better.
+
+| Dimension | What scores high | What scores low |
+|-----------|------------------|-----------------|
+| (dimension 1) | (what makes a 10) | (what makes a 0) |
+| (dimension 2) | ... | ... |
+| (dimension 3) | ... | ... |
+
+## Hard constraints (do NOT violate)
+
+- Length cap: stay under N words.
+- Must contain: specific phrase or fact.
+- Must NOT contain: forbidden phrasings, names, claims.
+- Tone: must match the user's prior emails to <recipient> (paste examples in references/).
+- (etc.)
+
+## Budget
+
+- Max iterations: 20 (default)
+- OR stop when score plateaus (no improvement for 5 iterations in a row)
+
+## Out of scope
+
+- (anything Claudia might be tempted to do that isn't the goal)
+```
+
+Claudia's first action when invoked: read the artifact, draft a program.md based on what the user said, present it for confirmation, then start the loop.
+
+## The loop (Claudia's internal workflow)
+
+For each iteration N:
+
+1. **Read the state.** Read `program.md`, `artifact.md`, last 3 rows of `results.tsv`.
+2. **Propose one change.** One specific edit, justified in one sentence. Not a rewrite. Not a refactor. One change.
+3. **Implement.** Apply the edit to `artifact.md`. Save.
+4. **Score.** Score the new `artifact.md` against the rubric in `program.md`. Sum the dimensions. Round to one decimal.
+5. **Decide.** If new score > best score so far: ratchet. Copy `artifact.md` to `iterations/NN/`, update `best.md` to point at the new winner, append a row to `results.tsv` marked `kept`. If new score <= best: revert. Copy `iterations/(best_iter)/artifact.md` back to `artifact.md`, append a row marked `reverted`.
+6. **Report.** One line to the user: `iter N: score 7.4 (kept), change: tightened lede to one sentence`.
+7. **Check stop conditions.** If budget exhausted: stop. If score plateaued (no improvement for 5 iterations): stop. Otherwise: next iteration.
+
+## Safety rules (mandatory, follow without exception)
+
+1. **Workspace-only edits.** The loop never writes to a file outside `~/.claudia/auto-research/<task-id>/`. The user's original file at `/Users/.../wherever.md` is untouched until the user explicitly approves the final hand-off.
+2. **No external actions during the loop.** No sending, no posting, no scheduling, no calling tools that affect the outside world. The loop is a closed system.
+3. **Baseline-score gate.** Before iteration 1, score the original artifact and write it to `results.tsv` as `iter 0: score X (baseline)`. If the rubric cannot produce a number for the original, the loop does not start; Claudia tells the user the rubric needs to be more specific.
+4. **Bounded budget.** Default 20 iterations. User can set higher (50 max) or lower. Plateau detection (no improvement for 5 in a row) stops early. The loop is not allowed to be "open-ended" the way Karpathy's autoresearch is; Claudia's safety principles require an end.
+5. **Per-iteration revertability.** Each iteration is a git commit inside the workspace. Workspace is a fresh git repo (`git init` on start, `git commit -am` per iteration). At any point: `git log` shows the history, `git checkout` rolls back to any prior iteration.
+6. **User interrupt at any time.** If the user says "stop", "pause", "show me what you have", or otherwise interrupts: stop the loop immediately. The workspace persists. The best version so far is in `best.md`. The user can resume by saying "continue" (loop picks up from the current best).
+7. **Honest about the conservatism ceiling.** Karpathy named this: RLHF-trained iteration tends toward safe, local-optimum edits. If the loop plateaus and the user clearly wanted bold reframing, say so: "I've plateaued at score 7.2. The iterations have been incremental polishing. If you wanted a fundamentally different angle, this loop won't get there; a fresh draft might."
+
+## Hand-off at the end of the loop
+
+When the loop stops (budget, plateau, or user interrupt):
+
+1. Read `best.md`.
+2. Read `results.tsv` and summarize: started at score X, ended at score Y, took N iterations, here are the three biggest jumps (which iterations and what they changed).
+3. Show `best.md` content to the user.
+4. Ask: "Want me to put this back at the original location (`<path>`), save it to a new location, or just leave it in the workspace?"
+5. **Only after explicit user confirmation**, copy `best.md` to the destination they name. The user's original file is touched here for the first time and only here.
+6. Optionally save the run as a memory: "auto-research run for <task>, ratcheted from X to Y, key changes: ...". Useful if the user wants to learn from past runs.
+
+## What this skill is NOT
+
+- **Not a draft generator.** It improves an artifact that already exists. If the user wants a draft from scratch, use `draft-reply`, `follow-up-draft`, `summarize-doc`, or just write it conversationally first.
+- **Not for bold reframing.** It's a hill-climber. It finds local optima. For "completely rethink this from a different angle", iteration is the wrong tool.
+- **Not autonomous in the Karpathy "NEVER STOP" sense.** Claudia's safety principles require bounded loops and user-in-loop hand-off. The loop runs without per-iteration approval, but it stops, and external actions stay with the user.
+
+## Examples of good rubrics
+
+For "iterate on this board update":
+
+| Dimension | 10 | 0 |
+|-----------|----|----|
+| Lede strength | Opens with the one number or decision that matters | Opens with throat-clearing or backstory |
+| Brevity | Reads in under 90 seconds | Goes over 5 minutes |
+| Ask clarity | The ask, if any, is one sentence | Asks are buried or multi-step |
+| Tone | Matches my prior board updates (samples in references/) | Sounds AI-generated |
+
+For "iterate on this proposal":
+
+| Dimension | 10 | 0 |
+|-----------|----|----|
+| Problem framing | Names the client's actual pain in their words | Generic problem framing |
+| Differentiation | One sentence on why I'm the right fit | No clear differentiator |
+| Scope clarity | Phases are explicit, no scope creep | Vague deliverables |
+| Price anchoring | Price appears after value, not before | Price leads or is hidden |
+
+Specific. Numerical. Tied to the user's actual standards.
+
+## Examples of bad rubrics
+
+"Make it better" — no signal.
+"More professional" — directionally OK but no scoring criteria.
+"Like Bezos would write" — aspirational but Claudia can't score "Bezos-ness" reliably.
+
+When the user gives a bad rubric, help them turn it into a good one before starting the loop.
+
+## See also
+
+- `wiki` for iterating wiki pages specifically (compress, sharpen, restructure)
+- `draft-reply`, `follow-up-draft` for one-shot draft generation
+- `summarize-doc` for one-pass summarization
+
+## Open questions for future versions
+
+- Shell-command evaluators (run `node test.js my-draft.md`, take the number it prints) are deferred. Today, Claudia scores against the rubric in `program.md` directly.
+- Token-spend budget and wall-clock budget are deferred. Today, only iteration count is supported.
+- Parallel branches (try 3 different changes in parallel, keep the winner) are deferred. Today, sequential only.
+- Wiki-page iteration as a first-class use case (apply auto-research to a wiki page until it's < N words while citing all sources) is deferred. The skill supports this in principle today, but a worked example doesn't ship until the wiki has earned its keep.

--- a/template-v2/.claude/skills/auto-research/references/program-template.md
+++ b/template-v2/.claude/skills/auto-research/references/program-template.md
@@ -1,0 +1,72 @@
+# program.md template
+
+Copy this when starting an auto-research run. Fill the placeholders. Show it to the user for confirmation before starting the loop.
+
+```markdown
+# Program for: <one-line description of the task>
+
+## Goal
+
+(1-3 sentences. What is the end state Claudia is iterating toward? Be specific. "Make this board update better" is not specific. "Make this board update fit in 250 words while preserving the three big asks" is specific.)
+
+## Artifact
+
+- Original location: `<path to user's file, if applicable>`
+- Working copy: `~/.claudia/auto-research/<task-id>/artifact.md`
+- Size: <word count of original>
+
+## Evaluator (rubric)
+
+Each iteration is scored 0-10 on each dimension. Total score = sum. Higher is better.
+
+| Dimension | Weight | What scores high (10) | What scores low (0) |
+|-----------|--------|----------------------|---------------------|
+| (dim 1) | (e.g., 0.4) | (concrete description) | (concrete description) |
+| (dim 2) | (e.g., 0.3) | ... | ... |
+| (dim 3) | (e.g., 0.3) | ... | ... |
+
+(Weights sum to 1.0. Total possible: 10. Round to one decimal.)
+
+## Hard constraints (do NOT violate)
+
+These are non-negotiable. If an iteration violates any of these, it is automatically reverted regardless of score.
+
+- Length cap: stay under N words.
+- Must contain: <specific phrase, fact, or section that has to survive>
+- Must NOT contain: <forbidden phrasings, names, claims, em dashes>
+- Tone: <specific tone constraint, e.g., "matches user's prior emails to <recipient> in references/sample-emails.md">
+- (etc.)
+
+## Budget
+
+- Max iterations: 20 (default; user may override up to 50)
+- Plateau stop: 5 consecutive iterations with no improvement
+- Wall clock: <none in v1; future versions support time-based budget>
+
+## Out of scope
+
+(What Claudia might be tempted to do that isn't the goal. Examples:)
+- Don't change the underlying message; only the phrasing.
+- Don't add new facts; work with what's already there.
+- Don't reframe the whole structure; iterate within the current outline.
+
+## Notes from the user
+
+(Anything else the user wants Claudia to know. Examples: "I tried three versions yesterday and they all felt stiff," "the recipient is a board member with a finance background," "I want this to feel like me, not like AI.")
+
+## Reference materials
+
+(Files in `references/` of the workspace that Claudia should consult during iteration. Examples:)
+- `sample-emails.md` — three prior emails to this recipient, for tone calibration
+- `style-guide.md` — house style notes
+```
+
+## How Claudia uses this
+
+1. After being invoked for auto-research, Claudia reads the user's artifact and what they said about it.
+2. Drafts an initial program.md based on the user's words, filling in best guesses for the rubric.
+3. **Shows the draft to the user.** Asks: "Does this rubric capture what 'better' means? Anything to add to hard constraints?"
+4. Adjusts based on feedback. Iterates on the program if needed (sometimes the rubric itself needs refinement before the loop starts).
+5. **Only after the user explicitly says the program is right**, kicks off iteration 1.
+
+The program.md is the human's one leverage point on the loop. Claudia respects it strictly.

--- a/template-v2/.claude/skills/auto-research/references/safety-rules.md
+++ b/template-v2/.claude/skills/auto-research/references/safety-rules.md
@@ -1,0 +1,110 @@
+# Auto-Research Safety Rules
+
+These rules are non-negotiable. They keep the loop bounded, reversible, and trustworthy.
+
+## Why these exist
+
+Karpathy's autoresearch (March 2026) operates with a "NEVER STOP" directive baked into its program.md. It runs forever, edits its target file directly, and assumes a benevolent training environment where the worst case is a wasted GPU hour. Claudia's environment is different: the artifacts she iterates on are user-facing (drafts, briefs, wiki pages), and her safety principle is "no external actions without approval."
+
+The rules below adapt the loop pattern to fit. They are deliberately stricter than Karpathy's.
+
+## Rule 1: Workspace-only edits
+
+The loop writes only to `~/.claudia/auto-research/<task-id>/` and its subdirectories.
+
+The user's original file (wherever it lives on disk) is NEVER touched during the loop. At the very end, when the user has reviewed the best version and explicitly approved hand-off, Claudia copies the result to whatever destination the user names.
+
+**Why:** A bad iteration that gets copied over the user's working draft is a small disaster that the user has to manually recover from. Workspace isolation prevents that class of problem entirely.
+
+## Rule 2: No external actions during the loop
+
+While the loop is running, Claudia does not:
+- Send any email, message, or notification
+- Post to any service
+- Create or modify any calendar event
+- Call any MCP tool that writes outside the workspace
+- Call any tool that interacts with services outside the local machine
+
+The loop is a closed system. Its only outputs are inside the workspace.
+
+**Why:** Iterative scoring can produce intermediate states that look complete but aren't. If the loop could send an email and revert the draft afterward, a user watching the wrong moment would see "the email sent" without realizing the loop wasn't done.
+
+## Rule 3: Baseline-score gate
+
+Before iteration 1, Claudia scores the original artifact against the rubric. The score gets written to `results.tsv` as `iter 0: score X (baseline)`.
+
+If the rubric cannot produce a number for the original (vague rubric, dimensions that don't apply), Claudia stops and tells the user: "Your rubric needs to be more specific. Right now I can't score the original; here's where it's ambiguous: ..."
+
+The loop does not start until the rubric can produce a defensible baseline.
+
+**Why:** A loop with no baseline is a loop with no signal. The first iteration "improves" against nothing, which is just generation, not iteration.
+
+## Rule 4: Bounded budget
+
+Default 20 iterations. User may set up to 50. The loop also stops early on plateau (5 consecutive iterations with no improvement).
+
+The loop is not allowed to be open-ended.
+
+**Why:** Claudia's safety principles require user-in-loop for unbounded autonomous behavior. A capped budget keeps the loop's cost predictable and makes "the loop is done" a well-defined state.
+
+## Rule 5: Per-iteration revertability
+
+The workspace is a fresh git repo. Each iteration commits the change. Failed iterations are git-reset. At any point, `git log` shows the history; `git checkout <hash>` rolls back to any prior state.
+
+**Why:** Audit trail. If the user disagrees with the final result and wants to see "wait, what did iteration 7 look like?", the history is there.
+
+## Rule 6: User interrupt
+
+The user can stop the loop at any time. Recognized signals: "stop", "pause", "show me what you have", "wait", "hold on", or just changing the subject.
+
+When stopped, the loop:
+- Halts immediately at the end of the current iteration (doesn't begin a new one)
+- Workspace persists
+- `best.md` is the current best version
+- User can resume by saying "continue", "keep going", "next iteration"
+
+**Why:** The loop is a tool for the user, not vice versa. They control its pace.
+
+## Rule 7: Honest conservatism
+
+Karpathy named this himself: RLHF-trained models are "cagy and scared" during iteration. They find local optima efficiently but won't make bold structural bets.
+
+For Claudia's users, this means: iteration is good for polish, tightening, clarification. It is not good for "rethink this completely from a different angle."
+
+When the loop plateaus, Claudia surfaces this honestly:
+
+> "I've plateaued at score 7.2 after 12 iterations. The recent changes have been incremental polishing: tighter sentences, clearer ordering, removed two unnecessary clauses. If you wanted a fundamentally different angle or structure, this loop won't get there. A fresh draft, or one prompt where you reframe the whole approach, would. Want to stop here, or want me to try one more pass with a more aggressive rubric?"
+
+The user decides.
+
+## Rule 8: Refuse-to-start situations
+
+The loop should refuse to start when:
+
+1. **External-action artifact.** The artifact is, or directly drives, an external action (e.g., an email currently in the compose window of an MCP-mediated email tool). Iterate it as a local file first, then the user decides whether to send.
+2. **Sensitive content.** Medical, legal-defensible, deeply personal artifacts. Iteration risks introducing plausible-sounding fabrications.
+3. **No clear rubric.** Per Rule 3, the rubric must produce a baseline. If after one pass of helping the user articulate it, the rubric still can't score, decline.
+4. **Already-good baseline.** If the baseline scores above the user's stated threshold, tell them and offer one targeted polish instead of N iterations.
+
+## Reporting cadence during the loop
+
+Default: report every iteration as one line.
+
+```
+iter 7: score 6.8 → 7.2 (kept), change: lede now opens with the revenue number
+iter 8: score 7.2 → 7.0 (reverted), change: tried merging para 2 and 3
+iter 9: score 7.2 → 7.5 (kept), change: cut the "as you know" preamble
+```
+
+For long runs (>20 iterations): summarize every 10 with a one-paragraph trace. At the end, show the full trace.
+
+## Hand-off at the end
+
+When the loop stops:
+
+1. Tell the user it's done. Brief summary: started at X, ended at Y, took N iterations.
+2. Show `best.md`.
+3. Ask: where do you want this? Three options: back at the original location, a new location they name, or just leave it in the workspace.
+4. Only after explicit user confirmation, write to the destination they chose.
+
+The user's original file is touched here for the first time and only here.


### PR DESCRIPTION
## Summary

Adds an **auto-research** skill that iteratively improves a local artifact (draft, brief, document, page) by running a hill-climbing loop against a user-named rubric. Inspired by [Karpathy's autoresearch pattern](https://github.com/karpathy/autoresearch), adapted to Claudia's safety principles.

The user names the artifact, the rubric, and the budget. Claudia proposes one specific change per iteration, scores against the rubric, ratchets if better or reverts if worse, repeats. The user gets the best-scoring version after the budget runs out, plus the iteration trace.

## How it works

```
User: "Iterate on this board update until it's under 250 words and leads with the ask"
Claudia: drafts a program.md (rubric + hard constraints + budget)
Claudia: scores the baseline → 4.2 / 10
Claudia: iter 1 → 4.8 (kept), lede now opens with the revenue number
Claudia: iter 2 → 4.6 (reverted), tried merging para 2 and 3
Claudia: iter 3 → 5.1 (kept), cut "as you know" preamble
...
Claudia: iter 17 → plateaued at 7.4. Recent iterations have been polish, not structural. Want to stop or push harder?
User: stop
Claudia: shows best.md, asks where to put it. User confirms destination. Done.
```

## Safety constraints (the "don't destroy certain skills" part)

1. **Workspace-only edits.** Loop writes only to \`~/.claudia/auto-research/<task-id>/\`. The user's original file is **never** modified during the loop.
2. **No external actions during the loop.** No send, no post, no schedule. Closed system.
3. **Baseline-score gate.** Refuses to start until the rubric can score the original artifact.
4. **Bounded budget.** Default 20 iterations. Plateau detection (5 consecutive no-improvement iterations) stops early. No "NEVER STOP" mode.
5. **Per-iteration revertability.** Each iteration is a git commit inside the workspace. \`git log\` shows the audit trail. \`git checkout\` rolls back to any prior state.
6. **User interrupt.** Saying "stop", "pause", "show me what you have" halts the loop. Workspace persists. "Continue" resumes.
7. **Honest conservatism.** Karpathy named this himself: RLHF-trained iteration is "cagy and scared." When the loop plateaus on safe local-optimum edits and bold reframing is the actual need, Claudia says so.
8. **Refuse-to-start.** External-action artifacts, sensitive content, vague rubrics, already-good baselines, and cases where the user really wants a fresh draft all block start.

## What ships

- **Skill** at \`template-v2/.claude/skills/auto-research/SKILL.md\`
- **program-template.md** in \`references/\` for the governance file each run uses (goal, rubric, hard constraints, budget, out-of-scope, reference materials)
- **safety-rules.md** in \`references/\` documenting all 8 mandatory safety rules

## What's deferred

- **Shell-command evaluators.** Today, rubric-based scoring only (Claudia scores against criteria in plain English). A future PR can add evaluators that shell out (\`node test.js my-draft.md\` → 0.73).
- **Token-spend and wall-clock budgets.** Today, iteration count only.
- **Parallel iteration branches.** Today, sequential only.
- **Worked example for wiki-page iteration.** The skill supports this in principle; a worked example ships once the wiki has earned its keep in real use.

## Stability contract honored

- CLI surface unchanged
- MCP tool names unchanged (no new tools)
- Existing skill names and triggers unchanged
- Database schema unchanged

## Verification

- \`npm test\`: 25 passed, 0 failed
- Manual review of the skill: refuse-to-start conditions documented, safety rules cross-referenced from SKILL.md to safety-rules.md, citation traceability via per-iteration git commits

## Context

Second of three companion PRs after v1.59.x. Sibling PRs:
- #63 (PR-A): wiki layer (new default vault projection)
- PR-C (skill router) coming next

🤖 Generated with [Claude Code](https://claude.com/claude-code)