### PR TITLE
fix: use PASSIVE WAL checkpoint to avoid blocking concurrent readers (Litestream)

### DIFF
--- a/memory-daemon/claudia_memory/database.py
+++ b/memory-daemon/claudia_memory/database.py
@@ -116,7 +116,10 @@ class Database:
             conn.execute("PRAGMA synchronous = NORMAL")
             conn.execute("PRAGMA foreign_keys = ON")
             # Recover any uncommitted WAL writes from a previous crashed daemon
-            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            # Use PASSIVE (not TRUNCATE) so concurrent readers (e.g. Litestream)
+            # don't cause a 30-second timeout. TRUNCATE blocks all readers;
+            # PASSIVE yields cleanly if a reader holds the WAL lock.
+            conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
 
             # Load sqlite-vec for vector search
             if not load_sqlite_vec(conn):


### PR DESCRIPTION
## What this fixes

When Litestream (or any concurrent WAL reader) is running alongside the claudia-memory daemon, the MCP server fails with:

```
MCP server "claudia-memory" connection timed out after 30000ms
```

**Root cause:** `database.py` line 119 runs `PRAGMA wal_checkpoint(TRUNCATE)` on every connection. `TRUNCATE` tries to acquire an exclusive lock and block all readers. Litestream holds a read lock on the WAL during replication. These two are incompatible — the checkpoint blocks and the MCP connection times out.

## The fix

One word change:

```python
# Before
conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")

# After
conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
```

`PASSIVE` transfers WAL frames to the main database without blocking readers. It returns cleanly even if it cannot checkpoint everything. This is what the SQLite documentation explicitly recommends for databases with concurrent readers.

## Why this is correct, not just a workaround

From the SQLite docs: `TRUNCATE` is the aggressive mode for single-writer scenarios where you want to force full WAL compaction and block everything else. Using it in a multi-reader setup is a documented misuse. `PASSIVE` is the right mode for this environment.

**Data integrity:** Unchanged. WAL mode itself ensures crash safety. The checkpoint is a compaction optimization, not a durability mechanism. The WAL still gets compacted — just without blocking readers.

## Discovered in production

Running Litestream → Proton Drive for continuous memory database replication alongside the claudia-memory daemon on macOS (Apple Silicon). The workaround was unloading Litestream before every Claude Code session and reloading it after MCP connect. This fix eliminates that entirely.

Tested: daemon connects cleanly with Litestream running, replication continues uninterrupted.