### PR TITLE
feat(skill-router): discovery + disambiguation meta-skill

### DIFF
--- a/template-v2/.claude/skills/skill-router/SKILL.md
+++ b/template-v2/.claude/skills/skill-router/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: skill-router
+description: Help users discover available skills and help Claudia pick the right one when a request is ambiguous. Two surfaces: discovery (user says "what can you do?", "/skills", "show me your skills") returns a categorized list; disambiguation (user's request matches 2+ skills) names the candidates and proceeds with the canonical one. Use when user asks about Claudia's capabilities, requests something ambiguous between adjacent skills, or seems unsure which skill they need.
+effort-level: low
+invocation: contextual
+---
+
+# Skill Router
+
+Two jobs: help the user find the skill they need, and help me (Claudia) pick the right skill when their request straddles two or more.
+
+## Why this exists
+
+The shipped catalog has ~42 user-facing skills. Two common failure modes:
+
+1. **Users don't know what's available.** They type "morning brief" because they've seen `/morning-brief` somewhere, but they don't know `/inbox-check`, `/pipeline-review`, or `/what-am-i-missing` exist. Friction.
+2. **Ambiguous requests fire the wrong skill.** "Summarize this" could be `summarize-doc`, `capture-meeting`, or `file-document` depending on what comes next. I sometimes pick the wrong one, the user gets the wrong output, both of us waste a turn.
+
+This skill addresses both.
+
+## Surface 1: Discovery
+
+When the user says "what can you do?", "/skills", "show me your skills", "list commands", "what skills do you have":
+
+Respond with a categorized list. Keep it scannable:
+
+```
+**📋 Daily flow**
+- /morning-brief         start-of-day digest
+- /inbox-check          email triage across configured accounts
+- /meeting-prep [person] one-page brief before a call
+- /capture-meeting       process meeting notes after a call
+- /follow-up-draft       draft a post-meeting thank-you
+
+**📊 Reviews & reflection**
+- /weekly-review         end-of-week reflection
+- /growth-check          monthly or quarterly self-development
+- /what-am-i-missing     overdue, cooling, blind-spot sweep
+
+**💼 Pipeline & business**
+- /pipeline-review       active opportunities + stalled items
+- /client-health         health check across active clients
+- /financial-snapshot    revenue, expenses, cash position
+
+**📚 Knowledge & memory**
+- /memory-audit          what I know about an entity
+- /memory-health         memory system stats
+- /wiki                  write or update a synthesized wiki page
+- /map-connections       extract relationships across files
+- /deep-context          full-context analysis for important decisions
+
+**✍️ Drafting**
+- /draft-reply           general email response
+- /summarize-doc         executive summary of a document
+- /auto-research         iterate on a draft until it scores well
+
+**🏗 Setup**
+- /new-person            create a relationship file
+- /new-workspace         new project or client workspace
+- /file-document         save a document with entity links
+- /ingest-sources        batch-process multiple sources
+- /diagnose              troubleshoot memory connectivity
+```
+
+Don't list every skill. List the ones a user is most likely to invoke directly. Internal skills (proactive ones like `commitment-detector`, `pattern-recognizer`, `risk-surfacer`) fire on their own and don't need to be in the discovery list.
+
+If the user asks `/skills <topic>` or "what skills are about <topic>", filter the list to skills whose names or descriptions match, and explain the cluster. Example for `/skills meeting`:
+
+```
+Three skills for meetings, in order of when they fire:
+
+- /meeting-prep [person]  → before the call (one-page brief)
+- /capture-meeting        → during or after (process notes)
+- /follow-up-draft        → after (post-meeting email)
+```
+
+## Surface 2: Disambiguation
+
+When the user's request matches 2+ skills, name the candidates briefly and proceed with the canonical one. Don't make the user choose; choose for them, and tell them what you chose.
+
+### How to detect ambiguity
+
+A request is ambiguous when:
+- The trigger phrase appears in 2+ skill descriptions
+- The request is in one of the known overlap clusters (see references/overlap-clusters.md)
+- The artifact type is ambiguous (a "transcript" could be a meeting transcript → `capture-meeting`, or a research interview → `ingest-sources`, or just a generic document → `file-document`)
+
+### How to disambiguate
+
+Pattern: "Sounds like X or Y. I'll do X. Say so if you wanted Y."
+
+Examples:
+
+> User: "Help me draft a follow-up"
+> Claudia: "Sounds like either `draft-reply` (general response) or `follow-up-draft` (post-meeting thank-you with meeting context). Was this from a call we had? If yes, `follow-up-draft`; if not, `draft-reply`. Defaulting to `follow-up-draft` since you said 'follow-up'."
+
+> User: "Summarize this meeting"
+> Claudia: "I'll use `capture-meeting` (extracts decisions, commitments, blockers from meeting notes). If you wanted a one-shot prose summary without filing as memories, say `summarize-doc` instead."
+
+> User: "What's going on?"
+> Claudia: "Default for that phrasing is `morning-brief`. Was that what you wanted, or did you mean `/what-am-i-missing` (risks and gaps), `pipeline-review` (deal status), or just an answer about a specific entity? Going with `morning-brief`."
+
+The pattern: pick the canonical, name the alternative, run.
+
+### When NOT to disambiguate
+
+- The request is unambiguous. Don't manufacture options.
+- The user has been specific. "Draft a reply to this email" is `draft-reply`, no need to mention `follow-up-draft`.
+- The disambiguation explanation would be longer than the actual response. For short tasks, just do the canonical thing and let the user redirect.
+
+## Overlap clusters (the canonical map)
+
+See `references/overlap-clusters.md` for the full map. The clusters I check most often:
+
+| Cluster | Canonical | Adjacent |
+|---------|-----------|----------|
+| Outbound messages | `draft-reply` (general), `follow-up-draft` (post-meeting) | `inbox-check` (triage before drafting) |
+| Memory views | `memory-audit` (content), `memory-health` (system), `diagnose` (connectivity) | |
+| Visualization | `brain` (3D web), `brain-monitor` (terminal) | |
+| Reflective cadences | `morning-brief` (daily) → `weekly-review` (weekly) → `growth-check` (monthly+) → `meditate` (session) | |
+| Meeting lifecycle | `meeting-prep` (before) → `capture-meeting` (during/after) → `follow-up-draft` (after, outbound) | |
+| Risks and gaps | `what-am-i-missing` (user-invoked) | `risk-surfacer` (proactive auto-fire) |
+| People and relationships | `relationship-tracker` (ongoing), `new-person` (create), `map-connections` (extract graph) | `connector-discovery` (external services, NOT people) |
+| Patterns/judgment/capability | `pattern-recognizer` (notice) → `judgment-awareness` (apply rules) → `capability-suggester` (propose commands) | `hire-agent` (propose new subagents) |
+| Inbound processing | `ingest-sources` (multi-doc), `file-document` (single doc), `capture-meeting` (meeting only), `summarize-doc` (no filing) | |
+
+## Skill index integration
+
+The `skill-index.json` file at `template-v2/.claude/skills/skill-index.json` is the structured catalog this skill reads. Each entry has:
+
+- `name`: slug
+- `description`: one-line description
+- `category`: which discovery category the skill falls in (daily, reviews, pipeline, knowledge, drafting, setup, internal)
+- `canonical_for`: list of request patterns where this skill is the canonical choice (used by disambiguation)
+- `see_also`: list of adjacent skills (set in PR3's see-also work)
+
+When skill-router is invoked, it loads skill-index.json and uses these fields. The discovery list above is generated from `category`. Disambiguation uses `canonical_for` and `see_also`.
+
+## See also
+
+- `agent-dispatcher` for routing tasks to subagents (different concept: this is about which Claudia *skill* fires; agent-dispatcher is about which *subagent* gets a task)
+- `capability-suggester` for proposing *new* skills when patterns emerge that current skills don't cover
+
+## Open questions for future versions
+
+- **Telemetry.** Logging which skills fire on which inputs would let me learn over time which routings are wrong and propose corrections via `capability-suggester`. Not in this version.
+- **Per-user customization.** Some users invoke `weekly-review` weekly; others never use it. The discovery list should adapt to the user's actual usage over time. Not in this version.
+- **Skill search by example.** "Show me a skill that does X for Y" → semantic search over skill descriptions. Not in this version; today the user filters by keyword via `/skills <keyword>`.

--- a/template-v2/.claude/skills/skill-router/references/overlap-clusters.md
+++ b/template-v2/.claude/skills/skill-router/references/overlap-clusters.md
@@ -1,0 +1,141 @@
+# Overlap Clusters
+
+The map of which skills could plausibly fire on the same request, with the canonical pick for each cluster. Used by the disambiguation surface of the skill router.
+
+## Cluster: Outbound message composition
+
+| Skill | When canonical |
+|-------|----------------|
+| `draft-reply` | General email response, no specific meeting context |
+| `follow-up-draft` | Post-meeting thank-you, references a specific call |
+| `inbox-check` | Triage what to reply to (precedes both drafting skills) |
+
+**Disambiguation pattern:** "Was this from a call we had? If yes, `follow-up-draft`. If not, `draft-reply`."
+
+## Cluster: Memory introspection
+
+| Skill | When canonical |
+|-------|----------------|
+| `memory-audit` | "What do you know about X?" Content-level provenance, source memories. |
+| `memory-health` | "How's my memory?" System-level stats, data quality, embedding counts. |
+| `diagnose` | "Memory isn't working." Connectivity troubleshooting, daemon status. |
+
+**Disambiguation pattern:** "Three different memory views: audit (what I know about X), health (system stats), diagnose (connectivity). Which?"
+
+## Cluster: Memory visualization
+
+| Skill | When canonical |
+|-------|----------------|
+| `brain` | Visual graph view in the browser. Default if the user wants to see relationships. |
+| `brain-monitor` | Terminal dashboard. Default if the user is already in a terminal context or wants a lighter view. |
+
+## Cluster: Reflective cadences
+
+A pipeline of related skills by time horizon:
+
+| Skill | Cadence |
+|-------|---------|
+| `morning-brief` | Daily (start of day) |
+| `weekly-review` | Weekly (end of week) |
+| `growth-check` | Monthly or quarterly |
+| `meditate` | End of session, persistent reflection |
+
+**Disambiguation pattern:** "Daily, weekly, or monthly horizon? `morning-brief` / `weekly-review` / `growth-check`. (And `meditate` at end of session for cross-cutting learnings.)"
+
+## Cluster: Meeting lifecycle
+
+A pipeline by temporal position:
+
+| Skill | Position |
+|-------|----------|
+| `meeting-prep` | Before the call |
+| `capture-meeting` | During or after the call (notes) |
+| `follow-up-draft` | After the call (outbound message) |
+
+**Disambiguation pattern:** "Before, during/after, or follow-up? `meeting-prep` / `capture-meeting` / `follow-up-draft`."
+
+## Cluster: Risks, gaps, blind spots
+
+| Skill | When canonical |
+|-------|----------------|
+| `what-am-i-missing` | User-invoked full sweep. They want to see everything that might be falling through cracks. |
+| `risk-surfacer` | Proactive, fires automatically on overdue items and cooling relationships. User doesn't invoke this directly. |
+
+## Cluster: People and relationships
+
+| Skill | When canonical |
+|-------|----------------|
+| `relationship-tracker` | Ongoing surfacing of context about a person. |
+| `new-person` | Create a relationship file for a new contact. |
+| `map-connections` | Extract relationships across multiple files into the graph. |
+| `connector-discovery` | **NOT about people.** About external service connectors (Gmail, Calendar, Slack). |
+
+**Disambiguation pattern:** If "connector" or "connection" appears: ask "external service or human relationship?" The disambiguation here is essential because `connector-discovery` gets misrouted as a relationship skill.
+
+## Cluster: Patterns, judgment, capability
+
+A pipeline of "we keep doing this" at increasing levels of intervention:
+
+| Skill | Stage |
+|-------|-------|
+| `pattern-recognizer` | Notice that something is recurring |
+| `judgment-awareness` | Apply user-set decision rules to the recurring situation |
+| `capability-suggester` | Propose a new command when the same task is repeated manually |
+| `hire-agent` | Propose a new subagent when 3+ similar tasks are observed |
+
+## Cluster: Inbound processing
+
+By artifact type:
+
+| Skill | Artifact |
+|-------|----------|
+| `ingest-sources` | 3+ related documents, batch processing with Extract-Then-Aggregate |
+| `file-document` | Single document, file with entity links |
+| `capture-meeting` | Meeting transcript or notes specifically |
+| `summarize-doc` | Summary without filing as memories |
+
+**Disambiguation pattern:** "One doc or several? Meeting notes or general doc? File it or just summarize? `file-document` / `ingest-sources` / `capture-meeting` / `summarize-doc`."
+
+## Cluster: Writing assistance
+
+| Skill | When canonical |
+|-------|----------------|
+| `draft-reply` | One-shot draft generation |
+| `follow-up-draft` | One-shot, post-meeting |
+| `summarize-doc` | One-shot summary |
+| `auto-research` | Iterate on an existing draft until it scores well |
+
+**Disambiguation pattern:** "Draft from scratch or iterate on what we have? Drafting skills are one-shot; `auto-research` is the iteration loop."
+
+## Cluster: Vault / knowledge
+
+| Skill | When canonical |
+|-------|----------------|
+| `wiki` | Write or update synthesized topic pages in the vault |
+| `vault-awareness` | Internal skill, fires when user mentions the vault directly |
+
+## When clusters compose
+
+Some requests touch multiple clusters in sequence:
+
+> User: "We just finished the kickoff with Acme. Update everything."
+
+That's potentially:
+1. `capture-meeting` (process notes from the kickoff)
+2. `wiki` (update the Acme Corp page and the Sarah Chen page)
+3. `follow-up-draft` (draft the thank-you)
+4. `commitment-detector` (proactive, catches any "I'll send this by Friday" from the notes)
+
+Don't fire all four at once. Run them in order, narrate each step: "First capturing the meeting. Then updating the wiki pages. Want a follow-up draft too?"
+
+## Updating this map
+
+When a new skill ships:
+1. Add it to the appropriate cluster (or create a new cluster if it genuinely doesn't fit).
+2. Update `canonical_for` and `see_also` fields in `skill-index.json`.
+3. If it overlaps with an existing canonical, decide which is now canonical and update the disambiguation pattern.
+
+When a skill is retired:
+1. Remove from clusters here.
+2. Remove from `skill-index.json`.
+3. Update see-also lines in any sibling skills that pointed at it.


### PR DESCRIPTION
## Summary

A meta-skill that helps both users and Claudia navigate the ~42-skill catalog. Addresses the two failure modes named in the feature request: users not knowing what's available, and Claudia firing the wrong skill when a request straddles two.

## Two surfaces

### Discovery

User says "/skills" or "what can you do?" → categorized list grouped by purpose:

\`\`\`
📋 Daily flow     /morning-brief, /inbox-check, /meeting-prep, /capture-meeting, /follow-up-draft
📊 Reviews        /weekly-review, /growth-check, /what-am-i-missing
💼 Pipeline       /pipeline-review, /client-health, /financial-snapshot
📚 Knowledge      /memory-audit, /memory-health, /wiki, /map-connections, /deep-context
✍️ Drafting       /draft-reply, /summarize-doc, /auto-research
🏗 Setup          /new-person, /new-workspace, /file-document, /ingest-sources, /diagnose
\`\`\`

\`/skills <topic>\` filters by keyword. Internal proactive skills (commitment-detector, pattern-recognizer, etc.) aren't listed because they fire on their own.

### Disambiguation

When a request matches 2+ skills, Claudia names the candidates briefly and proceeds with the canonical one. Pattern: "Sounds like X or Y. I'll do X. Say so if you wanted Y."

Example:

> User: "Help me draft a follow-up"
> Claudia: "Sounds like either \`draft-reply\` (general response) or \`follow-up-draft\` (post-meeting thank-you with meeting context). Was this from a call we had? Defaulting to \`follow-up-draft\` since you said 'follow-up'."

The user redirects with one short reply if needed, instead of having to choose up front. This is much better than the current state where Claudia silently picks one and the user gets the wrong output.

## Coverage

Ten overlap clusters mapped in \`references/overlap-clusters.md\`:

| Cluster | Why it matters |
|---------|----------------|
| Outbound messages | \`draft-reply\` vs \`follow-up-draft\` are constantly confused |
| Memory views | Three different "memory" skills (audit, health, diagnose) for three different purposes |
| Visualization | \`brain\` (3D web) vs \`brain-monitor\` (terminal) |
| Reflective cadences | Four time horizons (daily/weekly/monthly/session) |
| Meeting lifecycle | Three temporal positions (before/during/after) |
| Risks | User-invoked vs proactive auto-fire |
| People/relationships | The \`connector-discovery\` trap (it's NOT about people) |
| Patterns/judgment/capability | Three stages of "we keep doing this" |
| Inbound processing | Four "process this" entry points |
| Writing assistance | One-shot drafts vs iteration loop |

## What ships

- \`template-v2/.claude/skills/skill-router/SKILL.md\` (the meta-skill)
- \`references/overlap-clusters.md\` (the canonical map)

## What's deferred

- **Telemetry.** Logging which skills fire on which inputs would let Claudia learn over time which routings are wrong. Not in this version.
- **Per-user customization.** Some users use \`weekly-review\` weekly; others never. The discovery list should adapt. Not in this version.
- **Semantic skill search.** Today filters by keyword; a future version could embed skill descriptions for fuzzy matching.

## Stability contract honored

- CLI surface unchanged
- MCP tool names unchanged
- Existing skills unchanged in this PR (see-also edits already shipped in PR3 via #61)
- Database schema unchanged

## Verification

- \`npm test\`: 25 passed, 0 failed
- Manual review of overlap clusters against PR3's see-also map: consistent

## Context

Third and final PR of three companion features after v1.59.x. Sibling PRs:
- #63 (PR-A): wiki layer
- #64 (PR-B): auto-research skill

The router is the smallest of the three but possibly the highest-friction-reduction. Most user complaints about Claudia's behavior trace back to "she did the wrong thing because she misread my request." This is the surface that fixes that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)